### PR TITLE
chore: OAuth 리팩토링, ChampionStats 캐싱, 성능 테스트, Git 워크플로우 설정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,5 +32,8 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 RIOT_RSO_CLIENT_ID=your-riot-rso-client-id
 RIOT_RSO_CLIENT_SECRET=your-riot-rso-client-secret
 
+# --- Champion Stats Cache ---
+CHAMPION_STATS_CACHE_ENABLED=true
+
 # --- JWT ---
 JWT_SECRET_KEY=local-dev-secret-key-must-be-at-least-256-bits-long-for-hs256

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## 변경 유형
+<!-- feat / fix / refactor / docs / chore 중 선택 -->
+
+## 변경 사항
+-
+
+## 변경 이유
+-
+
+## 테스트
+- [ ] 단위 테스트 통과 (`./gradlew test`)
+- [ ] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
+- [ ] 로컬 빌드 확인 (`./gradlew build`)
+
+## 리뷰 포인트
+-

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ logs/
 !.github/workflows/*.yml
 !**/src/main/resources/*.yml
 !**/src/test/resources/*.yml
+!performance-tests/docker-compose.yml
 docker/
 
 ### STS ###
@@ -55,4 +56,5 @@ config/checkstyle/checkstyle-*-all.jar
 
 ### Performance Tests ###
 performance-tests/results/*.json
+performance-tests/results/*.txt
 !performance-tests/results/.gitkeep

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,22 @@ module/
 - 커맨드: `@Builder @Getter @Setter @NoArgsConstructor @AllArgsConstructor`
 - 트랜잭션: 조회 `@Transactional(readOnly = true)`, 변경 `@Transactional`
 
+### Git 워크플로우
+
+**브랜치 전략**: Git Flow 변형 (`main` / `develop` / feature 브랜치)
+
+| 브랜치 | 용도 |
+|--------|------|
+| `main` | 프로덕션 릴리스 |
+| `develop` | 개발 통합 브랜치 |
+| `feature/*` | 새 기능 개발 |
+| `fix/*` | 버그 수정 |
+| `refactor/*` | 리팩토링 |
+| `hotfix/*` | 프로덕션 긴급 수정 |
+
+**기본 플로우**: `feature/* → develop → main`
+**Hotfix 플로우**: `hotfix/* → main → develop 역반영`
+
 ### 커밋 메시지 컨벤션
 
 - 형식: `<type>: <한글 설명>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing Guide
+
+## 브랜치 전략
+
+이 프로젝트는 Git Flow 변형을 사용합니다.
+
+### 브랜치 구조
+
+| 브랜치 | 용도 |
+|--------|------|
+| `main` | 프로덕션 릴리스 |
+| `develop` | 개발 통합 브랜치 |
+| `feature/*` | 새 기능 개발 |
+| `fix/*` | 버그 수정 |
+| `refactor/*` | 리팩토링 |
+| `hotfix/*` | 프로덕션 긴급 수정 |
+
+### 브랜치 네이밍 규칙
+
+```
+feature/간단한-설명    # 새 기능
+fix/간단한-설명        # 버그 수정
+refactor/간단한-설명   # 리팩토링
+hotfix/간단한-설명     # 긴급 수정
+```
+
+예시: `feature/rso`, `fix/match-sync-error`, `refactor/ecr-deploy-pipeline`
+
+## 개발 플로우
+
+### 일반 개발
+
+1. `develop` 브랜치에서 새 브랜치 생성
+2. 작업 완료 후 `develop`으로 PR 생성
+3. CI 통과 확인 (빌드, 테스트, Checkstyle)
+4. 코드 리뷰 후 머지
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b feature/my-feature
+# 작업 후
+git push -u origin feature/my-feature
+# GitHub에서 PR 생성
+```
+
+### Hotfix 플로우
+
+1. `main` 브랜치에서 `hotfix/*` 브랜치 생성
+2. 수정 후 `main`으로 PR 생성 및 머지
+3. `develop`에 역반영
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b hotfix/critical-fix
+# 수정 후
+git push -u origin hotfix/critical-fix
+# main으로 PR 생성 → 머지 후 develop에도 반영
+```
+
+## 커밋 메시지
+
+### 형식
+
+```
+<type>: <한글 설명>
+```
+
+### 타입
+
+| 타입 | 용도 |
+|------|------|
+| `feat` | 새 기능 추가 |
+| `fix` | 버그 수정 |
+| `refactor` | 리팩토링 (기능 변경 없음) |
+| `docs` | 문서 변경 |
+| `chore` | 빌드, CI, 설정 등 기타 |
+
+### 예시
+
+```
+feat: 소환사별 매치 목록 배치 조회 API 추가
+fix: 매치 동기화 시 null 체크 누락 수정
+refactor: MemberQueryUseCase 분리 및 CORS 설정 외부화
+docs: API 문서 업데이트
+chore: CI 워크플로우 트리거 조건 변경
+```
+
+## PR 규칙
+
+- `main`, `develop` 브랜치에는 직접 push 금지
+- PR 생성 시 템플릿을 채워서 제출
+- CI 체크(빌드, 테스트) 통과 필수
+- 최소 1명의 리뷰 승인 후 머지
+
+## 빌드 및 테스트
+
+PR 제출 전 로컬에서 확인:
+
+```bash
+./gradlew build        # 전체 빌드 + 테스트
+./gradlew test         # 테스트만
+```

--- a/docs/review/2026-03-18-oauth-member-simplify.md
+++ b/docs/review/2026-03-18-oauth-member-simplify.md
@@ -1,0 +1,78 @@
+# Simplify Review: OAuth 인증 및 회원 도메인
+
+- **날짜**: 2026-03-18
+- **브랜치**: `feat/oauth-member-domain`
+- **대상 커밋**: `0ff419a feat: OAuth 로그인 및 회원 도메인 기능 추가`
+
+---
+
+## 리뷰 요약
+
+3개의 병렬 리뷰 에이전트 (코드 재사용, 코드 품질, 효율성)가 분석을 수행했으며, 발견된 이슈 중 실질적인 항목을 직접 수정했습니다.
+
+---
+
+## 수정 완료 항목
+
+### 1. [High] 도메인 객체 캡슐화 강화 (Member, RiotAccountLink)
+
+**문제**: `@Setter`로 모든 필드가 외부에 노출되어 도메인 불변성 보장 불가
+
+**수정**:
+- `Member.java`: `@Setter` 제거 → `@Builder` 추가 + `Member.create(OAuthUserInfo)` 팩토리 메서드 추가
+- `RiotAccountLink.java`: `@Setter` 제거 → `@Builder` 추가 + `RiotAccountLink.create(memberId, riotInfo, platformId)` 팩토리 메서드 추가
+- `MemberService.createMember()`: setter 호출 → `Member.create()` 사용
+- `MemberService.linkRiotAccount()`: setter 호출 → `RiotAccountLink.create()` 사용
+- MapStruct 호환성: `@Builder`를 통해 MapStruct가 자동으로 빌더 전략 사용
+
+### 2. [High] JWT 파싱 중복 제거 (MemberService.refreshToken)
+
+**문제**: `validateToken()` → `getMemberIdFromToken()` 순서로 호출 시 동일한 JWT를 2회 파싱 (암호화 연산 중복)
+
+**수정**:
+- `validateToken()` + `getMemberIdFromToken()` → `parseToken()` 한 번으로 통합
+- `parseToken()`이 `TokenInfo(memberId, role)` 반환하므로 단일 파싱으로 충분
+- 예외 발생 시 `CoreException(ErrorType.INVALID_TOKEN)` 던짐
+- 관련 테스트 3개 업데이트: `refreshToken_validToken`, `refreshToken_invalidToken`, `refreshToken_mismatchToken`
+
+---
+
+## 미수정 항목 (참고용)
+
+### 코드 재사용
+
+| 심각도 | 이슈                           | 파일                     | 비고                                                  |
+| ------ | ------------------------------ | ------------------------ | ----------------------------------------------------- |
+| 낮음   | `StringUtils.hasText()` 미사용 | MemberService.java:56    | null 체크로 충분, 기능적 차이 없음                    |
+| 낮음   | `orElse(null)` 패턴            | MemberService.java:69-71 | else 브랜치에 부수 효과가 있어 Optional 체이닝 부적합 |
+
+### 코드 품질
+
+| 심각도 | 이슈                                               | 파일                                                   | 비고                                                          |
+| ------ | -------------------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------- |
+| 중간   | Stringly-typed role (`"USER"` 하드코딩)            | Member.java:37                                         | Role enum 도입 시 영속성 계층 전체 변경 필요, 별도 작업 권장  |
+| 중간   | `OAuthTokenExchanger.providerName` 파라미터 스프롤 | OAuthTokenExchanger.java:25                            | `ProviderConfig`에 name 필드 추가로 해결 가능, 별도 작업 권장 |
+| 중간   | GoogleOAuthClient / RiotRsoClient 코드 중복        | GoogleOAuthClient.java:31-66, RiotRsoClient.java:31-65 | 추상 클래스 추출 가능하나, 현재 2개 구현체로 추상화 시기 아님 |
+| 중간   | Request DTO에 Bean Validation 부재                 | AuthController, MemberController                       | `@Valid` + `@NotBlank` 추가 권장, 별도 작업                   |
+| 경미   | `OAuthUserInfo`가 Google/Riot 정보 혼합            | OAuthUserInfo.java                                     | 현재 구조로 동작에 문제 없음                                  |
+| 경미   | `OAuthStateRedisAdapter`에서 의미 없는 "1" 값 저장 | OAuthStateRedisAdapter.java:19                         | Redis SET 사용 시 값 필수, 관례적 패턴                        |
+
+### 효율성
+
+| 심각도 | 이슈                                                        | 파일                               | 비고                                                                |
+| ------ | ----------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| 중간   | TOCTOU: Riot 링크 중복 체크 후 저장                         | MemberService.java:119-125         | DB UNIQUE 제약으로 보완 권장, 별도 마이그레이션 필요                |
+| 중간   | 로그인 시 매번 lastLogin UPDATE                             | MemberService.java:76-77           | 비동기 업데이트 또는 배치 전환 가능, 현재 부하 수준에서는 수용 가능 |
+| 경미   | `JwtAuthenticationFilter` AUTHORITY_CACHE 미스 시 객체 생성 | JwtAuthenticationFilter.java:50-52 | USER/ADMIN만 사용하므로 실질적 미스 없음                            |
+| 경미   | `generateTokens()`에서 expiry 메서드 중복 호출              | MemberService.java:165-172         | 캐시된 property 접근이므로 성능 영향 미미                           |
+
+---
+
+## 빌드 결과
+
+```
+BUILD SUCCESSFUL in 3m
+93 actionable tasks: 33 executed, 60 up-to-date
+```
+
+모든 테스트 통과 확인.

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
@@ -13,9 +13,10 @@ import com.example.lolserver.domain.championstats.application.model.ChampionStat
 import com.example.lolserver.domain.championstats.application.model.ChampionRateReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionWinRateReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsQueryPort;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.LinkedHashMap;
@@ -24,13 +25,34 @@ import java.util.Map;
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class ChampionStatsService {
 
     private final ChampionStatsQueryPort championStatsQueryPort;
+    private final ChampionStatsCachePort championStatsCachePort;
+    private final boolean cacheEnabled;
+
+    public ChampionStatsService(
+            ChampionStatsQueryPort championStatsQueryPort,
+            ChampionStatsCachePort championStatsCachePort,
+            @Value("${champion-stats.cache.enabled:true}") boolean cacheEnabled) {
+        this.championStatsQueryPort = championStatsQueryPort;
+        this.championStatsCachePort = championStatsCachePort;
+        this.cacheEnabled = cacheEnabled;
+    }
 
     public ChampionStatsReadModel getChampionStats(
             int championId, String patch, String platformId, TierFilter tierFilter) {
+
+        String tierDisplay = tierFilter.toDisplayString();
+
+        if (cacheEnabled) {
+            ChampionStatsReadModel cached = championStatsCachePort
+                    .findChampionStats(championId, patch, platformId, tierDisplay);
+            if (cached != null) {
+                log.debug("캐시 히트 - championId: {}, patch: {}, tier: {}", championId, patch, tierDisplay);
+                return cached;
+            }
+        }
 
         List<ChampionWinRateReadModel> winRates =
             championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter);
@@ -39,7 +61,13 @@ public class ChampionStatsService {
             .map(wr -> buildPositionStats(championId, patch, platformId, tierFilter, wr))
             .toList();
 
-        return new ChampionStatsReadModel(tierFilter.toDisplayString(), positions);
+        ChampionStatsReadModel result = new ChampionStatsReadModel(tierDisplay, positions);
+
+        if (cacheEnabled) {
+            championStatsCachePort.saveChampionStats(championId, patch, platformId, tierDisplay, result);
+        }
+
+        return result;
     }
 
     private ChampionPositionStatsReadModel buildPositionStats(
@@ -81,14 +109,32 @@ public class ChampionStatsService {
 
     public List<PositionChampionStatsReadModel> getChampionStatsByPosition(
             String patch, String platformId, TierFilter tierFilter) {
+
+        String tierDisplay = tierFilter.toDisplayString();
+
+        if (cacheEnabled) {
+            List<PositionChampionStatsReadModel> cached = championStatsCachePort
+                    .findChampionStatsByPosition(patch, platformId, tierDisplay);
+            if (cached != null) {
+                log.debug("캐시 히트 - positions, patch: {}, tier: {}", patch, tierDisplay);
+                return cached;
+            }
+        }
+
         Map<String, List<ChampionRateReadModel>> groupedByPosition =
                 championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter);
 
-        return groupedByPosition.entrySet().stream()
+        List<PositionChampionStatsReadModel> result = groupedByPosition.entrySet().stream()
                 .map(entry -> new PositionChampionStatsReadModel(
                         entry.getKey(),
                         ChampionTierCalculator.assignTiers(entry.getValue())
                 ))
                 .toList();
+
+        if (cacheEnabled) {
+            championStatsCachePort.saveChampionStatsByPosition(patch, platformId, tierDisplay, result);
+        }
+
+        return result;
     }
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsCachePort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsCachePort.java
@@ -1,0 +1,21 @@
+package com.example.lolserver.domain.championstats.application.port.out;
+
+import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
+
+import java.util.List;
+
+public interface ChampionStatsCachePort {
+
+    ChampionStatsReadModel findChampionStats(int championId, String patch, String platformId, String tierDisplay);
+
+    void saveChampionStats(int championId, String patch, String platformId,
+                           String tierDisplay, ChampionStatsReadModel stats);
+
+    List<PositionChampionStatsReadModel> findChampionStatsByPosition(
+            String patch, String platformId, String tierDisplay);
+
+    void saveChampionStatsByPosition(String patch, String platformId,
+                                     String tierDisplay,
+                                     List<PositionChampionStatsReadModel> stats);
+}

--- a/module/core/lol-server-domain/src/main/resources/core-dev.yml
+++ b/module/core/lol-server-domain/src/main/resources/core-dev.yml
@@ -1,3 +1,7 @@
+champion-stats:
+  cache:
+    enabled: ${CHAMPION_STATS_CACHE_ENABLED:true}
+
 spring:
   jackson:
     time-zone: Asia/Seoul

--- a/module/core/lol-server-domain/src/main/resources/core-local.yml
+++ b/module/core/lol-server-domain/src/main/resources/core-local.yml
@@ -11,6 +11,10 @@
 #    prometheus:
 #      enabled: true
 
+champion-stats:
+  cache:
+    enabled: ${CHAMPION_STATS_CACHE_ENABLED:true}
+
 logging:
   level:
     com.example.lolserver.domain.summoner: DEBUG

--- a/module/core/lol-server-domain/src/main/resources/core-prod.yml
+++ b/module/core/lol-server-domain/src/main/resources/core-prod.yml
@@ -1,3 +1,7 @@
+champion-stats:
+  cache:
+    enabled: ${CHAMPION_STATS_CACHE_ENABLED:true}
+
 spring:
   jackson:
     time-zone: Asia/Seoul

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceTest.java
@@ -13,9 +13,10 @@ import com.example.lolserver.domain.championstats.application.model.ChampionStat
 import com.example.lolserver.domain.championstats.application.model.ChampionRateReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionWinRateReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsQueryPort;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -25,7 +26,13 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class ChampionStatsServiceTest {
@@ -33,215 +40,343 @@ class ChampionStatsServiceTest {
     @Mock
     private ChampionStatsQueryPort championStatsQueryPort;
 
-    private ChampionStatsService championStatsService;
+    @Mock
+    private ChampionStatsCachePort championStatsCachePort;
 
-    @BeforeEach
-    void setUp() {
-        championStatsService = new ChampionStatsService(championStatsQueryPort);
+    private ChampionStatsService createService(boolean cacheEnabled) {
+        return new ChampionStatsService(championStatsQueryPort, championStatsCachePort, cacheEnabled);
     }
 
-    @DisplayName("모든 포지션의 챔피언 상세 통계를 그룹핑하여 반환한다")
-    @Test
-    void getChampionStats_returnsAllPositionStats() {
-        // given
-        int championId = 13;
-        String patch = "16.1";
-        String platformId = "KR";
-        TierFilter tierFilter = TierFilter.of("EMERALD");
+    @Nested
+    @DisplayName("캐시 미스 시나리오 (cacheEnabled=true)")
+    class CacheMissTests {
 
-        ChampionWinRateReadModel middleWinRate = new ChampionWinRateReadModel("MIDDLE", 1000, 520, 0.52);
-        ChampionWinRateReadModel topWinRate = new ChampionWinRateReadModel("TOP", 200, 110, 0.55);
+        @DisplayName("모든 포지션의 챔피언 상세 통계를 그룹핑하여 반환한다")
+        @Test
+        void getChampionStats_returnsAllPositionStats() {
+            // given
+            ChampionStatsService service = createService(true);
+            int championId = 13;
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
 
-        given(championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter))
-            .willReturn(List.of(middleWinRate, topWinRate));
+            given(championStatsCachePort.findChampionStats(championId, patch, platformId, "EMERALD"))
+                .willReturn(null);
 
-        // MIDDLE 포지션 상세 통계
-        List<ChampionRuneBuildReadModel> middleRuneBuilds = List.of(
-            new ChampionRuneBuildReadModel(8100, 8300, 8112, 8139, 8143, 8135, 8304, 8345, 5002, 5008, 5005, 300, 0.5333, 0.6)
-        );
-        List<ChampionSpellStatsReadModel> middleSpellStats = List.of(
-            new ChampionSpellStatsReadModel(4, 14, 800, 0.52, 0.8)
-        );
-        List<ChampionSkillBuildReadModel> middleSkillBuilds = List.of(
-            new ChampionSkillBuildReadModel("QWEQEEREQEQWWWW", 400, 0.525, 0.4)
-        );
-        List<ChampionStartItemBuildReadModel> middleStartItemBuilds = List.of(
-            new ChampionStartItemBuildReadModel("1056,2003", 600, 0.51, 0.6)
-        );
-        List<ChampionItemBuildReadModel> middleItemBuilds = List.of(
-            new ChampionItemBuildReadModel("3089,3157,3165", 500, 0.52, 0.5)
-        );
-        List<ChampionItemStatsReadModel> middleItemStats1 = List.of(
-            new ChampionItemStatsReadModel(3089, "Rabadon's Deathcap", 400, 0.55, 0.4)
-        );
-        List<ChampionItemStatsReadModel> middleItemStats2 = List.of(
-            new ChampionItemStatsReadModel(3157, "Zhonya's Hourglass", 350, 0.53, 0.35)
-        );
-        List<ChampionItemStatsReadModel> middleItemStats3 = List.of(
-            new ChampionItemStatsReadModel(3165, "Morellonomicon", 200, 0.50, 0.2)
-        );
+            ChampionWinRateReadModel middleWinRate = new ChampionWinRateReadModel("MIDDLE", 1000, 520, 0.52);
+            ChampionWinRateReadModel topWinRate = new ChampionWinRateReadModel("TOP", 200, 110, 0.55);
 
-        List<ChampionMatchupReadModel> middleStrongMatchups = List.of(
-            new ChampionMatchupReadModel(7, 120, 0.5417, 0.12),
-            new ChampionMatchupReadModel(103, 100, 0.5300, 0.10),
-            new ChampionMatchupReadModel(4, 80, 0.5250, 0.08)
-        );
-        List<ChampionMatchupReadModel> middleWeakMatchups = List.of(
-            new ChampionMatchupReadModel(238, 150, 0.4667, 0.15),
-            new ChampionMatchupReadModel(91, 130, 0.4692, 0.13),
-            new ChampionMatchupReadModel(55, 90, 0.4778, 0.09)
-        );
+            given(championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter))
+                .willReturn(List.of(middleWinRate, topWinRate));
 
-        given(championStatsQueryPort.getStrongMatchups(championId, patch, platformId, tierFilter, "MIDDLE"))
-            .willReturn(middleStrongMatchups);
-        given(championStatsQueryPort.getWeakMatchups(championId, patch, platformId, tierFilter, "MIDDLE"))
-            .willReturn(middleWeakMatchups);
-        given(championStatsQueryPort.getChampionRuneBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
-            .willReturn(middleRuneBuilds);
-        given(championStatsQueryPort.getChampionSpellStats(championId, patch, platformId, tierFilter, "MIDDLE"))
-            .willReturn(middleSpellStats);
-        given(championStatsQueryPort.getChampionSkillBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
-            .willReturn(middleSkillBuilds);
-        given(championStatsQueryPort.getChampionStartItemBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
-            .willReturn(middleStartItemBuilds);
-        given(championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
-            .willReturn(middleItemBuilds);
-        given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "MIDDLE", 1))
-            .willReturn(middleItemStats1);
-        given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "MIDDLE", 2))
-            .willReturn(middleItemStats2);
-        given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "MIDDLE", 3))
-            .willReturn(middleItemStats3);
+            // MIDDLE 포지션 상세 통계
+            List<ChampionRuneBuildReadModel> middleRuneBuilds = List.of(
+                new ChampionRuneBuildReadModel(8100, 8300, 8112, 8139, 8143, 8135, 8304, 8345, 5002, 5008, 5005, 300, 0.5333, 0.6)
+            );
+            List<ChampionSpellStatsReadModel> middleSpellStats = List.of(
+                new ChampionSpellStatsReadModel(4, 14, 800, 0.52, 0.8)
+            );
+            List<ChampionSkillBuildReadModel> middleSkillBuilds = List.of(
+                new ChampionSkillBuildReadModel("QWEQEEREQEQWWWW", 400, 0.525, 0.4)
+            );
+            List<ChampionStartItemBuildReadModel> middleStartItemBuilds = List.of(
+                new ChampionStartItemBuildReadModel("1056,2003", 600, 0.51, 0.6)
+            );
+            List<ChampionItemBuildReadModel> middleItemBuilds = List.of(
+                new ChampionItemBuildReadModel("3089,3157,3165", 500, 0.52, 0.5)
+            );
+            List<ChampionItemStatsReadModel> middleItemStats1 = List.of(
+                new ChampionItemStatsReadModel(3089, "Rabadon's Deathcap", 400, 0.55, 0.4)
+            );
+            List<ChampionItemStatsReadModel> middleItemStats2 = List.of(
+                new ChampionItemStatsReadModel(3157, "Zhonya's Hourglass", 350, 0.53, 0.35)
+            );
+            List<ChampionItemStatsReadModel> middleItemStats3 = List.of(
+                new ChampionItemStatsReadModel(3165, "Morellonomicon", 200, 0.50, 0.2)
+            );
 
-        // TOP 포지션 상세 통계
-        given(championStatsQueryPort.getStrongMatchups(championId, patch, platformId, tierFilter, "TOP"))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getWeakMatchups(championId, patch, platformId, tierFilter, "TOP"))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getChampionRuneBuilds(championId, patch, platformId, tierFilter, "TOP"))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getChampionSpellStats(championId, patch, platformId, tierFilter, "TOP"))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getChampionSkillBuilds(championId, patch, platformId, tierFilter, "TOP"))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getChampionStartItemBuilds(championId, patch, platformId, tierFilter, "TOP"))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, "TOP"))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "TOP", 1))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "TOP", 2))
-            .willReturn(List.of());
-        given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "TOP", 3))
-            .willReturn(List.of());
+            List<ChampionMatchupReadModel> middleStrongMatchups = List.of(
+                new ChampionMatchupReadModel(7, 120, 0.5417, 0.12),
+                new ChampionMatchupReadModel(103, 100, 0.5300, 0.10),
+                new ChampionMatchupReadModel(4, 80, 0.5250, 0.08)
+            );
+            List<ChampionMatchupReadModel> middleWeakMatchups = List.of(
+                new ChampionMatchupReadModel(238, 150, 0.4667, 0.15),
+                new ChampionMatchupReadModel(91, 130, 0.4692, 0.13),
+                new ChampionMatchupReadModel(55, 90, 0.4778, 0.09)
+            );
 
-        // when
-        ChampionStatsReadModel result = championStatsService.getChampionStats(
-            championId, patch, platformId, tierFilter);
+            given(championStatsQueryPort.getStrongMatchups(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(middleStrongMatchups);
+            given(championStatsQueryPort.getWeakMatchups(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(middleWeakMatchups);
+            given(championStatsQueryPort.getChampionRuneBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(middleRuneBuilds);
+            given(championStatsQueryPort.getChampionSpellStats(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(middleSpellStats);
+            given(championStatsQueryPort.getChampionSkillBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(middleSkillBuilds);
+            given(championStatsQueryPort.getChampionStartItemBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(middleStartItemBuilds);
+            given(championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(middleItemBuilds);
+            given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "MIDDLE", 1))
+                .willReturn(middleItemStats1);
+            given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "MIDDLE", 2))
+                .willReturn(middleItemStats2);
+            given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "MIDDLE", 3))
+                .willReturn(middleItemStats3);
 
-        // then
-        assertThat(result.tier()).isEqualTo("EMERALD");
-        assertThat(result.positions()).hasSize(2);
+            // TOP 포지션 상세 통계
+            given(championStatsQueryPort.getStrongMatchups(championId, patch, platformId, tierFilter, "TOP"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getWeakMatchups(championId, patch, platformId, tierFilter, "TOP"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionRuneBuilds(championId, patch, platformId, tierFilter, "TOP"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionSpellStats(championId, patch, platformId, tierFilter, "TOP"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionSkillBuilds(championId, patch, platformId, tierFilter, "TOP"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionStartItemBuilds(championId, patch, platformId, tierFilter, "TOP"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, "TOP"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "TOP", 1))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "TOP", 2))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionItemStats(championId, patch, platformId, tierFilter, "TOP", 3))
+                .willReturn(List.of());
 
-        ChampionPositionStatsReadModel middleStats = result.positions().get(0);
-        assertThat(middleStats.teamPosition()).isEqualTo("MIDDLE");
-        assertThat(middleStats.winRate()).isEqualTo(0.52);
-        assertThat(middleStats.totalGames()).isEqualTo(1000);
-        assertThat(middleStats.strongMatchups()).hasSize(3);
-        assertThat(middleStats.strongMatchups().get(0).opponentChampionId()).isEqualTo(7);
-        assertThat(middleStats.strongMatchups().get(0).winRate()).isEqualTo(0.5417);
-        assertThat(middleStats.weakMatchups()).hasSize(3);
-        assertThat(middleStats.weakMatchups().get(0).opponentChampionId()).isEqualTo(238);
-        assertThat(middleStats.weakMatchups().get(0).winRate()).isEqualTo(0.4667);
-        assertThat(middleStats.runeBuilds()).hasSize(1);
-        assertThat(middleStats.spellStats()).hasSize(1);
-        assertThat(middleStats.spellStats().get(0).summoner1Id()).isEqualTo(4);
-        assertThat(middleStats.skillBuilds()).hasSize(1);
-        assertThat(middleStats.startItemBuilds()).hasSize(1);
-        assertThat(middleStats.startItemBuilds().get(0).startItems()).isEqualTo("1056,2003");
-        assertThat(middleStats.itemBuilds()).hasSize(1);
-        assertThat(middleStats.itemStatsByOrder()).hasSize(3);
+            // when
+            ChampionStatsReadModel result = service.getChampionStats(
+                championId, patch, platformId, tierFilter);
 
-        ChampionPositionStatsReadModel topStats = result.positions().get(1);
-        assertThat(topStats.teamPosition()).isEqualTo("TOP");
-        assertThat(topStats.winRate()).isEqualTo(0.55);
-        assertThat(topStats.totalGames()).isEqualTo(200);
+            // then
+            assertThat(result.tier()).isEqualTo("EMERALD");
+            assertThat(result.positions()).hasSize(2);
+
+            ChampionPositionStatsReadModel middleStats = result.positions().get(0);
+            assertThat(middleStats.teamPosition()).isEqualTo("MIDDLE");
+            assertThat(middleStats.winRate()).isEqualTo(0.52);
+            assertThat(middleStats.totalGames()).isEqualTo(1000);
+            assertThat(middleStats.strongMatchups()).hasSize(3);
+            assertThat(middleStats.strongMatchups().get(0).opponentChampionId()).isEqualTo(7);
+            assertThat(middleStats.strongMatchups().get(0).winRate()).isEqualTo(0.5417);
+            assertThat(middleStats.weakMatchups()).hasSize(3);
+            assertThat(middleStats.weakMatchups().get(0).opponentChampionId()).isEqualTo(238);
+            assertThat(middleStats.weakMatchups().get(0).winRate()).isEqualTo(0.4667);
+            assertThat(middleStats.runeBuilds()).hasSize(1);
+            assertThat(middleStats.spellStats()).hasSize(1);
+            assertThat(middleStats.spellStats().get(0).summoner1Id()).isEqualTo(4);
+            assertThat(middleStats.skillBuilds()).hasSize(1);
+            assertThat(middleStats.startItemBuilds()).hasSize(1);
+            assertThat(middleStats.startItemBuilds().get(0).startItems()).isEqualTo("1056,2003");
+            assertThat(middleStats.itemBuilds()).hasSize(1);
+            assertThat(middleStats.itemStatsByOrder()).hasSize(3);
+
+            ChampionPositionStatsReadModel topStats = result.positions().get(1);
+            assertThat(topStats.teamPosition()).isEqualTo("TOP");
+            assertThat(topStats.winRate()).isEqualTo(0.55);
+            assertThat(topStats.totalGames()).isEqualTo(200);
+
+            then(championStatsCachePort).should().saveChampionStats(
+                eq(championId), eq(patch), eq(platformId), eq("EMERALD"), any(ChampionStatsReadModel.class));
+        }
+
+        @DisplayName("승률 데이터가 없으면 빈 포지션 리스트를 반환한다")
+        @Test
+        void getChampionStats_returnsEmptyPositions_whenNoWinRateData() {
+            // given
+            ChampionStatsService service = createService(true);
+            int championId = 999;
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
+
+            given(championStatsCachePort.findChampionStats(championId, patch, platformId, "EMERALD"))
+                .willReturn(null);
+
+            given(championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter))
+                .willReturn(List.of());
+
+            // when
+            ChampionStatsReadModel result = service.getChampionStats(
+                championId, patch, platformId, tierFilter);
+
+            // then
+            assertThat(result.tier()).isEqualTo("EMERALD");
+            assertThat(result.positions()).isEmpty();
+        }
+
+        @DisplayName("포지션별 챔피언 승률/픽률/밴률을 반환한다")
+        @Test
+        void getChampionStatsByPosition_returnsGroupedByPosition() {
+            // given
+            ChampionStatsService service = createService(true);
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
+
+            given(championStatsCachePort.findChampionStatsByPosition(patch, platformId, "EMERALD"))
+                .willReturn(null);
+
+            Map<String, List<ChampionRateReadModel>> grouped = Map.of(
+                "TOP", List.of(
+                    new ChampionRateReadModel(266, 0.5200, 0.0800, 0.0500, 1500),
+                    new ChampionRateReadModel(122, 0.4800, 0.0600, 0.0300, 1200)
+                ),
+                "JUNGLE", List.of(
+                    new ChampionRateReadModel(64, 0.5100, 0.1000, 0.0700, 2000)
+                )
+            );
+
+            given(championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter))
+                .willReturn(grouped);
+
+            // when
+            List<PositionChampionStatsReadModel> result =
+                service.getChampionStatsByPosition(patch, platformId, tierFilter);
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(PositionChampionStatsReadModel::teamPosition)
+                .containsExactlyInAnyOrder("TOP", "JUNGLE");
+
+            result.forEach(position ->
+                position.champions().forEach(champion ->
+                    assertThat(champion.tier()).isNotNull()
+                )
+            );
+
+            then(championStatsCachePort).should().saveChampionStatsByPosition(
+                eq(patch), eq(platformId), eq("EMERALD"), any());
+        }
+
+        @DisplayName("포지션별 챔피언 통계 조회 시 데이터가 없으면 빈 리스트를 반환한다")
+        @Test
+        void getChampionStatsByPosition_returnsEmptyList_whenNoData() {
+            // given
+            ChampionStatsService service = createService(true);
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
+
+            given(championStatsCachePort.findChampionStatsByPosition(patch, platformId, "EMERALD"))
+                .willReturn(null);
+
+            given(championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter))
+                .willReturn(Map.of());
+
+            // when
+            List<PositionChampionStatsReadModel> result =
+                service.getChampionStatsByPosition(patch, platformId, tierFilter);
+
+            // then
+            assertThat(result).isEmpty();
+        }
     }
 
-    @DisplayName("승률 데이터가 없으면 빈 포지션 리스트를 반환한다")
-    @Test
-    void getChampionStats_returnsEmptyPositions_whenNoWinRateData() {
-        // given
-        int championId = 999;
-        String patch = "16.1";
-        String platformId = "KR";
-        TierFilter tierFilter = TierFilter.of("EMERALD");
+    @Nested
+    @DisplayName("캐시 히트 시나리오 (cacheEnabled=true)")
+    class CacheHitTests {
 
-        given(championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter))
-            .willReturn(List.of());
+        @DisplayName("캐시 히트 시 QueryPort를 호출하지 않는다")
+        @Test
+        void getChampionStats_cacheHit_skipsQueryPort() {
+            // given
+            ChampionStatsService service = createService(true);
+            int championId = 13;
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
 
-        // when
-        ChampionStatsReadModel result = championStatsService.getChampionStats(
-            championId, patch, platformId, tierFilter);
+            ChampionStatsReadModel cached = new ChampionStatsReadModel("EMERALD", List.of());
 
-        // then
-        assertThat(result.tier()).isEqualTo("EMERALD");
-        assertThat(result.positions()).isEmpty();
+            given(championStatsCachePort.findChampionStats(championId, patch, platformId, "EMERALD"))
+                .willReturn(cached);
+
+            // when
+            ChampionStatsReadModel result = service.getChampionStats(championId, patch, platformId, tierFilter);
+
+            // then
+            assertThat(result).isSameAs(cached);
+            then(championStatsQueryPort).should(never()).getChampionWinRates(anyInt(), anyString(), anyString(), any());
+        }
+
+        @DisplayName("포지션별 캐시 히트 시 QueryPort를 호출하지 않는다")
+        @Test
+        void getChampionStatsByPosition_cacheHit_skipsQueryPort() {
+            // given
+            ChampionStatsService service = createService(true);
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
+
+            List<PositionChampionStatsReadModel> cached = List.of(
+                new PositionChampionStatsReadModel("TOP", List.of())
+            );
+
+            given(championStatsCachePort.findChampionStatsByPosition(patch, platformId, "EMERALD"))
+                .willReturn(cached);
+
+            // when
+            List<PositionChampionStatsReadModel> result = service.getChampionStatsByPosition(patch, platformId, tierFilter);
+
+            // then
+            assertThat(result).isSameAs(cached);
+            then(championStatsQueryPort).should(never()).getChampionStatsByPosition(anyString(), anyString(), any());
+        }
     }
 
-    @DisplayName("포지션별 챔피언 승률/픽률/밴률을 반환한다")
-    @Test
-    void getChampionStatsByPosition_returnsGroupedByPosition() {
-        // given
-        String patch = "16.1";
-        String platformId = "KR";
-        TierFilter tierFilter = TierFilter.of("EMERALD");
+    @Nested
+    @DisplayName("캐시 OFF 시나리오 (cacheEnabled=false)")
+    class CacheDisabledTests {
 
-        Map<String, List<ChampionRateReadModel>> grouped = Map.of(
-            "TOP", List.of(
-                new ChampionRateReadModel(266, 0.5200, 0.0800, 0.0500, 1500),
-                new ChampionRateReadModel(122, 0.4800, 0.0600, 0.0300, 1200)
-            ),
-            "JUNGLE", List.of(
-                new ChampionRateReadModel(64, 0.5100, 0.1000, 0.0700, 2000)
-            )
-        );
+        @DisplayName("캐시 OFF 시 캐시 포트를 호출하지 않는다")
+        @Test
+        void getChampionStats_cacheDisabled_skipsCachePort() {
+            // given
+            ChampionStatsService service = createService(false);
+            int championId = 13;
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
 
-        given(championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter))
-            .willReturn(grouped);
+            given(championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter))
+                .willReturn(List.of());
 
-        // when
-        List<PositionChampionStatsReadModel> result =
-            championStatsService.getChampionStatsByPosition(patch, platformId, tierFilter);
+            // when
+            ChampionStatsReadModel result = service.getChampionStats(championId, patch, platformId, tierFilter);
 
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result).extracting(PositionChampionStatsReadModel::teamPosition)
-            .containsExactlyInAnyOrder("TOP", "JUNGLE");
+            // then
+            assertThat(result.tier()).isEqualTo("EMERALD");
+            assertThat(result.positions()).isEmpty();
+            then(championStatsCachePort).should(never()).findChampionStats(anyInt(), anyString(), anyString(), anyString());
+            then(championStatsCachePort).should(never()).saveChampionStats(anyInt(), anyString(), anyString(), anyString(), any());
+        }
 
-        result.forEach(position ->
-            position.champions().forEach(champion ->
-                assertThat(champion.tier()).isNotNull()
-            )
-        );
-    }
+        @DisplayName("캐시 OFF 시 포지션별 조회에서도 캐시 포트를 호출하지 않는다")
+        @Test
+        void getChampionStatsByPosition_cacheDisabled_skipsCachePort() {
+            // given
+            ChampionStatsService service = createService(false);
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
 
-    @DisplayName("포지션별 챔피언 통계 조회 시 데이터가 없으면 빈 리스트를 반환한다")
-    @Test
-    void getChampionStatsByPosition_returnsEmptyList_whenNoData() {
-        // given
-        String patch = "16.1";
-        String platformId = "KR";
-        TierFilter tierFilter = TierFilter.of("EMERALD");
+            given(championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter))
+                .willReturn(Map.of());
 
-        given(championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter))
-            .willReturn(Map.of());
+            // when
+            List<PositionChampionStatsReadModel> result = service.getChampionStatsByPosition(patch, platformId, tierFilter);
 
-        // when
-        List<PositionChampionStatsReadModel> result =
-            championStatsService.getChampionStatsByPosition(patch, platformId, tierFilter);
-
-        // then
-        assertThat(result).isEmpty();
+            // then
+            assertThat(result).isEmpty();
+            then(championStatsCachePort).should(never()).findChampionStatsByPosition(anyString(), anyString(), anyString());
+            then(championStatsCachePort).should(never()).saveChampionStatsByPosition(anyString(), anyString(), anyString(), any());
+        }
     }
 }

--- a/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/GoogleOAuthClient.java
+++ b/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/GoogleOAuthClient.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.adapter.oauth;
 
 import com.example.lolserver.adapter.oauth.config.OAuthProperties;
+import com.example.lolserver.adapter.oauth.dto.OAuthTokenResponse;
 import com.example.lolserver.domain.member.application.model.OAuthUserInfo;
 import com.example.lolserver.domain.member.domain.vo.OAuthProvider;
 import com.example.lolserver.support.error.CoreException;
@@ -24,8 +25,8 @@ public class GoogleOAuthClient {
     public OAuthUserInfo getUserInfo(String code, String redirectUri) {
         OAuthProperties.ProviderConfig config = oAuthProperties.getGoogle();
 
-        String accessToken = tokenExchanger.exchange(code, redirectUri, config, "Google");
-        return fetchUserInfo(accessToken, config);
+        OAuthTokenResponse tokenResponse = tokenExchanger.exchange(code, redirectUri, config, OAuthProvider.GOOGLE);
+        return fetchUserInfo(tokenResponse.getAccessToken(), config);
     }
 
     @SuppressWarnings("unchecked")

--- a/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/OAuthAuthorizationAdapter.java
+++ b/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/OAuthAuthorizationAdapter.java
@@ -17,14 +17,18 @@ public class OAuthAuthorizationAdapter implements OAuthAuthorizationPort {
     public String buildAuthorizationUrl(OAuthProvider provider, String state) {
         OAuthProperties.ProviderConfig config = getConfig(provider);
 
-        return UriComponentsBuilder.fromUriString(config.getAuthorizationUri())
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(config.getAuthorizationUri())
                 .queryParam("client_id", config.getClientId())
                 .queryParam("redirect_uri", config.getCallbackUri())
                 .queryParam("response_type", "code")
                 .queryParam("scope", config.getScope())
-                .queryParam("state", state)
-                .queryParam("access_type", "offline")
-                .encode()
+                .queryParam("state", state);
+
+        if (provider == OAuthProvider.GOOGLE) {
+            builder.queryParam("access_type", "offline");
+        }
+
+        return builder.encode()
                 .build()
                 .toUriString();
     }

--- a/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/OAuthTokenExchanger.java
+++ b/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/OAuthTokenExchanger.java
@@ -1,6 +1,8 @@
 package com.example.lolserver.adapter.oauth;
 
 import com.example.lolserver.adapter.oauth.config.OAuthProperties;
+import com.example.lolserver.adapter.oauth.dto.OAuthTokenResponse;
+import com.example.lolserver.domain.member.domain.vo.OAuthProvider;
 import com.example.lolserver.support.error.CoreException;
 import com.example.lolserver.support.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 
 @Slf4j
@@ -21,35 +25,44 @@ public class OAuthTokenExchanger {
     private final RestClient oauthRestClient;
 
     @SuppressWarnings("unchecked")
-    public String exchange(String code, String redirectUri,
-                           OAuthProperties.ProviderConfig config, String providerName) {
+    public OAuthTokenResponse exchange(String code, String redirectUri,
+                                       OAuthProperties.ProviderConfig config, OAuthProvider provider) {
         MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
         body.add("code", code);
-        body.add("client_id", config.getClientId());
-        body.add("client_secret", config.getClientSecret());
         body.add("redirect_uri", redirectUri);
         body.add("grant_type", "authorization_code");
 
+        RestClient.RequestBodySpec requestSpec = oauthRestClient.post()
+                .uri(config.getTokenUri())
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        if (provider == OAuthProvider.RIOT) {
+            String credentials = config.getClientId() + ":" + config.getClientSecret();
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            requestSpec.header("Authorization", "Basic " + encoded);
+        } else {
+            body.add("client_id", config.getClientId());
+            body.add("client_secret", config.getClientSecret());
+        }
+
         try {
-            Map<String, Object> response = oauthRestClient.post()
-                    .uri(config.getTokenUri())
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            Map<String, Object> response = requestSpec
                     .body(body)
                     .retrieve()
                     .body(Map.class);
 
             if (response == null || !response.containsKey("access_token")) {
                 throw new CoreException(ErrorType.OAUTH_LOGIN_FAILED,
-                        providerName + " 토큰 교환에 실패했습니다.");
+                        provider.name() + " 토큰 교환에 실패했습니다.");
             }
 
-            return (String) response.get("access_token");
+            return OAuthTokenResponse.from(response);
         } catch (CoreException e) {
             throw e;
         } catch (Exception e) {
-            log.error("{} 토큰 교환 실패: {}", providerName, e.getMessage());
+            log.error("{} 토큰 교환 실패: {}", provider.name(), e.getMessage());
             throw new CoreException(ErrorType.OAUTH_LOGIN_FAILED,
-                    providerName + " 토큰 교환에 실패했습니다.");
+                    provider.name() + " 토큰 교환에 실패했습니다.");
         }
     }
 }

--- a/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/RiotRsoClient.java
+++ b/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/RiotRsoClient.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.adapter.oauth;
 
 import com.example.lolserver.adapter.oauth.config.OAuthProperties;
+import com.example.lolserver.adapter.oauth.dto.OAuthTokenResponse;
 import com.example.lolserver.domain.member.application.model.OAuthUserInfo;
 import com.example.lolserver.domain.member.domain.vo.OAuthProvider;
 import com.example.lolserver.support.error.CoreException;
@@ -24,13 +25,41 @@ public class RiotRsoClient {
     public OAuthUserInfo getUserInfo(String code, String redirectUri) {
         OAuthProperties.ProviderConfig config = oAuthProperties.getRiot();
 
-        String accessToken = tokenExchanger.exchange(code, redirectUri, config, "Riot");
-        return fetchAccountInfo(accessToken, config);
+        OAuthTokenResponse tokenResponse = tokenExchanger.exchange(code, redirectUri, config, OAuthProvider.RIOT);
+        String accessToken = tokenResponse.getAccessToken();
+
+        String sub = fetchUserInfoSub(accessToken, config);
+        return fetchAccountInfo(accessToken, config, sub);
+    }
+
+    @SuppressWarnings("unchecked")
+    private String fetchUserInfoSub(String accessToken, OAuthProperties.ProviderConfig config) {
+        try {
+            Map<String, Object> response = oauthRestClient.get()
+                    .uri(config.getUserInfoUri())
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .body(Map.class);
+
+            if (response == null || response.get("sub") == null) {
+                throw new CoreException(ErrorType.OAUTH_LOGIN_FAILED,
+                        "Riot 사용자 정보(sub) 조회에 실패했습니다.");
+            }
+
+            return (String) response.get("sub");
+        } catch (CoreException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("Riot userinfo 조회 실패: {}", e.getMessage());
+            throw new CoreException(ErrorType.OAUTH_LOGIN_FAILED,
+                    "Riot 사용자 정보 조회에 실패했습니다.");
+        }
     }
 
     @SuppressWarnings("unchecked")
     private OAuthUserInfo fetchAccountInfo(String accessToken,
-                                           OAuthProperties.ProviderConfig config) {
+                                           OAuthProperties.ProviderConfig config,
+                                           String sub) {
         try {
             Map<String, Object> response = oauthRestClient.get()
                     .uri(config.getAccountUri())
@@ -51,6 +80,7 @@ public class RiotRsoClient {
 
             return OAuthUserInfo.builder()
                     .provider(OAuthProvider.RIOT.name())
+                    .providerId(sub)
                     .puuid(puuid)
                     .gameName((String) response.get("gameName"))
                     .tagLine((String) response.get("tagLine"))

--- a/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/dto/OAuthTokenResponse.java
+++ b/module/infra/client/oauth/src/main/java/com/example/lolserver/adapter/oauth/dto/OAuthTokenResponse.java
@@ -1,0 +1,29 @@
+package com.example.lolserver.adapter.oauth.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class OAuthTokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private String idToken;
+    private String tokenType;
+    private Integer expiresIn;
+    private String sub;
+
+    public static OAuthTokenResponse from(Map<String, Object> response) {
+        return OAuthTokenResponse.builder()
+                .accessToken((String) response.get("access_token"))
+                .refreshToken((String) response.get("refresh_token"))
+                .idToken((String) response.get("id_token"))
+                .tokenType((String) response.get("token_type"))
+                .expiresIn(response.get("expires_in") instanceof Number n ? n.intValue() : null)
+                .sub((String) response.get("sub"))
+                .build();
+    }
+}

--- a/module/infra/client/oauth/src/main/resources/oauth-local.yml
+++ b/module/infra/client/oauth/src/main/resources/oauth-local.yml
@@ -11,4 +11,8 @@ oauth:
     client-id: ${RIOT_RSO_CLIENT_ID:}
     client-secret: ${RIOT_RSO_CLIENT_SECRET:}
     token-uri: https://auth.riotgames.com/token
+    user-info-uri: https://auth.riotgames.com/userinfo
     account-uri: https://americas.api.riotgames.com/riot/account/v1/accounts/me
+    authorization-uri: https://auth.riotgames.com/authorize
+    scope: openid cpid
+    callback-uri: http://localhost:8100/api/auth/riot/callback

--- a/module/infra/client/oauth/src/test/java/com/example/lolserver/adapter/oauth/OAuthAuthorizationAdapterTest.java
+++ b/module/infra/client/oauth/src/test/java/com/example/lolserver/adapter/oauth/OAuthAuthorizationAdapterTest.java
@@ -1,0 +1,89 @@
+package com.example.lolserver.adapter.oauth;
+
+import com.example.lolserver.adapter.oauth.config.OAuthProperties;
+import com.example.lolserver.domain.member.domain.vo.OAuthProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthAuthorizationAdapterTest {
+
+    @Mock
+    private OAuthProperties oAuthProperties;
+
+    @InjectMocks
+    private OAuthAuthorizationAdapter authorizationAdapter;
+
+    private OAuthProperties.ProviderConfig googleConfig;
+    private OAuthProperties.ProviderConfig riotConfig;
+
+    @BeforeEach
+    void setUp() {
+        googleConfig = new OAuthProperties.ProviderConfig();
+        googleConfig.setClientId("google-client-id");
+        googleConfig.setAuthorizationUri("https://accounts.google.com/o/oauth2/v2/auth");
+        googleConfig.setCallbackUri("http://localhost:8100/api/auth/google/callback");
+        googleConfig.setScope("openid email profile");
+
+        riotConfig = new OAuthProperties.ProviderConfig();
+        riotConfig.setClientId("riot-client-id");
+        riotConfig.setAuthorizationUri("https://auth.riotgames.com/authorize");
+        riotConfig.setCallbackUri("http://localhost:8100/api/auth/riot/callback");
+        riotConfig.setScope("openid cpid");
+    }
+
+    @Test
+    @DisplayName("Google authorization URL에 access_type=offline 포함")
+    void googleAuthorizationUrl_includesAccessTypeOffline() {
+        // given
+        given(oAuthProperties.getGoogle()).willReturn(googleConfig);
+
+        // when
+        String url = authorizationAdapter.buildAuthorizationUrl(OAuthProvider.GOOGLE, "test-state");
+
+        // then
+        assertThat(url).contains("access_type=offline");
+        assertThat(url).contains("client_id=google-client-id");
+        assertThat(url).contains("state=test-state");
+        assertThat(url).contains("response_type=code");
+        assertThat(url).startsWith("https://accounts.google.com/o/oauth2/v2/auth");
+    }
+
+    @Test
+    @DisplayName("Riot authorization URL에 access_type=offline 미포함")
+    void riotAuthorizationUrl_doesNotIncludeAccessTypeOffline() {
+        // given
+        given(oAuthProperties.getRiot()).willReturn(riotConfig);
+
+        // when
+        String url = authorizationAdapter.buildAuthorizationUrl(OAuthProvider.RIOT, "test-state");
+
+        // then
+        assertThat(url).doesNotContain("access_type");
+        assertThat(url).contains("client_id=riot-client-id");
+        assertThat(url).contains("scope=openid%20cpid");
+        assertThat(url).contains("state=test-state");
+        assertThat(url).startsWith("https://auth.riotgames.com/authorize");
+    }
+
+    @Test
+    @DisplayName("Riot callbackUri 반환")
+    void getCallbackUri_returnsRiotCallbackUri() {
+        // given
+        given(oAuthProperties.getRiot()).willReturn(riotConfig);
+
+        // when
+        String callbackUri = authorizationAdapter.getCallbackUri(OAuthProvider.RIOT);
+
+        // then
+        assertThat(callbackUri).isEqualTo("http://localhost:8100/api/auth/riot/callback");
+    }
+}

--- a/module/infra/client/oauth/src/test/java/com/example/lolserver/adapter/oauth/OAuthTokenExchangerTest.java
+++ b/module/infra/client/oauth/src/test/java/com/example/lolserver/adapter/oauth/OAuthTokenExchangerTest.java
@@ -1,0 +1,141 @@
+package com.example.lolserver.adapter.oauth;
+
+import com.example.lolserver.adapter.oauth.config.OAuthProperties;
+import com.example.lolserver.adapter.oauth.dto.OAuthTokenResponse;
+import com.example.lolserver.domain.member.domain.vo.OAuthProvider;
+import com.example.lolserver.support.error.CoreException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OAuthTokenExchangerTest {
+
+    @Mock
+    private RestClient oauthRestClient;
+
+    @Mock
+    private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+
+    @Mock
+    private RestClient.RequestBodySpec requestBodySpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    private OAuthTokenExchanger tokenExchanger;
+
+    private OAuthProperties.ProviderConfig config;
+
+    @BeforeEach
+    void setUp() {
+        tokenExchanger = new OAuthTokenExchanger(oauthRestClient);
+
+        config = new OAuthProperties.ProviderConfig();
+        config.setClientId("test-client-id");
+        config.setClientSecret("test-client-secret");
+        config.setTokenUri("https://example.com/token");
+    }
+
+    @Test
+    @DisplayName("Google 토큰 교환 시 form body에 client_id, client_secret 포함")
+    void googleExchange_includesCredentialsInFormBody() {
+        // given
+        given(oauthRestClient.post()).willReturn(requestBodyUriSpec);
+        given(requestBodyUriSpec.uri("https://example.com/token")).willReturn(requestBodySpec);
+        given(requestBodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED)).willReturn(requestBodySpec);
+        given(requestBodySpec.body(any(MultiValueMap.class))).willReturn(requestBodySpec);
+        given(requestBodySpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.body(Map.class)).willReturn(Map.of(
+                "access_token", "google-token",
+                "token_type", "Bearer"
+        ));
+
+        // when
+        OAuthTokenResponse response = tokenExchanger.exchange("code", "redirect", config, OAuthProvider.GOOGLE);
+
+        // then
+        assertThat(response.getAccessToken()).isEqualTo("google-token");
+
+        ArgumentCaptor<MultiValueMap<String, String>> bodyCaptor = ArgumentCaptor.forClass(MultiValueMap.class);
+        verify(requestBodySpec).body(bodyCaptor.capture());
+        MultiValueMap<String, String> body = bodyCaptor.getValue();
+
+        assertThat(body.getFirst("client_id")).isEqualTo("test-client-id");
+        assertThat(body.getFirst("client_secret")).isEqualTo("test-client-secret");
+        assertThat(body.getFirst("code")).isEqualTo("code");
+        assertThat(body.getFirst("grant_type")).isEqualTo("authorization_code");
+
+        verify(requestBodySpec, never()).header(eq("Authorization"), any());
+    }
+
+    @Test
+    @DisplayName("Riot 토큰 교환 시 Basic Auth 헤더 사용, form body에 credentials 미포함")
+    void riotExchange_usesBasicAuthHeader() {
+        // given
+        String expectedCredentials = Base64.getEncoder()
+                .encodeToString("test-client-id:test-client-secret".getBytes(StandardCharsets.UTF_8));
+
+        given(oauthRestClient.post()).willReturn(requestBodyUriSpec);
+        given(requestBodyUriSpec.uri("https://example.com/token")).willReturn(requestBodySpec);
+        given(requestBodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED)).willReturn(requestBodySpec);
+        given(requestBodySpec.header("Authorization", "Basic " + expectedCredentials)).willReturn(requestBodySpec);
+        given(requestBodySpec.body(any(MultiValueMap.class))).willReturn(requestBodySpec);
+        given(requestBodySpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.body(Map.class)).willReturn(Map.of(
+                "access_token", "riot-token",
+                "id_token", "riot-id-token",
+                "token_type", "Bearer"
+        ));
+
+        // when
+        OAuthTokenResponse response = tokenExchanger.exchange("code", "redirect", config, OAuthProvider.RIOT);
+
+        // then
+        assertThat(response.getAccessToken()).isEqualTo("riot-token");
+        assertThat(response.getIdToken()).isEqualTo("riot-id-token");
+
+        verify(requestBodySpec).header("Authorization", "Basic " + expectedCredentials);
+
+        ArgumentCaptor<MultiValueMap<String, String>> bodyCaptor = ArgumentCaptor.forClass(MultiValueMap.class);
+        verify(requestBodySpec).body(bodyCaptor.capture());
+        MultiValueMap<String, String> body = bodyCaptor.getValue();
+
+        assertThat(body.containsKey("client_id")).isFalse();
+        assertThat(body.containsKey("client_secret")).isFalse();
+    }
+
+    @Test
+    @DisplayName("토큰 응답에 access_token이 없으면 예외 발생")
+    void exchange_throwsWhenNoAccessToken() {
+        // given
+        given(oauthRestClient.post()).willReturn(requestBodyUriSpec);
+        given(requestBodyUriSpec.uri("https://example.com/token")).willReturn(requestBodySpec);
+        given(requestBodySpec.contentType(MediaType.APPLICATION_FORM_URLENCODED)).willReturn(requestBodySpec);
+        given(requestBodySpec.body(any(MultiValueMap.class))).willReturn(requestBodySpec);
+        given(requestBodySpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.body(Map.class)).willReturn(Map.of("error", "invalid_grant"));
+
+        // when & then
+        assertThatThrownBy(() -> tokenExchanger.exchange("code", "redirect", config, OAuthProvider.GOOGLE))
+                .isInstanceOf(CoreException.class);
+    }
+}

--- a/module/infra/client/oauth/src/test/java/com/example/lolserver/adapter/oauth/RiotRsoClientTest.java
+++ b/module/infra/client/oauth/src/test/java/com/example/lolserver/adapter/oauth/RiotRsoClientTest.java
@@ -1,0 +1,127 @@
+package com.example.lolserver.adapter.oauth;
+
+import com.example.lolserver.adapter.oauth.config.OAuthProperties;
+import com.example.lolserver.adapter.oauth.dto.OAuthTokenResponse;
+import com.example.lolserver.domain.member.application.model.OAuthUserInfo;
+import com.example.lolserver.domain.member.domain.vo.OAuthProvider;
+import com.example.lolserver.support.error.CoreException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class RiotRsoClientTest {
+
+    @Mock
+    private RestClient oauthRestClient;
+
+    @Mock
+    private OAuthProperties oAuthProperties;
+
+    @Mock
+    private OAuthTokenExchanger tokenExchanger;
+
+    @Mock
+    private RestClient.RequestHeadersUriSpec requestHeadersUriSpec;
+
+    @Mock
+    private RestClient.RequestHeadersSpec requestHeadersSpec;
+
+    @Mock
+    private RestClient.ResponseSpec responseSpec;
+
+    @InjectMocks
+    private RiotRsoClient riotRsoClient;
+
+    private OAuthProperties.ProviderConfig config;
+
+    @BeforeEach
+    void setUp() {
+        config = new OAuthProperties.ProviderConfig();
+        config.setClientId("riot-client-id");
+        config.setClientSecret("riot-client-secret");
+        config.setTokenUri("https://auth.riotgames.com/token");
+        config.setUserInfoUri("https://auth.riotgames.com/userinfo");
+        config.setAccountUri("https://americas.api.riotgames.com/riot/account/v1/accounts/me");
+    }
+
+    @Test
+    @DisplayName("RSO userinfo와 Account API를 순차 호출하여 OAuthUserInfo 생성")
+    void getUserInfo_callsUserInfoAndAccountApi() {
+        // given
+        given(oAuthProperties.getRiot()).willReturn(config);
+        given(tokenExchanger.exchange("code", "redirect", config, OAuthProvider.RIOT))
+                .willReturn(OAuthTokenResponse.builder()
+                        .accessToken("riot-access-token")
+                        .idToken("riot-id-token")
+                        .build());
+
+        // userinfo 호출
+        given(oauthRestClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri("https://auth.riotgames.com/userinfo")).willReturn(requestHeadersSpec);
+        given(requestHeadersSpec.header("Authorization", "Bearer riot-access-token")).willReturn(requestHeadersSpec);
+        given(requestHeadersSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.body(Map.class)).willReturn(Map.of("sub", "rso-sub-12345"));
+
+        // account API 호출 - 두 번째 get() 호출을 위한 새로운 mock chain
+        RestClient.RequestHeadersUriSpec accountUriSpec = org.mockito.Mockito.mock(RestClient.RequestHeadersUriSpec.class);
+        RestClient.RequestHeadersSpec accountHeadersSpec = org.mockito.Mockito.mock(RestClient.RequestHeadersSpec.class);
+        RestClient.ResponseSpec accountResponseSpec = org.mockito.Mockito.mock(RestClient.ResponseSpec.class);
+
+        given(oauthRestClient.get())
+                .willReturn(requestHeadersUriSpec)    // 첫 번째: userinfo
+                .willReturn(accountUriSpec);           // 두 번째: account
+        given(accountUriSpec.uri("https://americas.api.riotgames.com/riot/account/v1/accounts/me"))
+                .willReturn(accountHeadersSpec);
+        given(accountHeadersSpec.header("Authorization", "Bearer riot-access-token"))
+                .willReturn(accountHeadersSpec);
+        given(accountHeadersSpec.retrieve()).willReturn(accountResponseSpec);
+        given(accountResponseSpec.body(Map.class)).willReturn(Map.of(
+                "puuid", "test-puuid-123",
+                "gameName", "TestPlayer",
+                "tagLine", "KR1"
+        ));
+
+        // when
+        OAuthUserInfo userInfo = riotRsoClient.getUserInfo("code", "redirect");
+
+        // then
+        assertThat(userInfo.getProvider()).isEqualTo("RIOT");
+        assertThat(userInfo.getProviderId()).isEqualTo("rso-sub-12345");
+        assertThat(userInfo.getPuuid()).isEqualTo("test-puuid-123");
+        assertThat(userInfo.getGameName()).isEqualTo("TestPlayer");
+        assertThat(userInfo.getTagLine()).isEqualTo("KR1");
+    }
+
+    @Test
+    @DisplayName("userinfo에서 sub가 null이면 예외 발생")
+    void getUserInfo_throwsWhenSubIsNull() {
+        // given
+        given(oAuthProperties.getRiot()).willReturn(config);
+        given(tokenExchanger.exchange("code", "redirect", config, OAuthProvider.RIOT))
+                .willReturn(OAuthTokenResponse.builder()
+                        .accessToken("riot-access-token")
+                        .build());
+
+        given(oauthRestClient.get()).willReturn(requestHeadersUriSpec);
+        given(requestHeadersUriSpec.uri("https://auth.riotgames.com/userinfo")).willReturn(requestHeadersSpec);
+        given(requestHeadersSpec.header("Authorization", "Bearer riot-access-token")).willReturn(requestHeadersSpec);
+        given(requestHeadersSpec.retrieve()).willReturn(responseSpec);
+        given(responseSpec.body(Map.class)).willReturn(Map.of("cpid", "some-cpid"));
+
+        // when & then
+        assertThatThrownBy(() -> riotRsoClient.getUserInfo("code", "redirect"))
+                .isInstanceOf(CoreException.class);
+    }
+}

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
@@ -1,0 +1,91 @@
+package com.example.lolserver.repository.championstats;
+
+import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String DETAIL_KEY_PREFIX = "champion-stats:detail:";
+    private static final String POSITIONS_KEY_PREFIX = "champion-stats:positions:";
+    private static final Duration CACHE_TTL = Duration.ofHours(6);
+
+    @Override
+    public ChampionStatsReadModel findChampionStats(
+            int championId, String patch, String platformId, String tierDisplay) {
+        try {
+            String key = buildDetailKey(championId, patch, platformId, tierDisplay);
+            log.debug("캐시 조회 - key: {}", key);
+            return (ChampionStatsReadModel) redisTemplate.opsForValue().get(key);
+        } catch (Exception e) {
+            log.warn("캐시 조회 실패 - championId: {}, patch: {}, tier: {}", championId, patch, tierDisplay, e);
+            return null;
+        }
+    }
+
+    @Override
+    public void saveChampionStats(
+            int championId, String patch, String platformId,
+            String tierDisplay, ChampionStatsReadModel stats) {
+        if (stats == null) {
+            return;
+        }
+        try {
+            String key = buildDetailKey(championId, patch, platformId, tierDisplay);
+            log.debug("캐시 저장 - key: {}", key);
+            redisTemplate.opsForValue().set(key, stats, CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("캐시 저장 실패 - championId: {}, patch: {}, tier: {}", championId, patch, tierDisplay, e);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<PositionChampionStatsReadModel> findChampionStatsByPosition(
+            String patch, String platformId, String tierDisplay) {
+        try {
+            String key = buildPositionsKey(patch, platformId, tierDisplay);
+            log.debug("캐시 조회 - key: {}", key);
+            return (List<PositionChampionStatsReadModel>) redisTemplate.opsForValue().get(key);
+        } catch (Exception e) {
+            log.warn("캐시 조회 실패 - positions, patch: {}, tier: {}", patch, tierDisplay, e);
+            return null;
+        }
+    }
+
+    @Override
+    public void saveChampionStatsByPosition(
+            String patch, String platformId, String tierDisplay,
+            List<PositionChampionStatsReadModel> stats) {
+        if (stats == null) {
+            return;
+        }
+        try {
+            String key = buildPositionsKey(patch, platformId, tierDisplay);
+            log.debug("캐시 저장 - key: {}", key);
+            redisTemplate.opsForValue().set(key, stats, CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("캐시 저장 실패 - positions, patch: {}, tier: {}", patch, tierDisplay, e);
+        }
+    }
+
+    private String buildDetailKey(int championId, String patch, String platformId, String tierDisplay) {
+        return DETAIL_KEY_PREFIX + platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
+    }
+
+    private String buildPositionsKey(String patch, String platformId, String tierDisplay) {
+        return POSITIONS_KEY_PREFIX + platformId + ":" + patch + ":" + tierDisplay;
+    }
+}

--- a/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
+++ b/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
@@ -1,0 +1,237 @@
+package com.example.lolserver.repository.championstats;
+
+import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class ChampionStatsCacheAdapterTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private ChampionStatsCacheAdapter adapter;
+
+    private static final Duration CACHE_TTL = Duration.ofHours(6);
+
+    @BeforeEach
+    void setUp() {
+        adapter = new ChampionStatsCacheAdapter(redisTemplate);
+    }
+
+    @DisplayName("챔피언 상세 통계 캐시 히트 시 데이터를 반환한다")
+    @Test
+    void findChampionStats_cacheHit_returnsData() {
+        // given
+        int championId = 13;
+        String patch = "16.1";
+        String platformId = "KR";
+        String tierDisplay = "EMERALD";
+        String expectedKey = "champion-stats:detail:KR:13:16.1:EMERALD";
+
+        ChampionStatsReadModel cached = new ChampionStatsReadModel("EMERALD", List.of());
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn(cached);
+
+        // when
+        ChampionStatsReadModel result = adapter.findChampionStats(championId, patch, platformId, tierDisplay);
+
+        // then
+        assertThat(result).isEqualTo(cached);
+        then(valueOperations).should().get(expectedKey);
+    }
+
+    @DisplayName("챔피언 상세 통계 캐시 미스 시 null을 반환한다")
+    @Test
+    void findChampionStats_cacheMiss_returnsNull() {
+        // given
+        int championId = 13;
+        String patch = "16.1";
+        String platformId = "KR";
+        String tierDisplay = "EMERALD";
+        String expectedKey = "champion-stats:detail:KR:13:16.1:EMERALD";
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn(null);
+
+        // when
+        ChampionStatsReadModel result = adapter.findChampionStats(championId, patch, platformId, tierDisplay);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @DisplayName("챔피언 상세 통계를 캐시에 저장한다")
+    @Test
+    void saveChampionStats_validData_savesToCache() {
+        // given
+        int championId = 13;
+        String patch = "16.1";
+        String platformId = "KR";
+        String tierDisplay = "EMERALD";
+        String expectedKey = "champion-stats:detail:KR:13:16.1:EMERALD";
+
+        ChampionStatsReadModel stats = new ChampionStatsReadModel("EMERALD", List.of());
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        adapter.saveChampionStats(championId, patch, platformId, tierDisplay, stats);
+
+        // then
+        then(valueOperations).should().set(eq(expectedKey), eq(stats), eq(CACHE_TTL));
+    }
+
+    @DisplayName("null 통계는 캐시에 저장하지 않는다")
+    @Test
+    void saveChampionStats_nullData_doesNotSave() {
+        // when
+        adapter.saveChampionStats(13, "16.1", "KR", "EMERALD", null);
+
+        // then
+        then(redisTemplate).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("포지션별 통계 캐시 히트 시 데이터를 반환한다")
+    @Test
+    void findChampionStatsByPosition_cacheHit_returnsData() {
+        // given
+        String patch = "16.1";
+        String platformId = "KR";
+        String tierDisplay = "EMERALD";
+        String expectedKey = "champion-stats:positions:KR:16.1:EMERALD";
+
+        List<PositionChampionStatsReadModel> cached = List.of(
+            new PositionChampionStatsReadModel("TOP", List.of())
+        );
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn(cached);
+
+        // when
+        List<PositionChampionStatsReadModel> result = adapter.findChampionStatsByPosition(patch, platformId, tierDisplay);
+
+        // then
+        assertThat(result).isEqualTo(cached);
+    }
+
+    @DisplayName("포지션별 통계 캐시 미스 시 null을 반환한다")
+    @Test
+    void findChampionStatsByPosition_cacheMiss_returnsNull() {
+        // given
+        String patch = "16.1";
+        String platformId = "KR";
+        String tierDisplay = "EMERALD";
+        String expectedKey = "champion-stats:positions:KR:16.1:EMERALD";
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn(null);
+
+        // when
+        List<PositionChampionStatsReadModel> result = adapter.findChampionStatsByPosition(patch, platformId, tierDisplay);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @DisplayName("포지션별 통계를 캐시에 저장한다")
+    @Test
+    void saveChampionStatsByPosition_validData_savesToCache() {
+        // given
+        String patch = "16.1";
+        String platformId = "KR";
+        String tierDisplay = "EMERALD";
+        String expectedKey = "champion-stats:positions:KR:16.1:EMERALD";
+
+        List<PositionChampionStatsReadModel> stats = List.of(
+            new PositionChampionStatsReadModel("TOP", List.of())
+        );
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        adapter.saveChampionStatsByPosition(patch, platformId, tierDisplay, stats);
+
+        // then
+        then(valueOperations).should().set(eq(expectedKey), eq(stats), eq(CACHE_TTL));
+    }
+
+    @DisplayName("null 포지션별 통계는 캐시에 저장하지 않는다")
+    @Test
+    void saveChampionStatsByPosition_nullData_doesNotSave() {
+        // when
+        adapter.saveChampionStatsByPosition("16.1", "KR", "EMERALD", null);
+
+        // then
+        then(redisTemplate).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("Redis 장애 시 캐시 조회는 null을 반환한다")
+    @Test
+    void findChampionStats_redisFailure_returnsNull() {
+        // given
+        given(redisTemplate.opsForValue()).willThrow(new RuntimeException("Redis connection failed"));
+
+        // when
+        ChampionStatsReadModel result = adapter.findChampionStats(13, "16.1", "KR", "EMERALD");
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @DisplayName("Redis 장애 시 캐시 저장은 예외를 전파하지 않는다")
+    @Test
+    void saveChampionStats_redisFailure_doesNotThrow() {
+        // given
+        ChampionStatsReadModel stats = new ChampionStatsReadModel("EMERALD", List.of());
+        given(redisTemplate.opsForValue()).willThrow(new RuntimeException("Redis connection failed"));
+
+        // when & then
+        adapter.saveChampionStats(13, "16.1", "KR", "EMERALD", stats);
+    }
+
+    @DisplayName("Redis 장애 시 포지션별 캐시 조회는 null을 반환한다")
+    @Test
+    void findChampionStatsByPosition_redisFailure_returnsNull() {
+        // given
+        given(redisTemplate.opsForValue()).willThrow(new RuntimeException("Redis connection failed"));
+
+        // when
+        List<PositionChampionStatsReadModel> result = adapter.findChampionStatsByPosition("16.1", "KR", "EMERALD");
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @DisplayName("Redis 장애 시 포지션별 캐시 저장은 예외를 전파하지 않는다")
+    @Test
+    void saveChampionStatsByPosition_redisFailure_doesNotThrow() {
+        // given
+        List<PositionChampionStatsReadModel> stats = List.of(
+            new PositionChampionStatsReadModel("TOP", List.of())
+        );
+        given(redisTemplate.opsForValue()).willThrow(new RuntimeException("Redis connection failed"));
+
+        // when & then
+        adapter.saveChampionStatsByPosition("16.1", "KR", "EMERALD", stats);
+    }
+}

--- a/performance-tests/.env.example
+++ b/performance-tests/.env.example
@@ -1,0 +1,22 @@
+# ===========================================
+# 부하테스트 환경 변수
+# ===========================================
+# 사용법: cp .env.example .env && vim .env
+
+# --- Riot API (필수) ---
+RIOT_API_KEY=your-riot-api-key-here
+
+# --- Champion Stats 캐시 토글 ---
+CHAMPION_STATS_CACHE_ENABLED=true
+
+# --- PostgreSQL (외부) ---
+# 호스트 머신의 PostgreSQL 사용 시 기본값 그대로 사용
+# DB_URL=jdbc:postgresql://host.docker.internal:5432/postgres
+# DB_USERNAME=postgres
+# DB_PASSWORD=1234
+
+# --- ClickHouse (외부) ---
+# CH_HOST=host.docker.internal
+# CH_PORT=8123
+# CH_USERNAME=default
+# CH_PASSWORD=clickhouse

--- a/performance-tests/docker-compose.yml
+++ b/performance-tests/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  lol-server:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    container_name: lol-server
+    ports:
+      - "8100:8100"
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+      RIOT_API_KEY: ${RIOT_API_KEY}
+      CHAMPION_STATS_CACHE_ENABLED: ${CHAMPION_STATS_CACHE_ENABLED:-true}
+      # PostgreSQL (외부) - dev 프로파일 하드코딩 오버라이드
+      SPRING_DATASOURCE_URL: ${DB_URL:-jdbc:postgresql://host.docker.internal:5432/postgres}
+      SPRING_DATASOURCE_USERNAME: ${DB_USERNAME:-postgres}
+      SPRING_DATASOURCE_PASSWORD: ${DB_PASSWORD:-1234}
+      # ClickHouse (외부) - dev 프로파일은 ${CH_HOST:localhost} 사용
+      CH_HOST: ${CH_HOST:-host.docker.internal}
+      CH_PORT: ${CH_PORT:-8123}
+      CH_USERNAME: ${CH_USERNAME:-default}
+      CH_PASSWORD: ${CH_PASSWORD:-clickhouse}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      lol-redis:
+        condition: service_healthy
+      lol-rabbitmq:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:8100/actuator/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
+  lol-redis:
+    image: redis:7-alpine
+    container_name: lol-redis
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  lol-rabbitmq:
+    image: rabbitmq:3-management-alpine
+    container_name: lol-rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5

--- a/performance-tests/k6/lib/config.js
+++ b/performance-tests/k6/lib/config.js
@@ -59,6 +59,14 @@ export const ENDPOINTS = {
         getByPuuid: (puuid) => `/api/v1/leagues/by-puuid/${puuid}`,
     },
 
+    // Champion Stats API
+    championStats: {
+        getDetail: (platformId, championId, patch, tier) =>
+            `/api/v1/${platformId}/champion-stats?championId=${championId}&patch=${encodeURIComponent(patch)}&tier=${encodeURIComponent(tier)}`,
+        getPositions: (platformId, patch, tier) =>
+            `/api/v1/${platformId}/champion-stats/positions?patch=${encodeURIComponent(patch)}&tier=${encodeURIComponent(tier)}`,
+    },
+
     // Rank API
     rank: {
         champions: (puuid, queueId = 420) => `/api/v1/rank/champions?puuid=${puuid}&queueId=${queueId}`,

--- a/performance-tests/k6/lib/helpers.js
+++ b/performance-tests/k6/lib/helpers.js
@@ -16,7 +16,13 @@ export const customMetrics = {
     championRotationResponseTime: new Trend('champion_rotation_response_time', true),
     rankChampionsResponseTime: new Trend('rank_champions_response_time', true),
 
+    // Champion Stats API 응답 시간
+    championStatsDetailResponseTime: new Trend('champion_stats_detail_response_time', true),
+    championStatsPositionsResponseTime: new Trend('champion_stats_positions_response_time', true),
+
     // API별 성공률
+    championStatsDetailSuccessRate: new Rate('champion_stats_detail_success_rate'),
+    championStatsPositionsSuccessRate: new Rate('champion_stats_positions_success_rate'),
     summonerSuccessRate: new Rate('summoner_success_rate'),
     autocompleteSuccessRate: new Rate('autocomplete_success_rate'),
     matchSuccessRate: new Rate('match_success_rate'),
@@ -56,10 +62,10 @@ export function validateResponse(response, apiName, expectedStatus = 200) {
 export function validateApiSuccess(response, apiName) {
     try {
         const body = JSON.parse(response.body);
-        const isSuccess = body.success === true;
+        const isSuccess = body.result === 'SUCCESS';
 
         if (!isSuccess) {
-            console.error(`[${apiName}] API returned success=false: ${JSON.stringify(body)}`);
+            console.error(`[${apiName}] API returned result=${body.result}: ${JSON.stringify(body)}`);
         }
 
         return check(response, {

--- a/performance-tests/k6/scenarios/champion-stats-test.js
+++ b/performance-tests/k6/scenarios/champion-stats-test.js
@@ -1,0 +1,252 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.1/index.js';
+
+import { BASE_URL, DEFAULT_PLATFORM_ID, ENDPOINTS, HEADERS } from '../lib/config.js';
+import { customMetrics, randomItem, randomInt } from '../lib/helpers.js';
+
+/**
+ * Champion Stats 캐시 on/off 성능 비교 테스트
+ *
+ * 대상 API:
+ *   - GET /api/v1/{platformId}/champion-stats?championId=&patch=&tier=
+ *   - GET /api/v1/{platformId}/champion-stats/positions?patch=&tier=
+ *
+ * 목적: Redis 캐시 도입 전후 응답시간/처리량 비교
+ *
+ * 실행:
+ *   # 캐시 OFF
+ *   k6 run -e PHASE=cache-off scenarios/champion-stats-test.js
+ *
+ *   # 캐시 ON
+ *   k6 run -e PHASE=cache-on scenarios/champion-stats-test.js
+ *
+ *   # 결과: results/champion-stats-{phase}-{timestamp}.json / .txt
+ */
+
+// 인기 챔피언 ID 목록
+const CHAMPION_IDS = [
+    157, 238, 64, 412, 222,   // Yasuo, Zed, Lee Sin, Thresh, Jinx
+    103, 202, 236, 53, 555,   // Ahri, Jhin, Lucian, Blitzcrank, Pyke
+    39, 91, 145, 498, 497,    // Irelia, Talon, Kai'Sa, Xayah, Rakan
+    13, 1, 266, 86, 122,      // Ryze, Annie, Aatrox, Garen, Darius
+];
+
+const TIERS = ['EMERALD', 'DIAMOND', 'MASTER', 'GRANDMASTER', 'CHALLENGER'];
+
+const platformId = __ENV.PLATFORM_ID || DEFAULT_PLATFORM_ID;
+const patch = __ENV.PATCH || '16.5';
+const tier = __ENV.TIER || 'GRANDMASTER';
+const phase = __ENV.PHASE || 'unknown';
+
+export const options = {
+    scenarios: {
+        champion_stats_load: {
+            executor: 'constant-arrival-rate',
+            rate: Number(__ENV.RATE || 50),
+            timeUnit: '1s',
+            duration: __ENV.DURATION || '1m',
+            preAllocatedVUs: Number(__ENV.PRE_ALLOCATED_VUS || 50),
+            maxVUs: Number(__ENV.MAX_VUS || 100),
+        },
+    },
+    thresholds: {
+        http_req_failed: ['rate<0.01'],
+        champion_stats_detail_response_time: ['p(95)<500', 'avg<300'],
+        champion_stats_detail_success_rate: ['rate>0.995'],
+        champion_stats_positions_response_time: ['p(95)<500', 'avg<300'],
+        champion_stats_positions_success_rate: ['rate>0.995'],
+    },
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(95)', 'p(99)'],
+    tags: {
+        testType: 'load',
+        scenario: 'champion-stats-test',
+        phase: phase,
+    },
+};
+
+const requestOptions = {
+    headers: HEADERS,
+    timeout: '30s',
+};
+
+export default function () {
+
+    callDetailApi();
+    // 70% detail API, 30% positions API
+    // if (Math.random() < 0.7) {
+    //     callDetailApi();
+    // } else {
+    //     callPositionsApi();
+    // }
+}
+
+function callDetailApi() {
+    const championId = randomItem(CHAMPION_IDS);
+    const selectedTier = randomItem(TIERS);
+    const endpoint = ENDPOINTS.championStats.getDetail(platformId, championId, patch, selectedTier);
+    const url = `${BASE_URL}${endpoint}`;
+
+    const response = http.get(url, requestOptions);
+
+    customMetrics.championStatsDetailResponseTime.add(response.timings.duration);
+
+    const basicChecks = check(response, {
+        'detail: status is 200': (r) => r.status === 200,
+        'detail: response time < 5s': (r) => r.timings.duration < 5000,
+        'detail: response body exists': (r) => r.body && r.body.length > 0,
+    });
+
+    let apiSuccess = false;
+
+    if (response.status === 200) {
+        try {
+            const body = JSON.parse(response.body);
+            apiSuccess = body.result === 'SUCCESS';
+
+            check(response, {
+                'detail: API success': () => apiSuccess,
+            });
+        } catch (error) {
+            console.error(`[detail] Failed to parse response for championId=${championId}: ${error.message}`);
+        }
+    } else {
+        console.error(
+            `[detail] Request failed status=${response.status} duration=${response.timings.duration}ms championId=${championId} url=${url}`
+        );
+    }
+
+    const success = basicChecks && apiSuccess;
+    customMetrics.championStatsDetailSuccessRate.add(success);
+
+    if (!success) {
+        customMetrics.errorCount.add(1);
+    }
+}
+
+function callPositionsApi() {
+    const selectedTier = randomItem(TIERS);
+    const endpoint = ENDPOINTS.championStats.getPositions(platformId, patch, selectedTier);
+    const url = `${BASE_URL}${endpoint}`;
+
+    const response = http.get(url, requestOptions);
+
+    customMetrics.championStatsPositionsResponseTime.add(response.timings.duration);
+
+    const basicChecks = check(response, {
+        'positions: status is 200': (r) => r.status === 200,
+        'positions: response time < 5s': (r) => r.timings.duration < 5000,
+        'positions: response body exists': (r) => r.body && r.body.length > 0,
+    });
+
+    let apiSuccess = false;
+
+    if (response.status === 200) {
+        try {
+            const body = JSON.parse(response.body);
+            apiSuccess = body.result === 'SUCCESS';
+
+            check(response, {
+                'positions: API success': () => apiSuccess,
+            });
+        } catch (error) {
+            console.error(`[positions] Failed to parse response: ${error.message}`);
+        }
+    } else {
+        console.error(
+            `[positions] Request failed status=${response.status} duration=${response.timings.duration}ms url=${url}`
+        );
+    }
+
+    const success = basicChecks && apiSuccess;
+    customMetrics.championStatsPositionsSuccessRate.add(success);
+
+    if (!success) {
+        customMetrics.errorCount.add(1);
+    }
+}
+
+// --- handleSummary: 테스트 종료 시 결과 자동 저장 ---
+
+function round(val) {
+    return Math.round((val || 0) * 100) / 100;
+}
+
+function extractTrendMetrics(metric) {
+    if (!metric) return null;
+    const v = metric.values;
+    return {
+        avg_ms: round(v?.avg),
+        med_ms: round(v?.med),
+        p95_ms: round(v?.['p(95)']),
+        p99_ms: round(v?.['p(99)']),
+        max_ms: round(v?.max),
+        min_ms: round(v?.min),
+    };
+}
+
+function extractRateMetrics(metric) {
+    if (!metric) return null;
+    const v = metric.values;
+    return {
+        success_rate: round(v?.rate),
+        passes: v?.passes || 0,
+        fails: v?.fails || 0,
+    };
+}
+
+function formatApiSection(name, trend, rate) {
+    if (!trend) return `[${name}]\n  데이터 없음\n`;
+    const successPct = ((rate?.success_rate || 0) * 100).toFixed(2);
+    return `[${name}]\n` +
+        `  avg: ${trend.avg_ms}ms  |  p95: ${trend.p95_ms}ms  |  p99: ${trend.p99_ms}ms\n` +
+        `  Success Rate: ${successPct}% (${rate?.passes || 0} passed / ${rate?.fails || 0} failed)\n`;
+}
+
+export function handleSummary(data) {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    const baseName = `champion-stats-${phase}-${timestamp}`;
+
+    const detailTrend = extractTrendMetrics(data.metrics?.champion_stats_detail_response_time);
+    const detailRate = extractRateMetrics(data.metrics?.champion_stats_detail_success_rate);
+    const positionsTrend = extractTrendMetrics(data.metrics?.champion_stats_positions_response_time);
+    const positionsRate = extractRateMetrics(data.metrics?.champion_stats_positions_success_rate);
+
+    const httpReqs = data.metrics?.http_reqs?.values?.count || 0;
+    const httpRps = round(data.metrics?.http_reqs?.values?.rate);
+    const customErrors = data.metrics?.custom_errors?.values?.count || 0;
+
+    const jsonResult = {
+        meta: {
+            phase: phase,
+            timestamp: new Date().toISOString(),
+            platform: platformId,
+            patch: patch,
+            tier: tier,
+            rate: Number(__ENV.RATE || 50),
+            duration: __ENV.DURATION || '1m',
+        },
+        detail_api: detailTrend ? { ...detailTrend, ...detailRate } : null,
+        positions_api: positionsTrend ? { ...positionsTrend, ...positionsRate } : null,
+        totals: {
+            http_requests: httpReqs,
+            http_rps: httpRps,
+            custom_errors: customErrors,
+        },
+    };
+
+    const separator = '========================================';
+    const customText = `\n${separator}\n` +
+        `  Champion Stats 성능 테스트 결과\n` +
+        `  Phase: ${phase}\n` +
+        `${separator}\n\n` +
+        formatApiSection('Detail API', detailTrend, detailRate) + '\n' +
+        formatApiSection('Positions API', positionsTrend, positionsRate) +
+        `${separator}\n`;
+
+    return {
+        [`../results/${baseName}.json`]: JSON.stringify(jsonResult, null, 2),
+        [`../results/${baseName}.txt`]: customText,
+        stdout: textSummary(data, { indent: '  ', enableColors: true }) + customText,
+    };
+}

--- a/performance-tests/k6/thresholds.js
+++ b/performance-tests/k6/thresholds.js
@@ -57,6 +57,20 @@ export const thresholds = {
     ],
     rank_champions_success_rate: ['rate>0.995'],
 
+    // Champion Stats Detail API - ClickHouse 쿼리 다수
+    champion_stats_detail_response_time: [
+        'p(95)<500',    // p95 500ms 미만
+        'avg<300',      // 평균 300ms 미만
+    ],
+    champion_stats_detail_success_rate: ['rate>0.995'],
+
+    // Champion Stats Positions API - ClickHouse 집계 쿼리
+    champion_stats_positions_response_time: [
+        'p(95)<500',    // p95 500ms 미만
+        'avg<300',      // 평균 300ms 미만
+    ],
+    champion_stats_positions_success_rate: ['rate>0.995'],
+
     // 커스텀 에러 카운터
     custom_errors: ['count<10'],  // 커스텀 에러 10회 미만
 };

--- a/performance-tests/results/champion-stats-cache-report.md
+++ b/performance-tests/results/champion-stats-cache-report.md
@@ -1,0 +1,106 @@
+# Champion Stats 캐시 성능 비교 보고서
+
+## 테스트 환경
+
+| 항목 | 값 |
+|------|-----|
+| Date | YYYY-MM-DD |
+| Server | Spring Boot 3.3.6 / Java 17 |
+| ClickHouse | (버전 기입) |
+| Redis | (버전 기입) |
+| k6 Rate | 50 req/s |
+| Duration | 60s |
+| VUs | 50 (pre-allocated), 100 (max) |
+| Patch | 16.1 |
+| Tiers | EMERALD, DIAMOND, MASTER, GRANDMASTER, CHALLENGER |
+
+## Cache OFF (champion-stats.cache.enabled=false)
+
+### Detail API 메트릭
+
+| Metric | Value |
+|--------|-------|
+| avg | {ms} |
+| p50 | {ms} |
+| p95 | {ms} |
+| p99 | {ms} |
+| max | {ms} |
+| Error Rate | {%} |
+| Throughput | {req/s} |
+
+### Positions API 메트릭
+
+| Metric | Value |
+|--------|-------|
+| avg | {ms} |
+| p50 | {ms} |
+| p95 | {ms} |
+| p99 | {ms} |
+| max | {ms} |
+| Error Rate | {%} |
+| Throughput | {req/s} |
+
+### ClickHouse 커넥션
+
+| Metric | Value |
+|--------|-------|
+| Active Connections (peak) | {n} |
+| Timeout Count | {n} |
+
+## Cache ON (champion-stats.cache.enabled=true)
+
+### Detail API 메트릭
+
+| Metric | Value |
+|--------|-------|
+| avg | {ms} |
+| p50 | {ms} |
+| p95 | {ms} |
+| p99 | {ms} |
+| max | {ms} |
+| Error Rate | {%} |
+| Throughput | {req/s} |
+
+### Positions API 메트릭
+
+| Metric | Value |
+|--------|-------|
+| avg | {ms} |
+| p50 | {ms} |
+| p95 | {ms} |
+| p99 | {ms} |
+| max | {ms} |
+| Error Rate | {%} |
+| Throughput | {req/s} |
+
+### Redis 관찰
+
+| Metric | Value |
+|--------|-------|
+| Cache Hit Rate | {%} |
+| Redis Memory Usage | {MB} |
+
+## 비교 요약
+
+| Metric | Cache OFF | Cache ON | 개선율 |
+|--------|-----------|----------|--------|
+| Detail API p95 | {ms} | {ms} | {x}x |
+| Detail API avg | {ms} | {ms} | {x}x |
+| Positions API p95 | {ms} | {ms} | {x}x |
+| Positions API avg | {ms} | {ms} | {x}x |
+| CH Active Conn (peak) | {n} | {n} | -{n}% |
+| Error Rate | {%} | {%} | ... |
+
+## 결론
+
+(테스트 결과를 바탕으로 캐시 도입 효과 분석)
+
+## 실행 방법
+
+```bash
+# 캐시 OFF 테스트 (서버: champion-stats.cache.enabled=false)
+k6 run --tag phase=cache-off --out json=results/champion-stats-cache-off.json scenarios/champion-stats-test.js
+
+# 캐시 ON 테스트 (서버: champion-stats.cache.enabled=true)
+k6 run --tag phase=cache-on --out json=results/champion-stats-cache-on.json scenarios/champion-stats-test.js
+```


### PR DESCRIPTION
## Summary

- **OAuth 클라이언트 리팩토링**: GoogleOAuthClient, OAuthAuthorizationAdapter, OAuthTokenExchanger, RiotRsoClient 개선 및 DTO 분리 (`OAuthTokenResponse`), 단위 테스트 추가
- **ChampionStats Redis 캐싱 도입**: `ChampionStatsCachePort` 포트 신규, `ChampionStatsCacheAdapter` Redis 어댑터 구현, `ChampionStatsService` 캐시 적용, 테스트 추가
- **k6 성능 테스트 시나리오 추가**: champion-stats 테스트 시나리오, docker-compose, config/helpers/thresholds 설정
- **Git 워크플로우 설정**: PR 템플릿, CONTRIBUTING.md, CLAUDE.md 브랜치 전략 문서화
- **기타**: .env.example, .gitignore, core yml 설정 업데이트, OAuth 리팩토링 리뷰 문서

## Test plan

- [ ] OAuth 어댑터 단위 테스트 확인 (`OAuthAuthorizationAdapterTest`, `OAuthTokenExchangerTest`, `RiotRsoClientTest`)
- [ ] ChampionStats 캐싱 테스트 확인 (`ChampionStatsServiceTest`, `ChampionStatsCacheAdapterTest`)
- [ ] `./gradlew build` 전체 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)