### PR TITLE
feat: 일별 게임 수 조회 API에 최소/최대 요약 정보 추가

### DIFF
--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/MatchService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/MatchService.java
@@ -3,6 +3,7 @@ package com.example.lolserver.domain.match.application;
 import com.example.lolserver.domain.match.application.command.MSChampionCommand;
 import com.example.lolserver.domain.match.application.command.MatchCommand;
 import com.example.lolserver.domain.match.application.model.DailyGameCountReadModel;
+import com.example.lolserver.domain.match.application.model.DailyGameCountSummaryReadModel;
 import com.example.lolserver.domain.match.application.model.GameReadModel;
 import com.example.lolserver.domain.match.domain.MSChampion;
 import com.example.lolserver.domain.match.domain.TimelineData;
@@ -65,9 +66,17 @@ public class MatchService {
         return matchPersistencePort.findAllMatchIds(matchCommand.getPuuid(), matchCommand.getQueueId(), pageable);
     }
 
-    public List<DailyGameCountReadModel> getDailyGameCounts(
+    public DailyGameCountSummaryReadModel getDailyGameCounts(
             String puuid, Integer season, Integer queueId) {
         LocalDateTime startDate = LocalDate.now().minusMonths(3).atStartOfDay();
-        return matchPersistencePort.getDailyGameCounts(puuid, season, queueId, startDate);
+        List<DailyGameCountReadModel> dailyCounts =
+                matchPersistencePort.getDailyGameCounts(puuid, season, queueId, startDate);
+
+        long minCount = dailyCounts.stream()
+                .mapToLong(DailyGameCountReadModel::gameCount).min().orElse(0L);
+        long maxCount = dailyCounts.stream()
+                .mapToLong(DailyGameCountReadModel::gameCount).max().orElse(0L);
+
+        return new DailyGameCountSummaryReadModel(dailyCounts, minCount, maxCount);
     }
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/model/DailyGameCountSummaryReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/model/DailyGameCountSummaryReadModel.java
@@ -1,0 +1,9 @@
+package com.example.lolserver.domain.match.application.model;
+
+import java.util.List;
+
+public record DailyGameCountSummaryReadModel(
+    List<DailyGameCountReadModel> dailyCounts,
+    long minCount,
+    long maxCount
+) {}

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/match/MatchController.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/match/MatchController.java
@@ -4,7 +4,7 @@ import com.example.lolserver.domain.match.application.command.MSChampionCommand;
 import com.example.lolserver.domain.match.application.command.MatchCommand;
 import com.example.lolserver.domain.match.domain.MSChampion;
 import com.example.lolserver.domain.match.application.MatchService;
-import com.example.lolserver.domain.match.application.model.DailyGameCountReadModel;
+import com.example.lolserver.domain.match.application.model.DailyGameCountSummaryReadModel;
 import com.example.lolserver.domain.match.application.model.GameReadModel;
 import com.example.lolserver.domain.match.domain.TimelineData;
 import com.example.lolserver.controller.support.response.ApiResponse;
@@ -92,12 +92,12 @@ public class MatchController {
     }
 
     @GetMapping("/{platformId}/summoners/{puuid}/matches/daily-count")
-    public ResponseEntity<ApiResponse<List<DailyGameCountReadModel>>> getDailyGameCounts(
+    public ResponseEntity<ApiResponse<DailyGameCountSummaryReadModel>> getDailyGameCounts(
             @PathVariable("platformId") String platformId,
             @PathVariable("puuid") String puuid,
             @RequestParam Integer season,
             @RequestParam(required = false) Integer queueId) {
-        List<DailyGameCountReadModel> result =
+        DailyGameCountSummaryReadModel result =
                 matchService.getDailyGameCounts(puuid, season, queueId);
         return ResponseEntity.ok(ApiResponse.success(result));
     }

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/MatchControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/MatchControllerTest.java
@@ -17,6 +17,7 @@ import com.example.lolserver.domain.match.domain.gamedata.value.Style;
 import com.example.lolserver.domain.match.domain.TeamData;
 import com.example.lolserver.domain.match.application.MatchService;
 import com.example.lolserver.domain.match.application.model.DailyGameCountReadModel;
+import com.example.lolserver.domain.match.application.model.DailyGameCountSummaryReadModel;
 import com.example.lolserver.domain.match.application.model.GameReadModel;
 import com.example.lolserver.domain.match.domain.TimelineData;
 import com.example.lolserver.support.Page;
@@ -519,11 +520,13 @@ class MatchControllerTest extends RestDocsSupport {
     void getDailyGameCounts() throws Exception {
         // given
         String puuid = "puuid-1234";
-        List<DailyGameCountReadModel> response = List.of(
+        List<DailyGameCountReadModel> dailyCounts = List.of(
                 new DailyGameCountReadModel(LocalDate.of(2025, 1, 15), 3L),
                 new DailyGameCountReadModel(LocalDate.of(2025, 1, 14), 5L),
                 new DailyGameCountReadModel(LocalDate.of(2025, 1, 13), 2L)
         );
+        DailyGameCountSummaryReadModel response =
+                new DailyGameCountSummaryReadModel(dailyCounts, 2L, 5L);
 
         given(matchService.getDailyGameCounts(anyString(), anyInt(), any())).willReturn(response);
 
@@ -550,8 +553,10 @@ class MatchControllerTest extends RestDocsSupport {
                         responseFields(
                                 fieldWithPath("result").type(JsonFieldType.STRING).description("API 응답 결과 (SUCCESS, FAIL)"),
                                 fieldWithPath("errorMessage").type(JsonFieldType.NULL).description("에러 메시지 (정상 응답 시 null)"),
-                                fieldWithPath("data[].gameDate").type(JsonFieldType.STRING).description("게임 날짜 (yyyy-MM-dd)"),
-                                fieldWithPath("data[].gameCount").type(JsonFieldType.NUMBER).description("해당 날짜의 게임 수")
+                                fieldWithPath("data.dailyCounts[].gameDate").type(JsonFieldType.STRING).description("게임 날짜 (yyyy-MM-dd)"),
+                                fieldWithPath("data.dailyCounts[].gameCount").type(JsonFieldType.NUMBER).description("해당 날짜의 게임 수"),
+                                fieldWithPath("data.minCount").type(JsonFieldType.NUMBER).description("기간 내 일별 최소 게임 수"),
+                                fieldWithPath("data.maxCount").type(JsonFieldType.NUMBER).description("기간 내 일별 최대 게임 수")
                         )
                 ));
     }


### PR DESCRIPTION
## Summary
- `DailyGameCountSummaryReadModel` 도입하여 일별 게임 수 목록과 함께 `minCount`, `maxCount` 요약 통계를 반환
- `MatchService.getDailyGameCounts()` 반환 타입을 `List<DailyGameCountReadModel>` → `DailyGameCountSummaryReadModel`로 변경
- RestDocs 테스트 업데이트하여 변경된 응답 구조 반영

## Test plan
- [ ] `MatchControllerTest.getDailyGameCounts()` RestDocs 테스트 통과 확인
- [ ] `./gradlew build` 전체 빌드 성공 확인
- [ ] API 응답에 `data.dailyCounts[]`, `data.minCount`, `data.maxCount` 필드 정상 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)