### PR TITLE
refactor: ECR 배포 파이프라인 전면 재작성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,39 @@ on:
     branches: [main]
 
 jobs:
+  checkstyle:
+    name: Checkstyle
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Checkstyle
+        run: ./gradlew checkstyleMain checkstyleTest
+
   build:
     name: Build & Test
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -34,7 +57,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build and Test
-        run: ./gradlew build
+        run: ./gradlew build -x checkstyleMain -x checkstyleTest
 
       - name: Generate JaCoCo Coverage Report
         run: ./gradlew jacocoTestReport
@@ -52,3 +75,23 @@ jobs:
         with:
           name: coverage-report
           path: '**/build/reports/jacoco/'
+
+  notify:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs: [checkstyle, build]
+    if: always()
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "${{ contains(needs.*.result, 'failure') && '❌ CI 실패' || '✅ CI 성공' }}: ${{ github.repository }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ contains(needs.*.result, 'failure') && '❌ *CI 실패*' || '✅ *CI 성공*' }}\n*Repo:* ${{ github.repository }}\n*Branch:* ${{ github.head_ref || github.ref_name }}\n*PR:* <${{ github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}|링크>\n*Author:* ${{ github.actor }}\n*Checkstyle:* ${{ needs.checkstyle.result }}\n*Build:* ${{ needs.build.result }}"

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -55,17 +55,22 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Trigger CD deployment
-        uses: peter-evans/repository-dispatch@v4
+  notify:
+    name: Slack Notification
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: always()
+    steps:
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v2.1.1
         with:
-          token: ${{ secrets.CD_REPO_TOKEN }}
-          repository: ${{ vars.CD_REPO }}
-          event-type: deploy
-          client-payload: >-
-            {
-              "image": "${{ steps.ecr-login.outputs.registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.version.outputs.version }}-${{ steps.version.outputs.sha_short }}",
-              "version": "${{ steps.version.outputs.version }}",
-              "sha": "${{ github.event.workflow_run.head_sha }}",
-              "sha_short": "${{ steps.version.outputs.sha_short }}",
-              "tag": "${{ steps.version.outputs.version }}-${{ steps.version.outputs.sha_short }}"
-            }
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "${{ needs.deploy.result == 'success' && '🚀 배포 성공' || '❌ 배포 실패' }}: ${{ github.repository }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: "${{ needs.deploy.result == 'success' && '🚀 *배포 성공*' || '❌ *배포 실패*' }}\n*Repo:* ${{ github.repository }}\n*Branch:* ${{ github.event.workflow_run.head_branch }}\n*Commit:* <${{ format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.event.workflow_run.head_sha) }}|${{ github.event.workflow_run.head_sha }}>\n*Deploy:* ${{ needs.deploy.result }}"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,11 +18,15 @@ RUN ./gradlew :module:app:application:bootJar -x test --no-daemon
 FROM eclipse-temurin:17-jre
 WORKDIR /app
 
-# 환경변수 선언
+RUN groupadd --system --gid 1001 spring && \
+    useradd --system --uid 1001 --gid spring app
+
+COPY --from=build --chown=app:spring /app/module/app/application/build/libs/*.jar app.jar
+
+USER app
+
+EXPOSE 8080
+
 ENV SPRING_PROFILES_ACTIVE=dev
 
-# JAR 복사
-COPY --from=build /app/module/app/application/build/libs/*.jar app.jar
-
-# 실행
-ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE}", "-jar", "app.jar"]
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
## Summary
- CI 워크플로우: `checkstyle` + `build` 병렬 job 분리, `actions/checkout` v6 업그레이드, Slack 알림 job 추가
- Deploy 워크플로우: `repository-dispatch` (CD 트리거) 제거, Slack 알림 job 추가
- Dockerfile: 비root 사용자(`app:spring`) 적용, exec form ENTRYPOINT에서 불필요한 `-D` 플래그 제거, `EXPOSE 8080` 명시

## Test plan
- [ ] PR 생성 → CI 워크플로우에서 Checkstyle, Build 병렬 실행 확인
- [ ] CI 완료 후 Slack 알림 수신 확인
- [ ] main push → CI 성공 → Deploy 워크플로우 자동 트리거 확인
- [ ] ECR 콘솔에서 `{version}-{sha_short}` 및 `latest` 태그 확인
- [ ] Deploy 완료 후 Slack 알림 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)