### PR TITLE
refactor: MemberQueryUseCase 분리 및 CORS 설정 외부화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, develop]
   push:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   checkstyle:

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/member/application/MemberService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/member/application/MemberService.java
@@ -8,6 +8,7 @@ import com.example.lolserver.domain.member.application.model.MemberReadModel;
 import com.example.lolserver.domain.member.application.model.OAuthUserInfo;
 import com.example.lolserver.domain.member.application.model.RiotAccountLinkReadModel;
 import com.example.lolserver.domain.member.application.port.in.MemberAuthUseCase;
+import com.example.lolserver.domain.member.application.port.in.MemberQueryUseCase;
 import com.example.lolserver.domain.member.application.port.in.RiotAccountLinkUseCase;
 import com.example.lolserver.domain.member.application.port.out.MemberPersistencePort;
 import com.example.lolserver.domain.member.application.port.out.OAuthAuthorizationPort;
@@ -33,7 +34,7 @@ import java.util.UUID;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class MemberService implements MemberAuthUseCase, RiotAccountLinkUseCase {
+public class MemberService implements MemberAuthUseCase, MemberQueryUseCase, RiotAccountLinkUseCase {
 
     private final MemberPersistencePort memberPersistencePort;
     private final RiotAccountLinkPersistencePort riotAccountLinkPersistencePort;

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/member/application/port/in/MemberAuthUseCase.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/member/application/port/in/MemberAuthUseCase.java
@@ -3,7 +3,6 @@ package com.example.lolserver.domain.member.application.port.in;
 import com.example.lolserver.domain.member.application.dto.OAuthLoginCommand;
 import com.example.lolserver.domain.member.application.dto.TokenRefreshCommand;
 import com.example.lolserver.domain.member.application.model.AuthTokenReadModel;
-import com.example.lolserver.domain.member.application.model.MemberReadModel;
 import com.example.lolserver.domain.member.domain.vo.OAuthProvider;
 
 public interface MemberAuthUseCase {
@@ -15,6 +14,4 @@ public interface MemberAuthUseCase {
     AuthTokenReadModel refreshToken(TokenRefreshCommand command);
 
     void logout(Long memberId);
-
-    MemberReadModel getMyProfile(Long memberId);
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/member/application/port/in/MemberQueryUseCase.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/member/application/port/in/MemberQueryUseCase.java
@@ -1,0 +1,7 @@
+package com.example.lolserver.domain.member.application.port.in;
+
+import com.example.lolserver.domain.member.application.model.MemberReadModel;
+
+public interface MemberQueryUseCase {
+    MemberReadModel getMyProfile(Long memberId);
+}

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/member/MemberController.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/member/MemberController.java
@@ -8,7 +8,7 @@ import com.example.lolserver.controller.support.response.ApiResponse;
 import com.example.lolserver.domain.member.application.dto.RiotLinkCommand;
 import com.example.lolserver.domain.member.application.model.MemberReadModel;
 import com.example.lolserver.domain.member.application.model.RiotAccountLinkReadModel;
-import com.example.lolserver.domain.member.application.port.in.MemberAuthUseCase;
+import com.example.lolserver.domain.member.application.port.in.MemberQueryUseCase;
 import com.example.lolserver.domain.member.application.port.in.RiotAccountLinkUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,12 +29,12 @@ import java.util.List;
 public class MemberController {
 
     private final RiotAccountLinkUseCase riotAccountLinkUseCase;
-    private final MemberAuthUseCase memberAuthUseCase;
+    private final MemberQueryUseCase memberQueryUseCase;
 
     @GetMapping("/me")
     public ApiResponse<MemberResponse> getMyProfile(
             @AuthenticationPrincipal AuthenticatedMember member) {
-        MemberReadModel readModel = memberAuthUseCase.getMyProfile(member.memberId());
+        MemberReadModel readModel = memberQueryUseCase.getMyProfile(member.memberId());
         return ApiResponse.success(MemberResponse.from(readModel));
     }
 

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/security/CorsProperties.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/security/CorsProperties.java
@@ -1,0 +1,16 @@
+package com.example.lolserver.controller.security;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+    private List<String> allowedOrigins = List.of();
+}

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/security/SecurityConfig.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/security/SecurityConfig.java
@@ -22,6 +22,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CorsProperties corsProperties;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -50,12 +51,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(
-                "http://localhost:3000",
-                "http://localhost:8080",
-                "http://lol-ui:3000",
-                "https://metapick.me"
-        ));
+        configuration.setAllowedOrigins(corsProperties.getAllowedOrigins());
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("Content-Type", "Authorization", "X-Requested-With"));
         configuration.setAllowCredentials(true);

--- a/module/infra/api/src/main/resources/api-local.yml
+++ b/module/infra/api/src/main/resources/api-local.yml
@@ -8,3 +8,10 @@ jwt:
 
 app:
   frontend-callback-url: http://localhost:3000/auth/callback
+
+cors:
+  allowed-origins:
+    - http://localhost:3000
+    - http://localhost:8080
+    - http://lol-ui:3000
+    - https://metapick.me

--- a/module/infra/api/src/test/java/com/example/lolserver/controller/security/SecurityConfigTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/controller/security/SecurityConfigTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SecurityConfigTest {
@@ -21,8 +23,13 @@ class SecurityConfigTest {
         JwtTokenAdapter jwtTokenAdapter = new JwtTokenAdapter(jwtProperties);
         jwtTokenAdapter.init();
 
+        CorsProperties corsProperties = new CorsProperties();
+        corsProperties.setAllowedOrigins(List.of(
+                "http://localhost:3000", "http://localhost:8080",
+                "http://lol-ui:3000", "https://metapick.me"));
+
         JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtTokenAdapter);
-        securityConfig = new SecurityConfig(filter);
+        securityConfig = new SecurityConfig(filter, corsProperties);
     }
 
     @DisplayName("CORS 설정 소스가 정상적으로 생성된다")

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/MemberControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/MemberControllerTest.java
@@ -6,7 +6,7 @@ import com.example.lolserver.docs.RestDocsSupport;
 import com.example.lolserver.docs.TestAuthenticatedMemberResolver;
 import com.example.lolserver.domain.member.application.model.MemberReadModel;
 import com.example.lolserver.domain.member.application.model.RiotAccountLinkReadModel;
-import com.example.lolserver.domain.member.application.port.in.MemberAuthUseCase;
+import com.example.lolserver.domain.member.application.port.in.MemberQueryUseCase;
 import com.example.lolserver.domain.member.application.port.in.RiotAccountLinkUseCase;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -38,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 class MemberControllerTest extends RestDocsSupport {
 
     @Mock
-    private MemberAuthUseCase memberAuthUseCase;
+    private MemberQueryUseCase memberQueryUseCase;
 
     @Mock
     private RiotAccountLinkUseCase riotAccountLinkUseCase;
@@ -47,7 +47,7 @@ class MemberControllerTest extends RestDocsSupport {
 
     @Override
     protected Object initController() {
-        return new MemberController(riotAccountLinkUseCase, memberAuthUseCase);
+        return new MemberController(riotAccountLinkUseCase, memberQueryUseCase);
     }
 
     @Override
@@ -67,7 +67,7 @@ class MemberControllerTest extends RestDocsSupport {
                 .oauthProvider("GOOGLE")
                 .build();
 
-        given(memberAuthUseCase.getMyProfile(eq(1L))).willReturn(readModel);
+        given(memberQueryUseCase.getMyProfile(eq(1L))).willReturn(readModel);
 
         // when & then
         mockMvc.perform(


### PR DESCRIPTION
## Summary
- `MemberQueryUseCase` 인터페이스를 `MemberAuthUseCase`에서 분리하여 CQRS 원칙 적용
- CORS 설정을 `SecurityConfig` 하드코딩에서 `CorsProperties`로 외부화 (`api-local.yml` 기반)
- 관련 컨트롤러 및 테스트 코드 업데이트

## Test plan
- [x] `SecurityConfigTest` 업데이트 및 통과 확인
- [x] `MemberControllerTest` (RestDocs) 업데이트 및 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)