### PR TITLE
refactor: 중복 CompletableFuture.allOf().join() 제거

### DIFF
--- a/module/infra/persistence/postgresql/src/main/java/com/example/lolserver/repository/match/adapter/MatchPersistenceAdapter.java
+++ b/module/infra/persistence/postgresql/src/main/java/com/example/lolserver/repository/match/adapter/MatchPersistenceAdapter.java
@@ -172,10 +172,6 @@ public class MatchPersistenceAdapter implements MatchPersistencePort {
                                         SkillEventDTO::getMatchId)),
                         queryExecutor);
 
-        CompletableFuture.allOf(
-                summonersFuture, teamsFuture, itemsFuture, skillsFuture
-        ).join();
-
         Map<String, List<MatchSummonerDTO>> participantsByMatch =
                 summonersFuture.join();
         Map<String, List<MatchTeamDTO>> teamsByMatch =


### PR DESCRIPTION
## Summary
- `MatchPersistenceAdapter.getMatchesBatch()`에서 불필요한 `CompletableFuture.allOf(...).join()` 호출 제거
- 직후 개별 `.join()` 호출이 이미 각 future의 완료를 보장하므로 중복 동기화 제거

## Test plan
- [x] `./gradlew :module:infra:persistence:postgresql:test` — 전체 테스트 통과
- [x] `./gradlew build` — 빌드 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)