### PR TITLE
docs: CLAUDE.md 중복 섹션 통합 및 불필요한 내용 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,10 +28,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 기술 스택
 
-- Java 17, Spring Boot 3.3.6, Gradle 8.5
+- Java 21, Spring Boot 3.3.6, Gradle 8.5
 - PostgreSQL (영속성), Redis/Redisson (캐싱), RabbitMQ (메시징)
 - QueryDSL 5.1.0, MapStruct 1.5.5, Bucket4j (Rate Limiting)
-- Spring RestDocs (API 문서화)
+- Spring RestDocs (API 문서화)/
 
 ## 아키텍처
 
@@ -47,11 +47,16 @@ module/
 │   └── enum/                     # 공유 enum 타입
 ├── infra/
 │   ├── api/                      # REST 컨트롤러 (구동 어댑터)
-│   ├── client/lol-repository/    # Riot API 클라이언트 (피동 어댑터)
-│   ├── message/rabbitmq/         # 메시지 생산자/소비자
+│   ├── client/
+│   │   ├── lol-repository/       # Riot API 클라이언트 (피동 어댑터)
+│   │   └── oauth/                # OAuth2 클라이언트 (토큰 교환, RSO)
+│   ├── message/
+│   │   ├── rabbitmq/             # RabbitMQ 메시지 생산자/소비자
+│   │   └── kafka/                # Kafka 메시지 브로커 어댑터
 │   └── persistence/
 │       ├── postgresql/           # JPA 엔티티, 리포지토리, 어댑터
-│       └── redis/                # 캐싱 설정
+│       ├── redis/                # 캐싱, RefreshToken, OAuth State 저장
+│       └── clickhouse/           # 분석용 데이터 저장소
 └── support/logging/              # 횡단 관심사 유틸리티
 ```
 
@@ -66,7 +71,7 @@ module/
 
 ### 도메인 컨텍스트
 
-각 도메인 (champion, league, match, patchnote, queue_type, rank, spectator, summoner, tiercutoff, version)은 다음 구조를 따릅니다:
+각 도메인 (champion, championstats, community, league, match, member, patchnote, queue_type, rank, season, spectator, summoner, tiercutoff, version)은 다음 구조를 따릅니다:
 - `domain/` - 순수 도메인 객체 (Write Model)
 - `application/` - 애플리케이션 서비스
 - `application/port/` - 포트 인터페이스 (in/out)
@@ -148,8 +153,14 @@ module/
 - DI: `@RequiredArgsConstructor` + `private final` 필드 (생성자 주입)
 - 로깅: `@Slf4j`
 - 컨트롤러 응답 DTO: Java `record` (불변)
-- 커맨드: `@Builder @Getter @Setter @NoArgsConstructor @AllArgsConstructor`
+- 커맨드: `@Builder @Getter @NoArgsConstructor @AllArgsConstructor` (도메인 객체에 `@Setter` 사용 금지 — 팩토리 메서드/Builder 사용)
 - 트랜잭션: 조회 `@Transactional(readOnly = true)`, 변경 `@Transactional`
+
+### 비동기 쿼리 실행 패턴
+
+- `AsyncQueryConfig`에서 `Executors.newVirtualThreadPerTaskExecutor()` 빈 등록 (`@Qualifier("queryExecutor")`)
+- 대용량 데이터 조합 시 `CompletableFuture.supplyAsync()`로 병렬 쿼리 실행 후 `allOf().join()`
+- `@LogExecutionTime` AOP 어노테이션으로 메서드 실행 시간 로깅 가능
 
 ### Git 워크플로우
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Java 21, Spring Boot 3.3.6, Gradle 8.5
 - PostgreSQL (영속성), Redis/Redisson (캐싱), RabbitMQ (메시징)
 - QueryDSL 5.1.0, MapStruct 1.5.5, Bucket4j (Rate Limiting)
-- Spring RestDocs (API 문서화)/
+- Spring RestDocs (API 문서화)
 
 ## 아키텍처
 
@@ -71,60 +71,24 @@ module/
 
 ### 도메인 컨텍스트
 
-각 도메인 (champion, championstats, community, league, match, member, patchnote, queue_type, rank, season, spectator, summoner, tiercutoff, version)은 다음 구조를 따릅니다:
-- `domain/` - 순수 도메인 객체 (Write Model)
+각 도메인(`module/core/lol-server-domain/.../domain/` 하위)은 다음 구조를 따릅니다:
+- `domain/` - 순수 도메인 객체 (Write Model, 비즈니스 로직 포함)
 - `application/` - 애플리케이션 서비스
 - `application/port/` - 포트 인터페이스 (in/out)
 - `application/dto/` - Command, SearchDto 등 입력 DTO
-- `application/model/` - ReadModel 클래스 (조회용 DTO)
+- `application/model/` - ReadModel (불변, Java Record, 팩토리 메서드 `*.of()` 변환)
 
-### Read Model 패턴
+### 클래스 명명 규칙
 
-이 프로젝트는 **Write Model과 Read Model을 명확히 분리**합니다.
-
-#### Write Model (도메인 엔티티)
-- 위치: `domain/{도메인}/domain/`
-- 비즈니스 로직 포함
-- 상태 변경 가능
-
-#### Read Model (ReadModel)
-- 위치: `domain/{도메인}/application/model/`
-- 표현 전용, 비즈니스 로직 없음
-- 불변 (Java Record 권장)
-
-#### 계층별 Read Model
-
-| 계층 | 패키지 | 명명 규칙 | 용도 |
-|------|--------|----------|------|
-| 도메인 | `application/model/` | `*ReadModel` | 서비스 반환값, 조회 결과 |
-| API | `controller/*/response/` | `*Response` | API 응답 전용 |
-| 영속성 | `repository/*/dto/` | `*DTO` | QueryDSL 조회 결과 |
-
-#### Read Model 생성 방식
-
-- **팩토리 메서드** (권장): `SummonerReadModel.of(Summoner)` - Builder 패턴으로 도메인→ReadModel 변환
-- **Java Record**: 조회 결과용 불변 객체 (예: `CurrentGameInfoReadModel`)
-- **QueryDSL Projection**: `@QueryProjection` 생성자로 DB→DTO 직접 매핑
-
-### 패키지 명명 규칙
-
-- 도메인: `com.example.lolserver.domain.{domainName}`
-- 도메인 포트: `com.example.lolserver.domain.{domainName}.application.port`
-- 인프라 어댑터: `com.example.lolserver.repository.{domainName}.adapter`
-- 인프라 매퍼: `com.example.lolserver.repository.{domainName}.mapper`
-- 컨트롤러: `com.example.lolserver.controller.{domainName}`
-- 컨트롤러 응답: `com.example.lolserver.controller.{domainName}.response`
-- 컨트롤러 매퍼: `com.example.lolserver.controller.{domainName}.mapper`
-
-### 클래스 작성요령
-
-| 계층 | 접미사 | 예시 | 위치 |
-|------|--------|------|------|
-| 도메인 ReadModel | `*ReadModel` | `GameReadModel` | `application/model/` |
-| 컨트롤러 응답 | `*Response` | `SliceResponse` | `controller/*/response/` |
-| 영속성 DTO | `*DTO` | `MSChampionDTO` | `repository/*/dto/` |
-| 엔티티 | `*Entity` | `MatchEntity` | `repository/*/entity/` |
-| 커맨드 | `*Command` | `MatchCommand` | `application/command/` |
+| 계층 | 접미사 | 예시 | 패키지 |
+|------|--------|------|--------|
+| 도메인 ReadModel | `*ReadModel` | `GameReadModel` | `domain.{name}.application.model` |
+| 컨트롤러 응답 | `*Response` | `SliceResponse` | `controller.{name}.response` |
+| 영속성 DTO | `*DTO` | `MSChampionDTO` | `repository.{name}.dto` |
+| 엔티티 | `*Entity` | `MatchEntity` | `repository.{name}.entity` |
+| 어댑터 | `*Adapter` | `MatchPersistenceAdapter` | `repository.{name}.adapter` |
+| 매퍼 | `*Mapper` | `MatchMapper` | `repository.{name}.mapper` |
+| 커맨드 | `*Command` | `MatchCommand` | `domain.{name}.application.command` |
 
 ### API 응답 래퍼 패턴
 
@@ -158,25 +122,13 @@ module/
 
 ### 비동기 쿼리 실행 패턴
 
-- `AsyncQueryConfig`에서 `Executors.newVirtualThreadPerTaskExecutor()` 빈 등록 (`@Qualifier("queryExecutor")`)
-- 대용량 데이터 조합 시 `CompletableFuture.supplyAsync()`로 병렬 쿼리 실행 후 `allOf().join()`
-- `@LogExecutionTime` AOP 어노테이션으로 메서드 실행 시간 로깅 가능
+- Virtual Thread 기반 병렬 쿼리 실행 (`CompletableFuture.supplyAsync()` + `queryExecutor` 빈)
+- `@LogExecutionTime` AOP 어노테이션으로 메서드 실행 시간 로깅
 
 ### Git 워크플로우
 
-**브랜치 전략**: Git Flow 변형 (`main` / `develop` / feature 브랜치)
-
-| 브랜치 | 용도 |
-|--------|------|
-| `main` | 프로덕션 릴리스 |
-| `develop` | 개발 통합 브랜치 |
-| `feature/*` | 새 기능 개발 |
-| `fix/*` | 버그 수정 |
-| `refactor/*` | 리팩토링 |
-| `hotfix/*` | 프로덕션 긴급 수정 |
-
-**기본 플로우**: `feature/* → develop → main`
-**Hotfix 플로우**: `hotfix/* → main → develop 역반영`
+**브랜치 전략**: Git Flow 변형 — `feature/*`, `fix/*`, `refactor/*` → `develop` → `main`
+**Hotfix 플로우**: `hotfix/*` → `main` → `develop` 역반영
 
 ### 커밋 메시지 컨벤션
 
@@ -194,7 +146,4 @@ Riot API 키 설정: `riot.api.key` 속성
 
 ### 참조 문서
 
-TDD 진행 시 다음 스킬을 참조하여 패턴 준수:
-- `.claude/skills/test-driven-development/SKILL.md` - TDD 워크플로우 및 패턴
-- `.claude/skills/test-driven-development/testing-anti-patterns.md` - 테스트 안티패턴
 - `.claude/skills/build-validator/SKILL.md` - 빌드 오류 분석

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/member/application/model/OAuthUserInfo.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/member/application/model/OAuthUserInfo.java
@@ -2,9 +2,11 @@ package com.example.lolserver.domain.member.application.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 public class OAuthUserInfo {
 
     private String provider;

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/auth/AuthController.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/auth/AuthController.java
@@ -1,17 +1,18 @@
 package com.example.lolserver.controller.auth;
 
-import com.example.lolserver.controller.auth.request.TokenRefreshRequest;
-import com.example.lolserver.controller.auth.response.AuthTokenResponse;
+import com.example.lolserver.controller.auth.config.AuthCookieManager;
 import com.example.lolserver.controller.security.AuthenticatedMember;
 import com.example.lolserver.controller.support.response.ApiResponse;
 import com.example.lolserver.domain.member.application.dto.TokenRefreshCommand;
 import com.example.lolserver.domain.member.application.model.AuthTokenReadModel;
 import com.example.lolserver.domain.member.application.port.in.MemberAuthUseCase;
-import jakarta.validation.Valid;
+import com.example.lolserver.support.error.CoreException;
+import com.example.lolserver.support.error.ErrorType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,22 +22,30 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final MemberAuthUseCase memberAuthUseCase;
+    private final AuthCookieManager authCookieManager;
 
     @PostMapping("/refresh")
-    public ApiResponse<AuthTokenResponse> refreshToken(
-            @Valid @RequestBody TokenRefreshRequest request) {
+    public ApiResponse<?> refreshToken(
+            HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = authCookieManager.extractRefreshToken(request);
+        if (refreshToken == null) {
+            throw new CoreException(ErrorType.INVALID_TOKEN);
+        }
         TokenRefreshCommand command = TokenRefreshCommand.builder()
-                .refreshToken(request.refreshToken())
+                .refreshToken(refreshToken)
                 .build();
 
         AuthTokenReadModel result = memberAuthUseCase.refreshToken(command);
-        return ApiResponse.success(AuthTokenResponse.from(result));
+        authCookieManager.addAuthCookies(response, result);
+        return ApiResponse.success();
     }
 
     @PostMapping("/logout")
     public ApiResponse<?> logout(
-            @AuthenticationPrincipal AuthenticatedMember member) {
+            @AuthenticationPrincipal AuthenticatedMember member,
+            HttpServletResponse response) {
         memberAuthUseCase.logout(member.memberId());
+        authCookieManager.clearAuthCookies(response);
         return ApiResponse.success();
     }
 }

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/auth/config/AuthCookieManager.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/auth/config/AuthCookieManager.java
@@ -1,0 +1,87 @@
+package com.example.lolserver.controller.auth.config;
+
+import com.example.lolserver.controller.security.JwtProperties;
+import com.example.lolserver.domain.member.application.model.AuthTokenReadModel;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class AuthCookieManager {
+
+    private static final String ACCESS_TOKEN_COOKIE = "accessToken";
+    private static final String REFRESH_TOKEN_COOKIE = "refreshToken";
+
+    private final JwtProperties jwtProperties;
+    private final CookieProperties cookieProperties;
+
+    public void addAuthCookies(HttpServletResponse response, AuthTokenReadModel tokenReadModel) {
+        addCookie(response, ACCESS_TOKEN_COOKIE, tokenReadModel.accessToken(),
+                "/", (int) jwtProperties.getAccessTokenExpiry());
+        addCookie(response, REFRESH_TOKEN_COOKIE, tokenReadModel.refreshToken(),
+                "/api/auth/refresh", (int) jwtProperties.getRefreshTokenExpiry());
+    }
+
+    public void clearAuthCookies(HttpServletResponse response) {
+        deleteCookie(response, ACCESS_TOKEN_COOKIE, "/");
+        deleteCookie(response, REFRESH_TOKEN_COOKIE, "/api/auth/refresh");
+    }
+
+    public String extractAccessToken(HttpServletRequest request) {
+        return extractCookieValue(request, ACCESS_TOKEN_COOKIE);
+    }
+
+    public String extractRefreshToken(HttpServletRequest request) {
+        return extractCookieValue(request, REFRESH_TOKEN_COOKIE);
+    }
+
+    private void addCookie(HttpServletResponse response, String name, String value, String path, int maxAge) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(cookieProperties.isSecure())
+                .sameSite(cookieProperties.getSameSite())
+                .path(path)
+                .maxAge(maxAge);
+
+        String domain = cookieProperties.getDomain();
+        if (domain != null && !domain.isBlank()) {
+            builder.domain(domain);
+        }
+
+        response.addHeader(HttpHeaders.SET_COOKIE, builder.build().toString());
+    }
+
+    private void deleteCookie(HttpServletResponse response, String name, String path) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(cookieProperties.isSecure())
+                .sameSite(cookieProperties.getSameSite())
+                .path(path)
+                .maxAge(0);
+
+        String domain = cookieProperties.getDomain();
+        if (domain != null && !domain.isBlank()) {
+            builder.domain(domain);
+        }
+
+        response.addHeader(HttpHeaders.SET_COOKIE, builder.build().toString());
+    }
+
+    private String extractCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+        return Arrays.stream(request.getCookies())
+                .filter(c -> name.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/auth/config/CookieProperties.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/auth/config/CookieProperties.java
@@ -1,0 +1,16 @@
+package com.example.lolserver.controller.auth.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cookie")
+public class CookieProperties {
+    private boolean secure = true;
+    private String sameSite = "Lax";
+    private String domain = "";
+}

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/auth/request/TokenRefreshRequest.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/auth/request/TokenRefreshRequest.java
@@ -1,8 +1,0 @@
-package com.example.lolserver.controller.auth.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record TokenRefreshRequest(
-        @NotBlank String refreshToken
-) {
-}

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/member/MemberController.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/member/MemberController.java
@@ -2,7 +2,6 @@ package com.example.lolserver.controller.member;
 
 import com.example.lolserver.controller.member.request.NicknameUpdateRequest;
 import com.example.lolserver.controller.member.response.MemberResponse;
-import com.example.lolserver.controller.member.response.SocialAccountLinkResponse;
 import com.example.lolserver.controller.security.AuthenticatedMember;
 import com.example.lolserver.controller.security.SocialAccountLinkTokenStore;
 import com.example.lolserver.controller.support.response.ApiResponse;
@@ -13,8 +12,10 @@ import com.example.lolserver.domain.member.application.port.in.MemberCommandUseC
 import com.example.lolserver.domain.member.application.port.in.MemberQueryUseCase;
 import com.example.lolserver.support.error.CoreException;
 import com.example.lolserver.support.error.ErrorType;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,8 +25,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.io.IOException;
 import java.util.Set;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
@@ -62,9 +65,10 @@ public class MemberController {
     }
 
     @GetMapping("/me/social-accounts/link/{provider}")
-    public ApiResponse<SocialAccountLinkResponse> initSocialAccountLink(
+    public void initSocialAccountLink(
             @AuthenticationPrincipal AuthenticatedMember member,
-            @PathVariable String provider) {
+            @PathVariable String provider,
+            HttpServletResponse response) throws IOException {
         String registrationId = provider.toLowerCase();
         if (!SUPPORTED_PROVIDERS.contains(registrationId)) {
             throw new CoreException(ErrorType.OAUTH_LOGIN_FAILED);
@@ -75,8 +79,7 @@ public class MemberController {
         String redirectUrl = "/oauth2/authorize/" + registrationId
                 + "?link_token=" + linkToken;
 
-        return ApiResponse.success(
-                new SocialAccountLinkResponse(redirectUrl));
+        response.sendRedirect(redirectUrl);
     }
 
     @DeleteMapping("/me/social-accounts/{socialAccountId}")

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/member/response/SocialAccountLinkResponse.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/member/response/SocialAccountLinkResponse.java
@@ -1,4 +1,0 @@
-package com.example.lolserver.controller.member.response;
-
-public record SocialAccountLinkResponse(String redirectUrl) {
-}

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/security/JwtAuthenticationFilter.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.example.lolserver.controller.security;
 
+import com.example.lolserver.controller.auth.config.AuthCookieManager;
 import com.example.lolserver.domain.member.application.port.out.TokenPort;
 import com.example.lolserver.domain.member.application.port.out.TokenPort.TokenInfo;
 import jakarta.servlet.FilterChain;
@@ -33,6 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     );
 
     private final TokenPort tokenPort;
+    private final AuthCookieManager authCookieManager;
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
@@ -76,6 +78,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(BEARER_PREFIX.length());
         }
-        return null;
+        return authCookieManager.extractAccessToken(request);
     }
 }

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/security/OAuth2AuthenticationSuccessHandler.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/security/OAuth2AuthenticationSuccessHandler.java
@@ -80,6 +80,7 @@ public class OAuth2AuthenticationSuccessHandler
             }
 
             OAuthUserInfo userInfo = extractor.extract(oauth2User);
+            log.info("userInfo: {}", userInfo);
 
             Long linkMemberId = extractLinkMemberId(request);
             if (linkMemberId != null) {

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/security/OAuth2AuthenticationSuccessHandler.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/security/OAuth2AuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package com.example.lolserver.controller.security;
 
+import com.example.lolserver.controller.auth.config.AuthCookieManager;
 import com.example.lolserver.controller.auth.config.OAuthCallbackProperties;
 import com.example.lolserver.controller.security.oauth2.OAuth2UserInfoExtractor;
 import com.example.lolserver.domain.member.application.model.AuthTokenReadModel;
@@ -35,13 +36,15 @@ public class OAuth2AuthenticationSuccessHandler
     private final CookieOAuth2AuthorizationRequestRepository
             authorizationRequestRepository;
     private final Map<String, OAuth2UserInfoExtractor> extractors;
+    private final AuthCookieManager authCookieManager;
 
     public OAuth2AuthenticationSuccessHandler(
             MemberAuthUseCase memberAuthUseCase,
             OAuthCallbackProperties oAuthCallbackProperties,
             CookieOAuth2AuthorizationRequestRepository
                     authorizationRequestRepository,
-            List<OAuth2UserInfoExtractor> extractorList) {
+            List<OAuth2UserInfoExtractor> extractorList,
+            AuthCookieManager authCookieManager) {
         this.memberAuthUseCase = memberAuthUseCase;
         this.oAuthCallbackProperties = oAuthCallbackProperties;
         this.authorizationRequestRepository =
@@ -50,6 +53,7 @@ public class OAuth2AuthenticationSuccessHandler
                 .collect(Collectors.toMap(
                         OAuth2UserInfoExtractor::getRegistrationId,
                         Function.identity()));
+        this.authCookieManager = authCookieManager;
     }
 
     @Override
@@ -85,7 +89,9 @@ public class OAuth2AuthenticationSuccessHandler
             } else {
                 AuthTokenReadModel result =
                         memberAuthUseCase.loginWithOAuthUserInfo(userInfo);
-                response.sendRedirect(buildTokenRedirectUrl(result));
+                authCookieManager.addAuthCookies(response, result);
+                response.sendRedirect(
+                        oAuthCallbackProperties.getFrontendCallbackUrl());
             }
         } catch (CoreException e) {
             log.error("OAuth2 처리 중 오류: {}", e.getMessage());
@@ -115,16 +121,6 @@ public class OAuth2AuthenticationSuccessHandler
             return null;
         }
         return Long.valueOf(memberId.toString());
-    }
-
-    private String buildTokenRedirectUrl(AuthTokenReadModel result) {
-        return UriComponentsBuilder
-                .fromUriString(
-                        oAuthCallbackProperties.getFrontendCallbackUrl())
-                .fragment("accessToken=" + result.accessToken()
-                        + "&refreshToken=" + result.refreshToken()
-                        + "&expiresIn=" + result.expiresIn())
-                .build().toUriString();
     }
 
     private String buildLinkSuccessRedirectUrl() {

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/security/oauth2/RiotOAuth2UserInfoExtractor.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/security/oauth2/RiotOAuth2UserInfoExtractor.java
@@ -20,7 +20,7 @@ public class RiotOAuth2UserInfoExtractor
         Map<String, Object> attributes = oauth2User.getAttributes();
         return OAuthUserInfo.builder()
                 .provider("RIOT")
-                .providerId((String) attributes.get("puuid"))
+                .providerId((String) attributes.get("sub"))
                 .build();
     }
 }

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/security/oauth2/RiotOAuth2UserInfoExtractor.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/security/oauth2/RiotOAuth2UserInfoExtractor.java
@@ -20,7 +20,7 @@ public class RiotOAuth2UserInfoExtractor
         Map<String, Object> attributes = oauth2User.getAttributes();
         return OAuthUserInfo.builder()
                 .provider("RIOT")
-                .providerId((String) attributes.get("sub"))
+                .providerId((String) attributes.get("puuid"))
                 .build();
     }
 }

--- a/module/infra/api/src/main/resources/api-local.yml
+++ b/module/infra/api/src/main/resources/api-local.yml
@@ -58,3 +58,7 @@ cors:
     - http://localhost:8080
     - http://lol-ui:3000
     - https://metapick.me
+
+cookie:
+  secure: false
+  same-site: Lax

--- a/module/infra/api/src/test/java/com/example/lolserver/controller/auth/config/AuthCookieManagerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/controller/auth/config/AuthCookieManagerTest.java
@@ -1,0 +1,151 @@
+package com.example.lolserver.controller.auth.config;
+
+import com.example.lolserver.controller.security.JwtProperties;
+import com.example.lolserver.domain.member.application.model.AuthTokenReadModel;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("AuthCookieManager 테스트")
+class AuthCookieManagerTest {
+
+    private AuthCookieManager authCookieManager;
+
+    @BeforeEach
+    void setUp() {
+        JwtProperties jwtProperties = new JwtProperties();
+        jwtProperties.setSecretKey("test-secret-key");
+        jwtProperties.setAccessTokenExpiry(1800L);
+        jwtProperties.setRefreshTokenExpiry(604800L);
+
+        CookieProperties cookieProperties = new CookieProperties();
+        cookieProperties.setSecure(true);
+        cookieProperties.setSameSite("Lax");
+        cookieProperties.setDomain("");
+
+        authCookieManager = new AuthCookieManager(jwtProperties, cookieProperties);
+    }
+
+    @DisplayName("addAuthCookies - accessToken, refreshToken 쿠키가 올바른 속성으로 설정된다")
+    @Test
+    void addAuthCookies() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        AuthTokenReadModel tokenReadModel = new AuthTokenReadModel("access-token-value", "refresh-token-value", 1800);
+
+        // when
+        authCookieManager.addAuthCookies(response, tokenReadModel);
+
+        // then
+        List<String> setCookieHeaders = response.getHeaders("Set-Cookie");
+        assertThat(setCookieHeaders).hasSize(2);
+
+        String accessCookie = setCookieHeaders.stream()
+                .filter(c -> c.startsWith("accessToken="))
+                .findFirst()
+                .orElse(null);
+        assertThat(accessCookie).isNotNull();
+        assertThat(accessCookie).contains("accessToken=access-token-value");
+        assertThat(accessCookie).contains("HttpOnly");
+        assertThat(accessCookie).contains("Secure");
+        assertThat(accessCookie).contains("Path=/");
+        assertThat(accessCookie).contains("Max-Age=1800");
+        assertThat(accessCookie).contains("SameSite=Lax");
+
+        String refreshCookie = setCookieHeaders.stream()
+                .filter(c -> c.startsWith("refreshToken="))
+                .findFirst()
+                .orElse(null);
+        assertThat(refreshCookie).isNotNull();
+        assertThat(refreshCookie).contains("refreshToken=refresh-token-value");
+        assertThat(refreshCookie).contains("HttpOnly");
+        assertThat(refreshCookie).contains("Secure");
+        assertThat(refreshCookie).contains("Path=/api/auth/refresh");
+        assertThat(refreshCookie).contains("Max-Age=604800");
+        assertThat(refreshCookie).contains("SameSite=Lax");
+    }
+
+    @DisplayName("clearAuthCookies - Max-Age=0으로 삭제 쿠키가 설정된다")
+    @Test
+    void clearAuthCookies() {
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        authCookieManager.clearAuthCookies(response);
+
+        // then
+        List<String> setCookieHeaders = response.getHeaders("Set-Cookie");
+        assertThat(setCookieHeaders).hasSize(2);
+
+        String accessCookie = setCookieHeaders.stream()
+                .filter(c -> c.startsWith("accessToken="))
+                .findFirst()
+                .orElse(null);
+        assertThat(accessCookie).isNotNull();
+        assertThat(accessCookie).contains("Max-Age=0");
+        assertThat(accessCookie).contains("Path=/");
+
+        String refreshCookie = setCookieHeaders.stream()
+                .filter(c -> c.startsWith("refreshToken="))
+                .findFirst()
+                .orElse(null);
+        assertThat(refreshCookie).isNotNull();
+        assertThat(refreshCookie).contains("Max-Age=0");
+        assertThat(refreshCookie).contains("Path=/api/auth/refresh");
+    }
+
+    @DisplayName("extractAccessToken - 쿠키에서 accessToken을 올바르게 추출한다")
+    @Test
+    void extractAccessToken() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(
+                new Cookie("accessToken", "my-access-token"),
+                new Cookie("refreshToken", "my-refresh-token")
+        );
+
+        // when
+        String result = authCookieManager.extractAccessToken(request);
+
+        // then
+        assertThat(result).isEqualTo("my-access-token");
+    }
+
+    @DisplayName("extractRefreshToken - 쿠키에서 refreshToken을 올바르게 추출한다")
+    @Test
+    void extractRefreshToken() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(
+                new Cookie("accessToken", "my-access-token"),
+                new Cookie("refreshToken", "my-refresh-token")
+        );
+
+        // when
+        String result = authCookieManager.extractRefreshToken(request);
+
+        // then
+        assertThat(result).isEqualTo("my-refresh-token");
+    }
+
+    @DisplayName("extractAccessToken - 쿠키가 없을 때 null을 반환한다")
+    @Test
+    void extractAccessTokenWhenNoCookies() {
+        // given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        // when
+        String result = authCookieManager.extractAccessToken(request);
+
+        // then
+        assertThat(result).isNull();
+    }
+}

--- a/module/infra/api/src/test/java/com/example/lolserver/controller/security/SecurityConfigTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/controller/security/SecurityConfigTest.java
@@ -1,5 +1,7 @@
 package com.example.lolserver.controller.security;
 
+import com.example.lolserver.controller.auth.config.AuthCookieManager;
+import com.example.lolserver.controller.auth.config.CookieProperties;
 import com.example.lolserver.controller.security.oauth2.CustomOidcUserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -56,8 +58,12 @@ class SecurityConfigTest {
                 "http://localhost:3000", "http://localhost:8080",
                 "http://lol-ui:3000", "https://metapick.me"));
 
+        CookieProperties cookieProperties = new CookieProperties();
+        AuthCookieManager authCookieManager =
+                new AuthCookieManager(jwtProperties, cookieProperties);
+
         JwtAuthenticationFilter filter =
-                new JwtAuthenticationFilter(jwtTokenAdapter);
+                new JwtAuthenticationFilter(jwtTokenAdapter, authCookieManager);
 
         securityConfig = new SecurityConfig(
                 filter, corsProperties,

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/AuthControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/AuthControllerTest.java
@@ -1,12 +1,12 @@
 package com.example.lolserver.docs.controller;
 
 import com.example.lolserver.controller.auth.AuthController;
-import com.example.lolserver.controller.auth.request.TokenRefreshRequest;
+import com.example.lolserver.controller.auth.config.AuthCookieManager;
 import com.example.lolserver.docs.RestDocsSupport;
 import com.example.lolserver.docs.TestAuthenticatedMemberResolver;
 import com.example.lolserver.domain.member.application.model.AuthTokenReadModel;
 import com.example.lolserver.domain.member.application.port.in.MemberAuthUseCase;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,11 +34,12 @@ class AuthControllerTest extends RestDocsSupport {
     @Mock
     private MemberAuthUseCase memberAuthUseCase;
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Mock
+    private AuthCookieManager authCookieManager;
 
     @Override
     protected Object initController() {
-        return new AuthController(memberAuthUseCase);
+        return new AuthController(memberAuthUseCase, authCookieManager);
     }
 
     @Override
@@ -52,32 +53,26 @@ class AuthControllerTest extends RestDocsSupport {
     void refreshToken() throws Exception {
         // given
         AuthTokenReadModel tokenReadModel = new AuthTokenReadModel(
-                "eyJhbGciOiJIUzI1NiJ9.new-access-token",
-                "eyJhbGciOiJIUzI1NiJ9.new-refresh-token",
+                "test-access-token",
+                "test-refresh-token",
                 3600
         );
 
+        given(authCookieManager.extractRefreshToken(any()))
+                .willReturn("test-refresh-token");
         given(memberAuthUseCase.refreshToken(any())).willReturn(tokenReadModel);
-
-        TokenRefreshRequest request = new TokenRefreshRequest(
-                "eyJhbGciOiJIUzI1NiJ9.refresh-token");
 
         // when & then
         mockMvc.perform(
                         post("/api/auth/refresh")
                                 .contentType(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(request))
+                                .cookie(new Cookie("refreshToken", "test-refresh-token"))
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("auth-refresh",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
-                        requestFields(
-                                fieldWithPath("refreshToken")
-                                        .type(JsonFieldType.STRING)
-                                        .description("갱신할 리프레시 토큰")
-                        ),
                         responseFields(
                                 fieldWithPath("result")
                                         .type(JsonFieldType.STRING)
@@ -87,18 +82,9 @@ class AuthControllerTest extends RestDocsSupport {
                                         .type(JsonFieldType.NULL)
                                         .description(
                                                 "에러 메시지 (정상 응답 시 null)"),
-                                fieldWithPath("data.accessToken")
-                                        .type(JsonFieldType.STRING)
-                                        .description(
-                                                "새로 발급된 JWT 액세스 토큰"),
-                                fieldWithPath("data.refreshToken")
-                                        .type(JsonFieldType.STRING)
-                                        .description(
-                                                "새로 발급된 JWT 리프레시 토큰"),
-                                fieldWithPath("data.expiresIn")
-                                        .type(JsonFieldType.NUMBER)
-                                        .description(
-                                                "액세스 토큰 만료 시간 (초)")
+                                fieldWithPath("data")
+                                        .type(JsonFieldType.NULL)
+                                        .description("데이터 없음")
                         )
                 ));
     }
@@ -108,6 +94,7 @@ class AuthControllerTest extends RestDocsSupport {
     void logout() throws Exception {
         // given
         willDoNothing().given(memberAuthUseCase).logout(eq(1L));
+        willDoNothing().given(authCookieManager).clearAuthCookies(any());
 
         // when & then
         mockMvc.perform(

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/MemberControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/MemberControllerTest.java
@@ -36,6 +36,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("MemberController 테스트")
@@ -215,24 +216,16 @@ class MemberControllerTest extends RestDocsSupport {
         // when & then
         mockMvc.perform(
                         get("/api/members/me/social-accounts/link/{provider}", "google")
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
-                .andExpect(status().isOk())
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern("/oauth2/authorize/google?link_token=*"))
                 .andDo(document("member-link-social-account",
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         pathParameters(
                                 parameterWithName("provider")
                                         .description("소셜 프로바이더 (google, riot)")
-                        ),
-                        responseFields(
-                                fieldWithPath("result").type(JsonFieldType.STRING)
-                                        .description("API 응답 결과 (SUCCESS, ERROR)"),
-                                fieldWithPath("errorMessage").type(JsonFieldType.NULL)
-                                        .description("에러 메시지 (정상 응답 시 null)"),
-                                fieldWithPath("data.redirectUrl").type(JsonFieldType.STRING)
-                                        .description("OAuth 인가 페이지 리다이렉트 URL")
                         )
                 ));
     }


### PR DESCRIPTION
## Summary
- Read Model 패턴/패키지 명명/클래스 작성요령 3개 섹션을 **클래스 명명 규칙** 테이블 하나로 통합
- 하드코딩된 도메인 목록 제거 → 디렉토리 경로 참조로 변경
- Git 브랜치 테이블을 2줄 요약으로 압축
- 비동기 쿼리 패턴 구현 디테일 제거, 핵심만 유지
- 존재하지 않는 TDD 스킬 파일 참조 삭제
- RestDocs 오타(`/`) 수정
- 200줄 → 148줄로 감소

## Test plan
- [ ] CLAUDE.md 내용이 프로젝트 구조와 일치하는지 확인
- [ ] 깨진 참조 링크가 없는지 확인