### PR TITLE
refactor: 커뮤니티 도메인 캡슐화 강화 및 빌드 안정성 개선

### DIFF
--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/application/CommentService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/application/CommentService.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -55,14 +54,8 @@ public class CommentService implements CommentUseCase, CommentQueryUseCase {
             }
         }
 
-        Comment comment = new Comment();
-        comment.setPostId(postId);
-        comment.setMemberId(memberId);
-        comment.setParentCommentId(command.getParentCommentId());
-        comment.setContent(command.getContent());
-        comment.setDepth(depth);
-        comment.setCreatedAt(LocalDateTime.now());
-        comment.setUpdatedAt(LocalDateTime.now());
+        Comment comment = Comment.create(postId, memberId, command.getContent(),
+                command.getParentCommentId(), depth);
 
         Comment saved = commentPersistencePort.save(comment);
 

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/application/PostService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/application/PostService.java
@@ -24,8 +24,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -43,14 +41,8 @@ public class PostService implements PostUseCase, PostQueryUseCase {
         Member member = memberPersistencePort.findById(memberId)
                 .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));
 
-        Post post = new Post();
-        post.setMemberId(memberId);
-        post.setTitle(command.getTitle());
-        post.setContent(command.getContent());
-        post.setCategory(command.getCategory());
-        post.setCreatedAt(LocalDateTime.now());
-        post.setUpdatedAt(LocalDateTime.now());
-        post.calculateHotScore();
+        Post post = Post.create(memberId, command.getTitle(),
+                command.getContent(), command.getCategory());
 
         Post saved = postPersistencePort.save(post);
 
@@ -103,7 +95,7 @@ public class PostService implements PostUseCase, PostQueryUseCase {
         }
 
         postPersistencePort.incrementViewCount(postId);
-        post.setViewCount(post.getViewCount() + 1);
+        post.incrementViewCount();
 
         Member member = memberPersistencePort.findById(post.getMemberId())
                 .orElseThrow(() -> new CoreException(ErrorType.MEMBER_NOT_FOUND));

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/application/VoteService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/application/VoteService.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Slf4j
@@ -46,15 +45,11 @@ public class VoteService implements VoteUseCase {
                         command.getTargetId(),
                         command.getVoteType());
             }
-            vote.setVoteType(command.getVoteType());
+            vote.changeVoteType(command.getVoteType());
             votePersistencePort.save(vote);
         } else {
-            Vote vote = new Vote();
-            vote.setMemberId(memberId);
-            vote.setTargetType(command.getTargetType());
-            vote.setTargetId(command.getTargetId());
-            vote.setVoteType(command.getVoteType());
-            vote.setCreatedAt(LocalDateTime.now());
+            Vote vote = Vote.create(memberId, command.getTargetType(),
+                    command.getTargetId(), command.getVoteType());
             votePersistencePort.save(vote);
         }
 
@@ -133,10 +128,8 @@ public class VoteService implements VoteUseCase {
     private void updateHotScore(
             Long postId, int upvoteCount, int downvoteCount) {
         postPersistencePort.findById(postId).ifPresent(post -> {
-            post.setUpvoteCount(upvoteCount);
-            post.setDownvoteCount(downvoteCount);
-            double hotScore = post.calculateHotScore();
-            postPersistencePort.updateHotScore(postId, hotScore);
+            post.applyVoteCounts(upvoteCount, downvoteCount);
+            postPersistencePort.updateHotScore(postId, post.getHotScore());
         });
     }
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/domain/Comment.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/domain/Comment.java
@@ -1,16 +1,15 @@
 package com.example.lolserver.domain.community.domain;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Comment {
 
     private Long id;
@@ -24,6 +23,19 @@ public class Comment {
     private boolean deleted;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    public static Comment create(Long postId, Long memberId, String content,
+                                  Long parentCommentId, int depth) {
+        return Comment.builder()
+                .postId(postId)
+                .memberId(memberId)
+                .content(content)
+                .parentCommentId(parentCommentId)
+                .depth(depth)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
 
     public boolean isOwner(Long memberId) {
         return this.memberId.equals(memberId);

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/domain/Post.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/domain/Post.java
@@ -1,17 +1,16 @@
 package com.example.lolserver.domain.community.domain;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Post {
 
     private Long id;
@@ -28,6 +27,19 @@ public class Post {
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
 
+    public static Post create(Long memberId, String title, String content, String category) {
+        Post post = Post.builder()
+                .memberId(memberId)
+                .title(title)
+                .content(content)
+                .category(category)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+        post.calculateHotScore();
+        return post;
+    }
+
     public boolean isOwner(Long memberId) {
         return this.memberId.equals(memberId);
     }
@@ -42,6 +54,16 @@ public class Post {
         this.content = content;
         this.category = category;
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
+
+    public void applyVoteCounts(int upvoteCount, int downvoteCount) {
+        this.upvoteCount = upvoteCount;
+        this.downvoteCount = downvoteCount;
+        calculateHotScore();
     }
 
     public double calculateHotScore() {

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/domain/Vote.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/community/domain/Vote.java
@@ -2,17 +2,16 @@ package com.example.lolserver.domain.community.domain;
 
 import com.example.lolserver.domain.community.domain.vo.VoteTargetType;
 import com.example.lolserver.domain.community.domain.vo.VoteType;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
-@NoArgsConstructor
-@AllArgsConstructor
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Vote {
 
     private Long id;
@@ -21,4 +20,19 @@ public class Vote {
     private Long targetId;
     private VoteType voteType;
     private LocalDateTime createdAt;
+
+    public static Vote create(Long memberId, VoteTargetType targetType,
+                               Long targetId, VoteType voteType) {
+        return Vote.builder()
+                .memberId(memberId)
+                .targetType(targetType)
+                .targetId(targetId)
+                .voteType(voteType)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+
+    public void changeVoteType(VoteType newType) {
+        this.voteType = newType;
+    }
 }

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/community/application/CommentServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/community/application/CommentServiceTest.java
@@ -218,14 +218,14 @@ class CommentServiceTest {
     }
 
     private Post createPost(Long postId) {
-        Post post = new Post();
-        post.setId(postId);
-        post.setMemberId(1L);
-        post.setTitle("제목");
-        post.setContent("내용");
-        post.setCategory("GENERAL");
-        post.setCreatedAt(LocalDateTime.now());
-        return post;
+        return Post.builder()
+                .id(postId)
+                .memberId(1L)
+                .title("제목")
+                .content("내용")
+                .category("GENERAL")
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 
     private Member createMember(Long memberId) {
@@ -237,15 +237,15 @@ class CommentServiceTest {
     private Comment createComment(Long id, Long postId,
                                   Long memberId, Long parentId,
                                   int depth) {
-        Comment comment = new Comment();
-        comment.setId(id);
-        comment.setPostId(postId);
-        comment.setMemberId(memberId);
-        comment.setParentCommentId(parentId);
-        comment.setContent("댓글 내용");
-        comment.setDepth(depth);
-        comment.setCreatedAt(LocalDateTime.now());
-        comment.setUpdatedAt(LocalDateTime.now());
-        return comment;
+        return Comment.builder()
+                .id(id)
+                .postId(postId)
+                .memberId(memberId)
+                .parentCommentId(parentId)
+                .content("댓글 내용")
+                .depth(depth)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
     }
 }

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/community/application/PostServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/community/application/PostServiceTest.java
@@ -232,14 +232,14 @@ class PostServiceTest {
     }
 
     private Post createPost(Long postId, Long memberId) {
-        Post post = new Post();
-        post.setId(postId);
-        post.setMemberId(memberId);
-        post.setTitle("테스트 제목");
-        post.setContent("테스트 내용");
-        post.setCategory("GENERAL");
-        post.setCreatedAt(LocalDateTime.now());
-        post.setUpdatedAt(LocalDateTime.now());
-        return post;
+        return Post.builder()
+                .id(postId)
+                .memberId(memberId)
+                .title("테스트 제목")
+                .content("테스트 내용")
+                .category("GENERAL")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
     }
 }

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/community/application/VoteServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/community/application/VoteServiceTest.java
@@ -62,7 +62,7 @@ class VoteServiceTest {
                         memberId, VoteTargetType.POST, 1L))
                 .willReturn(Optional.empty());
         given(votePersistencePort.save(any(Vote.class)))
-                .willReturn(new Vote());
+                .willReturn(Vote.builder().build());
         given(votePersistencePort
                 .countByTargetTypeAndTargetIdAndVoteType(
                         VoteTargetType.POST, 1L, VoteType.UPVOTE))
@@ -92,9 +92,10 @@ class VoteServiceTest {
                 .build();
 
         Post post = createPost(1L);
-        Vote existingVote = new Vote(
-                1L, memberId, VoteTargetType.POST, 1L,
-                VoteType.UPVOTE, LocalDateTime.now());
+        Vote existingVote = Vote.builder()
+                .id(1L).memberId(memberId).targetType(VoteTargetType.POST)
+                .targetId(1L).voteType(VoteType.UPVOTE)
+                .createdAt(LocalDateTime.now()).build();
 
         given(postPersistencePort.findById(1L))
                 .willReturn(Optional.of(post));
@@ -132,9 +133,10 @@ class VoteServiceTest {
                 .build();
 
         Post post = createPost(1L);
-        Vote existingVote = new Vote(
-                1L, memberId, VoteTargetType.POST, 1L,
-                VoteType.UPVOTE, LocalDateTime.now());
+        Vote existingVote = Vote.builder()
+                .id(1L).memberId(memberId).targetType(VoteTargetType.POST)
+                .targetId(1L).voteType(VoteType.UPVOTE)
+                .createdAt(LocalDateTime.now()).build();
 
         given(postPersistencePort.findById(1L))
                 .willReturn(Optional.of(post));
@@ -166,9 +168,10 @@ class VoteServiceTest {
     void removeVote_success() {
         // given
         Long memberId = 1L;
-        Vote vote = new Vote(
-                1L, memberId, VoteTargetType.POST, 1L,
-                VoteType.UPVOTE, LocalDateTime.now());
+        Vote vote = Vote.builder()
+                .id(1L).memberId(memberId).targetType(VoteTargetType.POST)
+                .targetId(1L).voteType(VoteType.UPVOTE)
+                .createdAt(LocalDateTime.now()).build();
 
         given(votePersistencePort
                 .findByMemberIdAndTargetTypeAndTargetId(
@@ -233,14 +236,14 @@ class VoteServiceTest {
     }
 
     private Post createPost(Long postId) {
-        Post post = new Post();
-        post.setId(postId);
-        post.setMemberId(1L);
-        post.setTitle("제목");
-        post.setContent("내용");
-        post.setCategory("GENERAL");
-        post.setCreatedAt(LocalDateTime.now());
-        post.setUpdatedAt(LocalDateTime.now());
-        return post;
+        return Post.builder()
+                .id(postId)
+                .memberId(1L)
+                .title("제목")
+                .content("내용")
+                .category("GENERAL")
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
     }
 }

--- a/module/infra/api/build.gradle
+++ b/module/infra/api/build.gradle
@@ -26,7 +26,7 @@ test {
 }
 
 asciidoctor {
-    inputs.dir snippetsDir
+    inputs.files fileTree(snippetsDir)
     configurations 'asciidoctorExt'
 
     sources { // 특정 파일만 html로 만든다.

--- a/module/infra/api/src/docs/asciidoc/api/community/community-comment-create.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-comment-create.adoc
@@ -1,0 +1,11 @@
+[[community-comment-create]]
+=== 댓글 작성
+
+==== HTTP Request
+include::{snippets}/community-comment-create/http-request.adoc[]
+include::{snippets}/community-comment-create/path-parameters.adoc[]
+include::{snippets}/community-comment-create/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-comment-create/http-response.adoc[]
+include::{snippets}/community-comment-create/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-comment-delete.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-comment-delete.adoc
@@ -1,0 +1,10 @@
+[[community-comment-delete]]
+=== 댓글 삭제
+
+==== HTTP Request
+include::{snippets}/community-comment-delete/http-request.adoc[]
+include::{snippets}/community-comment-delete/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-comment-delete/http-response.adoc[]
+include::{snippets}/community-comment-delete/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-comment-list.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-comment-list.adoc
@@ -1,0 +1,10 @@
+[[community-comment-list]]
+=== 댓글 목록 조회
+
+==== HTTP Request
+include::{snippets}/community-comment-list/http-request.adoc[]
+include::{snippets}/community-comment-list/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-comment-list/http-response.adoc[]
+include::{snippets}/community-comment-list/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-comment-update.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-comment-update.adoc
@@ -1,0 +1,11 @@
+[[community-comment-update]]
+=== 댓글 수정
+
+==== HTTP Request
+include::{snippets}/community-comment-update/http-request.adoc[]
+include::{snippets}/community-comment-update/path-parameters.adoc[]
+include::{snippets}/community-comment-update/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-comment-update/http-response.adoc[]
+include::{snippets}/community-comment-update/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-post-create.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-post-create.adoc
@@ -1,0 +1,10 @@
+[[community-post-create]]
+=== 게시글 작성
+
+==== HTTP Request
+include::{snippets}/community-post-create/http-request.adoc[]
+include::{snippets}/community-post-create/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-post-create/http-response.adoc[]
+include::{snippets}/community-post-create/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-post-delete.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-post-delete.adoc
@@ -1,0 +1,10 @@
+[[community-post-delete]]
+=== 게시글 삭제
+
+==== HTTP Request
+include::{snippets}/community-post-delete/http-request.adoc[]
+include::{snippets}/community-post-delete/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-post-delete/http-response.adoc[]
+include::{snippets}/community-post-delete/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-post-detail.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-post-detail.adoc
@@ -1,0 +1,10 @@
+[[community-post-detail]]
+=== 게시글 상세 조회
+
+==== HTTP Request
+include::{snippets}/community-post-detail/http-request.adoc[]
+include::{snippets}/community-post-detail/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-post-detail/http-response.adoc[]
+include::{snippets}/community-post-detail/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-post-list.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-post-list.adoc
@@ -1,0 +1,10 @@
+[[community-post-list]]
+=== 게시글 목록 조회
+
+==== HTTP Request
+include::{snippets}/community-post-list/http-request.adoc[]
+include::{snippets}/community-post-list/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-post-list/http-response.adoc[]
+include::{snippets}/community-post-list/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-post-my-list.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-post-my-list.adoc
@@ -1,0 +1,10 @@
+[[community-post-my-list]]
+=== 내 게시글 목록 조회
+
+==== HTTP Request
+include::{snippets}/community-post-my-list/http-request.adoc[]
+include::{snippets}/community-post-my-list/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-post-my-list/http-response.adoc[]
+include::{snippets}/community-post-my-list/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-post-search.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-post-search.adoc
@@ -1,0 +1,10 @@
+[[community-post-search]]
+=== 게시글 검색
+
+==== HTTP Request
+include::{snippets}/community-post-search/http-request.adoc[]
+include::{snippets}/community-post-search/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-post-search/http-response.adoc[]
+include::{snippets}/community-post-search/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-post-update.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-post-update.adoc
@@ -1,0 +1,11 @@
+[[community-post-update]]
+=== 게시글 수정
+
+==== HTTP Request
+include::{snippets}/community-post-update/http-request.adoc[]
+include::{snippets}/community-post-update/path-parameters.adoc[]
+include::{snippets}/community-post-update/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-post-update/http-response.adoc[]
+include::{snippets}/community-post-update/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-vote-remove.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-vote-remove.adoc
@@ -1,0 +1,10 @@
+[[community-vote-remove]]
+=== 투표 취소
+
+==== HTTP Request
+include::{snippets}/community-vote-remove/http-request.adoc[]
+include::{snippets}/community-vote-remove/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-vote-remove/http-response.adoc[]
+include::{snippets}/community-vote-remove/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/api/community/community-vote.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/community/community-vote.adoc
@@ -1,0 +1,10 @@
+[[community-vote]]
+=== 투표
+
+==== HTTP Request
+include::{snippets}/community-vote/http-request.adoc[]
+include::{snippets}/community-vote/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/community-vote/http-response.adoc[]
+include::{snippets}/community-vote/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/index.adoc
+++ b/module/infra/api/src/docs/asciidoc/index.adoc
@@ -103,3 +103,32 @@ include::api/tiercutoff/tiercutoff-detail.adoc[]
 include::api/season/season-list.adoc[]
 
 include::api/season/season-detail.adoc[]
+
+[[Community-API]]
+== Community API
+
+include::api/community/community-post-create.adoc[]
+
+include::api/community/community-post-list.adoc[]
+
+include::api/community/community-post-detail.adoc[]
+
+include::api/community/community-post-update.adoc[]
+
+include::api/community/community-post-delete.adoc[]
+
+include::api/community/community-post-search.adoc[]
+
+include::api/community/community-post-my-list.adoc[]
+
+include::api/community/community-comment-create.adoc[]
+
+include::api/community/community-comment-list.adoc[]
+
+include::api/community/community-comment-update.adoc[]
+
+include::api/community/community-comment-delete.adoc[]
+
+include::api/community/community-vote.adoc[]
+
+include::api/community/community-vote-remove.adoc[]

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/CommunityCommentControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/CommunityCommentControllerTest.java
@@ -1,0 +1,291 @@
+package com.example.lolserver.docs.controller;
+
+import com.example.lolserver.controller.community.CommunityCommentController;
+import com.example.lolserver.controller.community.request.CreateCommentRequest;
+import com.example.lolserver.controller.community.request.UpdateCommentRequest;
+import com.example.lolserver.docs.RestDocsSupport;
+import com.example.lolserver.docs.TestAuthenticatedMemberResolver;
+import com.example.lolserver.domain.community.application.model.AuthorReadModel;
+import com.example.lolserver.domain.community.application.model.CommentTreeReadModel;
+import com.example.lolserver.domain.community.application.port.in.CommentQueryUseCase;
+import com.example.lolserver.domain.community.application.port.in.CommentUseCase;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CommunityCommentController 테스트")
+@ExtendWith(MockitoExtension.class)
+class CommunityCommentControllerTest extends RestDocsSupport {
+
+    @Mock
+    private CommentUseCase commentUseCase;
+
+    @Mock
+    private CommentQueryUseCase commentQueryUseCase;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected Object initController() {
+        return new CommunityCommentController(commentUseCase, commentQueryUseCase);
+    }
+
+    @Override
+    protected HandlerMethodArgumentResolver[] customArgumentResolvers() {
+        return new HandlerMethodArgumentResolver[]{new TestAuthenticatedMemberResolver()};
+    }
+
+    private AuthorReadModel sampleAuthor() {
+        return new AuthorReadModel(1L, "테스트유저", "https://example.com/profile.jpg");
+    }
+
+    private CommentTreeReadModel sampleComment() {
+        return CommentTreeReadModel.builder()
+                .id(1L)
+                .postId(1L)
+                .parentCommentId(null)
+                .content("좋은 글이네요!")
+                .depth(0)
+                .upvoteCount(5)
+                .downvoteCount(0)
+                .deleted(false)
+                .author(sampleAuthor())
+                .createdAt(LocalDateTime.of(2026, 3, 20, 11, 0, 0))
+                .updatedAt(LocalDateTime.of(2026, 3, 20, 11, 0, 0))
+                .build();
+    }
+
+    private CommentTreeReadModel sampleCommentWithChild() {
+        CommentTreeReadModel child = CommentTreeReadModel.builder()
+                .id(2L)
+                .postId(1L)
+                .parentCommentId(1L)
+                .content("감사합니다!")
+                .depth(1)
+                .upvoteCount(2)
+                .downvoteCount(0)
+                .deleted(false)
+                .author(sampleAuthor())
+                .createdAt(LocalDateTime.of(2026, 3, 20, 12, 0, 0))
+                .updatedAt(LocalDateTime.of(2026, 3, 20, 12, 0, 0))
+                .build();
+
+        CommentTreeReadModel parent = CommentTreeReadModel.builder()
+                .id(1L)
+                .postId(1L)
+                .parentCommentId(null)
+                .content("좋은 글이네요!")
+                .depth(0)
+                .upvoteCount(5)
+                .downvoteCount(0)
+                .deleted(false)
+                .author(sampleAuthor())
+                .createdAt(LocalDateTime.of(2026, 3, 20, 11, 0, 0))
+                .updatedAt(LocalDateTime.of(2026, 3, 20, 11, 0, 0))
+                .build();
+        parent.setChildren(List.of(child));
+        return parent;
+    }
+
+    @DisplayName("댓글 작성 API")
+    @Test
+    void createComment() throws Exception {
+        given(commentUseCase.createComment(eq(1L), eq(1L), any())).willReturn(sampleComment());
+
+        CreateCommentRequest request = new CreateCommentRequest("좋은 글이네요!", null);
+
+        mockMvc.perform(
+                        post("/api/community/posts/{postId}/comments", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-comment-create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").type(JsonFieldType.STRING)
+                                        .description("댓글 내용"),
+                                fieldWithPath("parentCommentId").type(JsonFieldType.NULL)
+                                        .description("부모 댓글 ID (대댓글인 경우)")
+                                        .optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                                        .description("댓글 ID"),
+                                fieldWithPath("data.postId").type(JsonFieldType.NUMBER)
+                                        .description("게시글 ID"),
+                                fieldWithPath("data.parentCommentId").type(JsonFieldType.NULL)
+                                        .description("부모 댓글 ID (대댓글인 경우)")
+                                        .optional(),
+                                fieldWithPath("data.content").type(JsonFieldType.STRING)
+                                        .description("댓글 내용"),
+                                fieldWithPath("data.depth").type(JsonFieldType.NUMBER)
+                                        .description("댓글 깊이 (0: 최상위)"),
+                                fieldWithPath("data.upvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("추천수"),
+                                fieldWithPath("data.downvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("비추천수"),
+                                fieldWithPath("data.deleted").type(JsonFieldType.BOOLEAN)
+                                        .description("삭제 여부"),
+                                fieldWithPath("data.author.id").type(JsonFieldType.NUMBER)
+                                        .description("작성자 ID"),
+                                fieldWithPath("data.author.nickname").type(JsonFieldType.STRING)
+                                        .description("작성자 닉네임"),
+                                fieldWithPath("data.author.profileImageUrl").type(JsonFieldType.STRING)
+                                        .description("작성자 프로필 이미지 URL"),
+                                fieldWithPath("data.createdAt").type(JsonFieldType.STRING)
+                                        .description("작성일시"),
+                                fieldWithPath("data.updatedAt").type(JsonFieldType.STRING)
+                                        .description("수정일시"),
+                                fieldWithPath("data.children").type(JsonFieldType.ARRAY)
+                                        .description("자식 댓글 목록")
+                        )
+                ));
+    }
+
+    @DisplayName("댓글 목록 조회 API")
+    @Test
+    void getComments() throws Exception {
+        given(commentQueryUseCase.getComments(eq(1L))).willReturn(List.of(sampleCommentWithChild()));
+
+        mockMvc.perform(
+                        get("/api/community/posts/{postId}/comments", 1L)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-comment-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data[].id").type(JsonFieldType.NUMBER)
+                                        .description("댓글 ID"),
+                                fieldWithPath("data[].postId").type(JsonFieldType.NUMBER)
+                                        .description("게시글 ID"),
+                                fieldWithPath("data[].parentCommentId").type(JsonFieldType.NULL)
+                                        .description("부모 댓글 ID")
+                                        .optional(),
+                                fieldWithPath("data[].content").type(JsonFieldType.STRING)
+                                        .description("댓글 내용"),
+                                fieldWithPath("data[].depth").type(JsonFieldType.NUMBER)
+                                        .description("댓글 깊이"),
+                                fieldWithPath("data[].upvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("추천수"),
+                                fieldWithPath("data[].downvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("비추천수"),
+                                fieldWithPath("data[].deleted").type(JsonFieldType.BOOLEAN)
+                                        .description("삭제 여부"),
+                                fieldWithPath("data[].author.id").type(JsonFieldType.NUMBER)
+                                        .description("작성자 ID"),
+                                fieldWithPath("data[].author.nickname").type(JsonFieldType.STRING)
+                                        .description("작성자 닉네임"),
+                                fieldWithPath("data[].author.profileImageUrl").type(JsonFieldType.STRING)
+                                        .description("작성자 프로필 이미지 URL"),
+                                fieldWithPath("data[].createdAt").type(JsonFieldType.STRING)
+                                        .description("작성일시"),
+                                fieldWithPath("data[].updatedAt").type(JsonFieldType.STRING)
+                                        .description("수정일시"),
+                                subsectionWithPath("data[].children").type(JsonFieldType.ARRAY)
+                                        .description("자식 댓글 목록 (재귀 구조)")
+                        )
+                ));
+    }
+
+    @DisplayName("댓글 수정 API")
+    @Test
+    void updateComment() throws Exception {
+        given(commentUseCase.updateComment(eq(1L), eq(1L), any())).willReturn(sampleComment());
+
+        UpdateCommentRequest request = new UpdateCommentRequest("수정된 댓글 내용");
+
+        mockMvc.perform(
+                        put("/api/community/comments/{commentId}", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-comment-update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("commentId").description("댓글 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("content").type(JsonFieldType.STRING)
+                                        .description("수정할 댓글 내용")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                subsectionWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("수정된 댓글 상세 (CommentResponse)")
+                        )
+                ));
+    }
+
+    @DisplayName("댓글 삭제 API")
+    @Test
+    void deleteComment() throws Exception {
+        willDoNothing().given(commentUseCase).deleteComment(eq(1L), eq(1L));
+
+        mockMvc.perform(
+                        delete("/api/community/comments/{commentId}", 1L)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-comment-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("commentId").description("댓글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data").type(JsonFieldType.NULL)
+                                        .description("데이터 없음")
+                        )
+                ));
+    }
+}

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/CommunityPostControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/CommunityPostControllerTest.java
@@ -1,0 +1,415 @@
+package com.example.lolserver.docs.controller;
+
+import com.example.lolserver.controller.community.CommunityPostController;
+import com.example.lolserver.controller.community.request.CreatePostRequest;
+import com.example.lolserver.controller.community.request.UpdatePostRequest;
+import com.example.lolserver.docs.RestDocsSupport;
+import com.example.lolserver.docs.TestAuthenticatedMemberResolver;
+import com.example.lolserver.domain.community.application.model.AuthorReadModel;
+import com.example.lolserver.domain.community.application.model.PostDetailReadModel;
+import com.example.lolserver.domain.community.application.model.PostListReadModel;
+import com.example.lolserver.domain.community.application.port.in.PostQueryUseCase;
+import com.example.lolserver.domain.community.application.port.in.PostUseCase;
+import com.example.lolserver.domain.community.domain.vo.VoteType;
+import com.example.lolserver.support.Page;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CommunityPostController 테스트")
+@ExtendWith(MockitoExtension.class)
+class CommunityPostControllerTest extends RestDocsSupport {
+
+    @Mock
+    private PostUseCase postUseCase;
+
+    @Mock
+    private PostQueryUseCase postQueryUseCase;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected Object initController() {
+        return new CommunityPostController(postUseCase, postQueryUseCase);
+    }
+
+    @Override
+    protected HandlerMethodArgumentResolver[] customArgumentResolvers() {
+        return new HandlerMethodArgumentResolver[]{new TestAuthenticatedMemberResolver()};
+    }
+
+    private AuthorReadModel sampleAuthor() {
+        return new AuthorReadModel(1L, "테스트유저", "https://example.com/profile.jpg");
+    }
+
+    private PostDetailReadModel samplePostDetail() {
+        return PostDetailReadModel.builder()
+                .id(1L)
+                .title("챔피언 밸런스 패치 의견")
+                .content("이번 패치에서 아리 너프가 너무 심한 것 같습니다.")
+                .category("CHAMPION_DISCUSSION")
+                .viewCount(150)
+                .upvoteCount(25)
+                .downvoteCount(3)
+                .commentCount(12)
+                .author(sampleAuthor())
+                .currentUserVote(VoteType.UPVOTE)
+                .createdAt(LocalDateTime.of(2026, 3, 20, 10, 0, 0))
+                .updatedAt(LocalDateTime.of(2026, 3, 20, 10, 0, 0))
+                .build();
+    }
+
+    private PostListReadModel samplePostList(Long id, String title) {
+        return PostListReadModel.builder()
+                .id(id)
+                .title(title)
+                .category("CHAMPION_DISCUSSION")
+                .viewCount(150)
+                .upvoteCount(25)
+                .downvoteCount(3)
+                .commentCount(12)
+                .hotScore(85.5)
+                .author(sampleAuthor())
+                .createdAt(LocalDateTime.of(2026, 3, 20, 10, 0, 0))
+                .build();
+    }
+
+    @DisplayName("게시글 작성 API")
+    @Test
+    void createPost() throws Exception {
+        given(postUseCase.createPost(eq(1L), any())).willReturn(samplePostDetail());
+
+        CreatePostRequest request = new CreatePostRequest(
+                "챔피언 밸런스 패치 의견",
+                "이번 패치에서 아리 너프가 너무 심한 것 같습니다.",
+                "CHAMPION_DISCUSSION");
+
+        mockMvc.perform(
+                        post("/api/community/posts")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-post-create",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("title").type(JsonFieldType.STRING)
+                                        .description("게시글 제목 (최대 300자)"),
+                                fieldWithPath("content").type(JsonFieldType.STRING)
+                                        .description("게시글 내용"),
+                                fieldWithPath("category").type(JsonFieldType.STRING)
+                                        .description("카테고리 (CHAMPION_DISCUSSION, PATCH_NOTES, TIPS_AND_GUIDES, META_DISCUSSION, COMMUNITY, HUMOR, GENERAL)")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                                        .description("게시글 ID"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING)
+                                        .description("게시글 제목"),
+                                fieldWithPath("data.content").type(JsonFieldType.STRING)
+                                        .description("게시글 내용"),
+                                fieldWithPath("data.category").type(JsonFieldType.STRING)
+                                        .description("카테고리"),
+                                fieldWithPath("data.viewCount").type(JsonFieldType.NUMBER)
+                                        .description("조회수"),
+                                fieldWithPath("data.upvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("추천수"),
+                                fieldWithPath("data.downvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("비추천수"),
+                                fieldWithPath("data.commentCount").type(JsonFieldType.NUMBER)
+                                        .description("댓글수"),
+                                fieldWithPath("data.author.id").type(JsonFieldType.NUMBER)
+                                        .description("작성자 ID"),
+                                fieldWithPath("data.author.nickname").type(JsonFieldType.STRING)
+                                        .description("작성자 닉네임"),
+                                fieldWithPath("data.author.profileImageUrl").type(JsonFieldType.STRING)
+                                        .description("작성자 프로필 이미지 URL"),
+                                fieldWithPath("data.currentUserVote").type(JsonFieldType.STRING)
+                                        .description("현재 사용자의 투표 (UPVOTE, DOWNVOTE, null)")
+                                        .optional(),
+                                fieldWithPath("data.createdAt").type(JsonFieldType.STRING)
+                                        .description("작성일시"),
+                                fieldWithPath("data.updatedAt").type(JsonFieldType.STRING)
+                                        .description("수정일시")
+                        )
+                ));
+    }
+
+    @DisplayName("게시글 목록 조회 API")
+    @Test
+    void getPosts() throws Exception {
+        Page<PostListReadModel> page = new Page<>(
+                List.of(samplePostList(1L, "첫 번째 게시글"), samplePostList(2L, "두 번째 게시글")),
+                true);
+        given(postQueryUseCase.getPosts(any())).willReturn(page);
+
+        mockMvc.perform(
+                        get("/api/community/posts")
+                                .param("category", "CHAMPION_DISCUSSION")
+                                .param("sort", "HOT")
+                                .param("period", "ALL")
+                                .param("page", "0")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-post-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("category").description("카테고리 필터 (선택)").optional(),
+                                parameterWithName("sort").description("정렬 기준 (HOT, NEW, TOP / 기본값: HOT)").optional(),
+                                parameterWithName("period").description("기간 필터 (DAILY, WEEKLY, MONTHLY, ALL / 기본값: ALL)").optional(),
+                                parameterWithName("page").description("페이지 번호 (기본값: 0)").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER)
+                                        .description("게시글 ID"),
+                                fieldWithPath("data.content[].title").type(JsonFieldType.STRING)
+                                        .description("게시글 제목"),
+                                fieldWithPath("data.content[].category").type(JsonFieldType.STRING)
+                                        .description("카테고리"),
+                                fieldWithPath("data.content[].viewCount").type(JsonFieldType.NUMBER)
+                                        .description("조회수"),
+                                fieldWithPath("data.content[].upvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("추천수"),
+                                fieldWithPath("data.content[].downvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("비추천수"),
+                                fieldWithPath("data.content[].commentCount").type(JsonFieldType.NUMBER)
+                                        .description("댓글수"),
+                                fieldWithPath("data.content[].hotScore").type(JsonFieldType.NUMBER)
+                                        .description("인기 점수"),
+                                fieldWithPath("data.content[].author.id").type(JsonFieldType.NUMBER)
+                                        .description("작성자 ID"),
+                                fieldWithPath("data.content[].author.nickname").type(JsonFieldType.STRING)
+                                        .description("작성자 닉네임"),
+                                fieldWithPath("data.content[].author.profileImageUrl").type(JsonFieldType.STRING)
+                                        .description("작성자 프로필 이미지 URL"),
+                                fieldWithPath("data.content[].createdAt").type(JsonFieldType.STRING)
+                                        .description("작성일시"),
+                                fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN)
+                                        .description("다음 페이지 존재 여부")
+                        )
+                ));
+    }
+
+    @DisplayName("게시글 상세 조회 API")
+    @Test
+    void getPost() throws Exception {
+        given(postQueryUseCase.getPost(eq(1L), any())).willReturn(samplePostDetail());
+
+        mockMvc.perform(
+                        get("/api/community/posts/{postId}", 1L)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-post-detail",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                                        .description("게시글 ID"),
+                                fieldWithPath("data.title").type(JsonFieldType.STRING)
+                                        .description("게시글 제목"),
+                                fieldWithPath("data.content").type(JsonFieldType.STRING)
+                                        .description("게시글 내용"),
+                                fieldWithPath("data.category").type(JsonFieldType.STRING)
+                                        .description("카테고리"),
+                                fieldWithPath("data.viewCount").type(JsonFieldType.NUMBER)
+                                        .description("조회수"),
+                                fieldWithPath("data.upvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("추천수"),
+                                fieldWithPath("data.downvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("비추천수"),
+                                fieldWithPath("data.commentCount").type(JsonFieldType.NUMBER)
+                                        .description("댓글수"),
+                                fieldWithPath("data.author.id").type(JsonFieldType.NUMBER)
+                                        .description("작성자 ID"),
+                                fieldWithPath("data.author.nickname").type(JsonFieldType.STRING)
+                                        .description("작성자 닉네임"),
+                                fieldWithPath("data.author.profileImageUrl").type(JsonFieldType.STRING)
+                                        .description("작성자 프로필 이미지 URL"),
+                                fieldWithPath("data.currentUserVote").type(JsonFieldType.STRING)
+                                        .description("현재 사용자의 투표 (UPVOTE, DOWNVOTE, null)")
+                                        .optional(),
+                                fieldWithPath("data.createdAt").type(JsonFieldType.STRING)
+                                        .description("작성일시"),
+                                fieldWithPath("data.updatedAt").type(JsonFieldType.STRING)
+                                        .description("수정일시")
+                        )
+                ));
+    }
+
+    @DisplayName("게시글 수정 API")
+    @Test
+    void updatePost() throws Exception {
+        given(postUseCase.updatePost(eq(1L), eq(1L), any())).willReturn(samplePostDetail());
+
+        UpdatePostRequest request = new UpdatePostRequest(
+                "챔피언 밸런스 패치 의견",
+                "이번 패치에서 아리 너프가 너무 심한 것 같습니다.",
+                "CHAMPION_DISCUSSION");
+
+        mockMvc.perform(
+                        put("/api/community/posts/{postId}", 1L)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-post-update",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("title").type(JsonFieldType.STRING)
+                                        .description("게시글 제목 (최대 300자)"),
+                                fieldWithPath("content").type(JsonFieldType.STRING)
+                                        .description("게시글 내용"),
+                                fieldWithPath("category").type(JsonFieldType.STRING)
+                                        .description("카테고리")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                subsectionWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("수정된 게시글 상세 (PostResponse)")
+                        )
+                ));
+    }
+
+    @DisplayName("게시글 삭제 API")
+    @Test
+    void deletePost() throws Exception {
+        willDoNothing().given(postUseCase).deletePost(eq(1L), eq(1L));
+
+        mockMvc.perform(
+                        delete("/api/community/posts/{postId}", 1L)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-post-delete",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("postId").description("게시글 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data").type(JsonFieldType.NULL)
+                                        .description("데이터 없음")
+                        )
+                ));
+    }
+
+    @DisplayName("게시글 검색 API")
+    @Test
+    void searchPosts() throws Exception {
+        Page<PostListReadModel> page = new Page<>(
+                List.of(samplePostList(1L, "아리 너프 관련 의견")),
+                false);
+        given(postQueryUseCase.searchPosts(any())).willReturn(page);
+
+        mockMvc.perform(
+                        get("/api/community/posts/search")
+                                .param("keyword", "아리")
+                                .param("page", "0")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-post-search",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("keyword").description("검색 키워드"),
+                                parameterWithName("page").description("페이지 번호 (기본값: 0)").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                subsectionWithPath("data.content[]").type(JsonFieldType.ARRAY)
+                                        .description("검색된 게시글 목록"),
+                                fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN)
+                                        .description("다음 페이지 존재 여부")
+                        )
+                ));
+    }
+
+    @DisplayName("내 게시글 목록 조회 API")
+    @Test
+    void getMyPosts() throws Exception {
+        Page<PostListReadModel> page = new Page<>(
+                List.of(samplePostList(1L, "내가 쓴 게시글")),
+                false);
+        given(postQueryUseCase.getMyPosts(eq(1L), eq(0))).willReturn(page);
+
+        mockMvc.perform(
+                        get("/api/community/me/posts")
+                                .param("page", "0")
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-post-my-list",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        queryParameters(
+                                parameterWithName("page").description("페이지 번호 (기본값: 0)").optional()
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                subsectionWithPath("data.content[]").type(JsonFieldType.ARRAY)
+                                        .description("내 게시글 목록"),
+                                fieldWithPath("data.hasNext").type(JsonFieldType.BOOLEAN)
+                                        .description("다음 페이지 존재 여부")
+                        )
+                ));
+    }
+}

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/CommunityVoteControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/CommunityVoteControllerTest.java
@@ -1,0 +1,126 @@
+package com.example.lolserver.docs.controller;
+
+import com.example.lolserver.controller.community.CommunityVoteController;
+import com.example.lolserver.controller.community.request.VoteRequest;
+import com.example.lolserver.docs.RestDocsSupport;
+import com.example.lolserver.docs.TestAuthenticatedMemberResolver;
+import com.example.lolserver.domain.community.application.model.VoteReadModel;
+import com.example.lolserver.domain.community.application.port.in.VoteUseCase;
+import com.example.lolserver.domain.community.domain.vo.VoteTargetType;
+import com.example.lolserver.domain.community.domain.vo.VoteType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("CommunityVoteController 테스트")
+@ExtendWith(MockitoExtension.class)
+class CommunityVoteControllerTest extends RestDocsSupport {
+
+    @Mock
+    private VoteUseCase voteUseCase;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected Object initController() {
+        return new CommunityVoteController(voteUseCase);
+    }
+
+    @Override
+    protected HandlerMethodArgumentResolver[] customArgumentResolvers() {
+        return new HandlerMethodArgumentResolver[]{new TestAuthenticatedMemberResolver()};
+    }
+
+    @DisplayName("투표 API")
+    @Test
+    void vote() throws Exception {
+        VoteReadModel readModel = new VoteReadModel(
+                VoteTargetType.POST, 1L, VoteType.UPVOTE, 26, 3);
+
+        given(voteUseCase.vote(eq(1L), any())).willReturn(readModel);
+
+        VoteRequest request = new VoteRequest("POST", 1L, "UPVOTE");
+
+        mockMvc.perform(
+                        post("/api/community/votes")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-vote",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestFields(
+                                fieldWithPath("targetType").type(JsonFieldType.STRING)
+                                        .description("투표 대상 타입 (POST, COMMENT)"),
+                                fieldWithPath("targetId").type(JsonFieldType.NUMBER)
+                                        .description("투표 대상 ID"),
+                                fieldWithPath("voteType").type(JsonFieldType.STRING)
+                                        .description("투표 타입 (UPVOTE, DOWNVOTE)")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data.targetType").type(JsonFieldType.STRING)
+                                        .description("투표 대상 타입"),
+                                fieldWithPath("data.targetId").type(JsonFieldType.NUMBER)
+                                        .description("투표 대상 ID"),
+                                fieldWithPath("data.voteType").type(JsonFieldType.STRING)
+                                        .description("투표 타입"),
+                                fieldWithPath("data.newUpvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("변경 후 추천수"),
+                                fieldWithPath("data.newDownvoteCount").type(JsonFieldType.NUMBER)
+                                        .description("변경 후 비추천수")
+                        )
+                ));
+    }
+
+    @DisplayName("투표 취소 API")
+    @Test
+    void removeVote() throws Exception {
+        willDoNothing().given(voteUseCase).removeVote(eq(1L), eq(VoteTargetType.POST), eq(1L));
+
+        mockMvc.perform(
+                        delete("/api/community/votes/{targetType}/{targetId}", "POST", 1L)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("community-vote-remove",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("targetType").description("투표 대상 타입 (POST, COMMENT)"),
+                                parameterWithName("targetId").description("투표 대상 ID")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING)
+                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
+                                        .description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data").type(JsonFieldType.NULL)
+                                        .description("데이터 없음")
+                        )
+                ));
+    }
+}


### PR DESCRIPTION
## Summary
- 커뮤니티 도메인 객체(Post, Comment, Vote)에서 `@Setter` 제거, 정적 팩토리 메서드 및 도메인 메서드로 캡슐화 복원
- 커뮤니티 API RestDocs 테스트 및 .adoc 문서 추가 (게시글/댓글/투표 13개 엔드포인트)
- `lol-db-schema` 서브모듈 참조 업데이트 (V11 커뮤니티 테이블, V12 ClickHouse ETL View)
- asciidoctor `inputs.dir` → `inputs.files fileTree`로 변경하여 `clean build` 시 빌드 실패 해결

## Test plan
- [ ] `./gradlew clean build` 성공 확인
- [ ] `./gradlew :module:core:lol-server-domain:test --tests "com.example.lolserver.domain.community.*"` 통과 확인
- [ ] 커뮤니티 도메인 객체에서 `@Setter` 완전 제거 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)