### PR TITLE
[MP-16] chore: AI-ready audit ROI 후속 조치 (B2/E4/F)

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - '**/*.md'
       - '.github/workflows/docs-check.yml'
+  schedule:
+    # Weekly Monday 09:00 UTC — surfaces stale CLAUDE.md on code-only PRs
+    # by running independently of doc changes.
+    - cron: '0 9 * * 1'
   workflow_dispatch:
 
 jobs:
@@ -73,7 +77,6 @@ jobs:
           set -euo pipefail
           STALE_DAYS=180
           now=$(date +%s)
-          stale=0
           while IFS= read -r f; do
             ts=$(git log -1 --format=%ct -- "$f" 2>/dev/null || echo "")
             if [ -z "$ts" ]; then
@@ -83,9 +86,7 @@ jobs:
             age=$(( (now - ts) / 86400 ))
             if [ "$age" -gt "$STALE_DAYS" ]; then
               echo "::warning file=$f::CLAUDE.md last touched ${age}d ago (threshold ${STALE_DAYS}d). Quarterly review overdue — verify it still matches the code."
-              stale=$((stale + 1))
             else
               echo "ok  $f (${age}d)"
             fi
           done < <(git ls-files '**/CLAUDE.md' 'CLAUDE.md')
-          echo "stale_count=$stale"

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -58,3 +58,34 @@ jobs:
             fi
           done < <(git ls-files '**/CLAUDE.md' 'CLAUDE.md')
           exit $fail
+
+  context-doc-freshness:
+    name: CLAUDE.md Freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Warn on stale CLAUDE.md (>180d)
+        shell: bash
+        run: |
+          set -euo pipefail
+          STALE_DAYS=180
+          now=$(date +%s)
+          stale=0
+          while IFS= read -r f; do
+            ts=$(git log -1 --format=%ct -- "$f" 2>/dev/null || echo "")
+            if [ -z "$ts" ]; then
+              echo "skip $f (no git history)"
+              continue
+            fi
+            age=$(( (now - ts) / 86400 ))
+            if [ "$age" -gt "$STALE_DAYS" ]; then
+              echo "::warning file=$f::CLAUDE.md last touched ${age}d ago (threshold ${STALE_DAYS}d). Quarterly review overdue — verify it still matches the code."
+              stale=$((stale + 1))
+            else
+              echo "ok  $f (${age}d)"
+            fi
+          done < <(git ls-files '**/CLAUDE.md' 'CLAUDE.md')
+          echo "stale_count=$stale"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — 모듈 의존 그래프 + 데이터 흐름 (mermaid) + 변경 영향 표
 - [`docs/workflow.md`](docs/workflow.md) — Linear(`MP-*`) 키 기반 브랜치/커밋/이슈 생명주기
+- [`docs/docs-maintenance.md`](docs/docs-maintenance.md) — CLAUDE.md/문서 동기화 절차 (PR 시점 / 분기 리뷰 / CI 게이트)
 - `docs/oauth2-login.md`, `docs/rso-oauth2-troubleshooting.md` — OAuth/RSO 흐름 디테일
 - `docs/0[1-4]_*.sql` — ClickHouse 스키마 정의/뷰/쿼리
 - `docs/review/` — 과거 리팩터링/리뷰 메모

--- a/docs/docs-maintenance.md
+++ b/docs/docs-maintenance.md
@@ -1,0 +1,61 @@
+# 문서 유지보수 절차
+
+CLAUDE.md, ARCHITECTURE.md, `docs/*.md` 같은 AI/팀 공유 문서가 코드와 동기화되도록 유지하는 규칙. AI agent (Claude Code) 가 잘못된 가정을 내리지 않게 하는 게 목적.
+
+## 1. PR 시점 — 영향받는 문서를 함께 수정
+
+코드 변경이 다음 중 하나에 해당하면 **같은 PR** 안에서 관련 CLAUDE.md/문서를 수정한다. 별도 PR 로 미루지 않는다.
+
+| 변경 종류 | 같이 수정해야 하는 문서 |
+|---|---|
+| 새 모듈 추가 / 모듈 이동 / 모듈 제거 | 루트 `CLAUDE.md` 모듈 테이블, `docs/ARCHITECTURE.md` 의존 그래프 |
+| 모듈 내부 구조 (Layout/Key Files) 변화 | 해당 모듈 `CLAUDE.md` Layout / Key Files |
+| out port / in port 신설·시그니처 변경 | 도메인측 + 어댑터측 양쪽 모듈 CLAUDE.md (Cross-Module Dependencies) |
+| 새 빌드/테스트 명령 추가 (gradle task, asciidoctor 등) | 해당 모듈 `Quick Commands` |
+| 자주 밟는 함정/회귀가 새로 드러남 | 해당 모듈 `Failure Patterns / Gotchas` (❌/✅ 패턴) |
+| 신규 외부 의존성 (broker, DB, OAuth provider 등) | 해당 모듈 `Boundaries` 허용/금지 목록 + `application.yml` 카탈로그 |
+
+원칙: 코드 PR 의 리뷰어는 위 표 기준으로 **doc 누락도 review comment** 로 남길 책임이 있다.
+
+## 2. 분기별 정기 리뷰 (3·6·9·12 월 마지막 영업일)
+
+담당: 모듈 owner (없으면 가장 최근 커밋자).
+
+체크리스트:
+
+1. `gh pr list --state merged --search "merged:>$(date -d '3 months ago' +%Y-%m-%d)"` 로 머지된 PR 훑고 doc 미반영분 캡처
+2. 각 모듈 CLAUDE.md 의 Key Files / Layout 이 실제 디렉토리 구조와 일치하는지 `tree -L 3` 비교
+3. Failure Patterns 의 ❌/✅ 가 여전히 유효한지 (이미 수정된 함정은 제거, 새 함정은 추가)
+4. broken refs 확인: `python3 ~/.claude-marketplaces/local/plugins/ai-ready-audit/skills/audit-codebase/scripts/audit.py . --pretty | jq '.signals.broken_path_refs_in_docs'`
+5. 의심 모듈 1개 골라서 `/ai-ready-audit:audit-codebase` 재실행 — 점수 회귀 여부 확인
+
+분기 리뷰 결과는 `chore/MP-<번호>-quarterly-doc-review` 브랜치 + PR 한 건으로 묶는다.
+
+## 3. 자동 게이트 (CI)
+
+`.github/workflows/docs-check.yml` 가 PR 단위로 다음을 검증한다:
+
+| Job | 검증 | 실패 시 |
+|---|---|---|
+| `link-check` | lychee 로 `**/*.md` 파일 링크 — 깨진 file/URL refs | PR 차단 (`fail: true`) |
+| `context-doc-lint` | 모든 CLAUDE.md 가 80줄 이하 ("compass, not encyclopedia") | PR 차단 |
+| `context-doc-freshness` | CLAUDE.md 가 180일 넘게 미수정이면 `::warning` | 경고만 (차단 안 함) |
+
+freshness 경고가 PR 에 떴다면 분기 리뷰가 밀린 것 — section 2 절차 트리거.
+
+## 4. 신규 모듈 체크리스트
+
+새 Gradle 모듈 (`module/<layer>/<name>`) 추가 시:
+
+- [ ] `module/<layer>/<name>/CLAUDE.md` 작성 (기존 모듈 CLAUDE.md 구조 그대로 복사: Boundaries / Layout / Key Files / Common Modifications / Failure Patterns / Cross-Module Dependencies / Quick Commands / See Also)
+- [ ] 80줄 이내, 5질문 (owned/modification/failure/deps/tribal) 모두 답
+- [ ] 루트 `CLAUDE.md` 모듈 테이블에 한 줄 + `What to read first` 시나리오 갱신
+- [ ] `docs/ARCHITECTURE.md` 의존 그래프 mermaid 노드 추가 + 영향 범위 표 갱신
+- [ ] `settings.gradle` include + `app/application/build.gradle` implementation 추가
+
+## See Also
+
+- [`docs/workflow.md`](workflow.md) — Linear/Git 워크플로우 (브랜치/커밋/PR 규칙)
+- [`docs/ARCHITECTURE.md`](ARCHITECTURE.md) — 모듈 의존 그래프 + 데이터 플로우
+- [`.github/workflows/docs-check.yml`](../.github/workflows/docs-check.yml) — 자동 게이트 정의
+- 루트 [`CLAUDE.md`](../CLAUDE.md) — 진입점, 모듈 카탈로그

--- a/docs/docs-maintenance.md
+++ b/docs/docs-maintenance.md
@@ -39,9 +39,9 @@ CLAUDE.md, ARCHITECTURE.md, `docs/*.md` 같은 AI/팀 공유 문서가 코드와
 |---|---|---|
 | `link-check` | lychee 로 `**/*.md` 파일 링크 — 깨진 file/URL refs | PR 차단 (`fail: true`) |
 | `context-doc-lint` | 모든 CLAUDE.md 가 80줄 이하 ("compass, not encyclopedia") | PR 차단 |
-| `context-doc-freshness` | CLAUDE.md 가 180일 넘게 미수정이면 `::warning` | 경고만 (차단 안 함) |
+| `context-doc-freshness` | CLAUDE.md 가 180일 넘게 미수정이면 `::warning` (PR + 매주 월 09:00 UTC cron) | 경고만 (차단 안 함) |
 
-freshness 경고가 PR 에 떴다면 분기 리뷰가 밀린 것 — section 2 절차 트리거.
+freshness 경고가 PR 또는 주간 cron run 에 떴다면 분기 리뷰가 밀린 것 — section 2 절차 트리거. PR 트리거는 markdown 변경 PR 한정이라 코드-only PR 의 stale 신호는 cron run 으로만 잡힌다.
 
 ## 4. 신규 모듈 체크리스트
 

--- a/module/app/application/CLAUDE.md
+++ b/module/app/application/CLAUDE.md
@@ -50,6 +50,14 @@ Spring Boot 진입점 + 컴포지션 루트. **모든 인프라 모듈을 implem
 - consumed by: 없음 (terminal, bootJar 산출)
 - 빌드: `./gradlew bootRun -Dspring.profiles.active=local` — Postgres/Redis/RabbitMQ 등 Docker 서비스 필요
 
+## Quick Commands
+
+```bash
+./gradlew :module:app:application:bootRun -Dspring.profiles.active=local  # local 부트 (Docker 서비스 필요)
+./gradlew :module:app:application:bootJar                                 # 실행 가능 fat jar
+./gradlew :module:app:application:test                                    # 모듈 단위 테스트
+```
+
 ## See Also
 
 - [Root CLAUDE.md](../../../CLAUDE.md) — 전체 컴퍼스, build/run 명령어

--- a/module/infra/client/oauth/CLAUDE.md
+++ b/module/infra/client/oauth/CLAUDE.md
@@ -54,6 +54,13 @@ OAuth2 / RSO (Riot Sign-On) 어댑터 (driven adapter). Authorization URL 생성
 - consumed by: `app:application` (런타임 빈 주입)
 - 협력: `infra:persistence:redis` 의 `OAuthStateRedisAdapter` 가 state 토큰 저장/검증, `infra:api` 의 `OAuth2AuthenticationSuccessHandler` 가 이 어댑터들의 결과로 JWT 발급
 
+## Quick Commands
+
+```bash
+./gradlew :module:infra:client:oauth:test           # OAuth/RSO 어댑터 테스트
+./gradlew :module:infra:client:oauth:checkstyleMain # checkstyle 단독 실행
+```
+
 ## See Also
 
 - [core:lol-server-domain](../../../core/lol-server-domain/CLAUDE.md) — `domain/member/application/port/out/` 의 OAuth 관련 port

--- a/module/infra/message/kafka/CLAUDE.md
+++ b/module/infra/message/kafka/CLAUDE.md
@@ -47,6 +47,13 @@ Kafka 메시지 어댑터 (driven adapter). 도메인 `*MessagePort` (현재는 
 - consumed by: `app:application` (런타임 빈 주입, `message.broker=kafka` 일 때)
 - 형제: [infra:message:rabbitmq](../rabbitmq/CLAUDE.md) — 같은 port 의 다른 broker 구현체
 
+## Quick Commands
+
+```bash
+./gradlew :module:infra:message:kafka:test           # Kafka 어댑터 테스트 (broker 없이 mock 기반)
+./gradlew :module:infra:message:kafka:checkstyleMain # checkstyle 단독 실행
+```
+
 ## See Also
 
 - [core:lol-server-domain](../../../core/lol-server-domain/CLAUDE.md) — `domain/summoner/application/port/out/SummonerMessagePort`

--- a/module/infra/message/rabbitmq/CLAUDE.md
+++ b/module/infra/message/rabbitmq/CLAUDE.md
@@ -45,6 +45,13 @@ RabbitMQ 메시지 어댑터 (driven adapter). 도메인 `*MessagePort` (현재�
 - consumed by: `app:application` (런타임 빈 주입, 기본 broker)
 - 형제: [infra:message:kafka](../kafka/CLAUDE.md) — 같은 port 의 다른 broker 구현체
 
+## Quick Commands
+
+```bash
+./gradlew :module:infra:message:rabbitmq:test           # RabbitMQ 어댑터 테스트 (broker 없이 mock 기반)
+./gradlew :module:infra:message:rabbitmq:checkstyleMain # checkstyle 단독 실행
+```
+
 ## See Also
 
 - [core:lol-server-domain](../../../core/lol-server-domain/CLAUDE.md) — `domain/summoner/application/port/out/SummonerMessagePort`

--- a/module/infra/persistence/clickhouse/CLAUDE.md
+++ b/module/infra/persistence/clickhouse/CLAUDE.md
@@ -44,6 +44,13 @@ ClickHouse 분석 어댑터 (driven adapter). 챔피언 통계 (승률/픽률/�
 - consumed by: `app:application` 만 (다른 인프라 모듈은 직접 의존 안 함)
 - ClickHouse 데이터는 외부 ETL 파이프라인이 적재 — 이 모듈은 read-only
 
+## Quick Commands
+
+```bash
+./gradlew :module:infra:persistence:clickhouse:test           # 어댑터 테스트 (Testcontainers/ClickHouse 필요)
+./gradlew :module:infra:persistence:clickhouse:checkstyleMain # checkstyle 단독 실행
+```
+
 ## See Also
 
 - [core:lol-server-domain](../../../core/lol-server-domain/CLAUDE.md) — `domain/championstats/` 가 호출자

--- a/module/infra/persistence/redis/CLAUDE.md
+++ b/module/infra/persistence/redis/CLAUDE.md
@@ -53,6 +53,13 @@ Redis 어댑터 (driven adapter). 캐시, 세션 (Refresh Token, OAuth State), �
 - consumed by: `app:application` (런타임 빈 주입)
 - `infra:api` 는 직접 의존 안 하지만, JWT 인증 플로우가 `RefreshTokenPort` (이 모듈 구현체) 에 의존 — 빈이 빠지면 인증 깨짐
 
+## Quick Commands
+
+```bash
+./gradlew :module:infra:persistence:redis:test           # Redis 어댑터 테스트
+./gradlew :module:infra:persistence:redis:checkstyleMain # checkstyle 단독 실행
+```
+
 ## See Also
 
 - [core:lol-server-domain](../../../core/lol-server-domain/CLAUDE.md) — 캐시 port 의 출처


### PR DESCRIPTION
## Summary

2026-05-05 audit (72/100, AI-Assisted) ROI top 3 항목 일괄 적용. 예상 점수 72 → **77** (B2 +1, E4 +2, F +2).

- **B2 Quick Commands 보강**: 6개 모듈 CLAUDE.md (`oauth`, `redis`, `clickhouse`, `kafka`, `rabbitmq`, `app/application`) 에 `## Quick Commands` 섹션 추가. 모두 80줄 이내 유지.
- **E4 Freshness CI**: `.github/workflows/docs-check.yml` 에 `context-doc-freshness` job 추가 — CLAUDE.md 가 180일 넘게 미수정이면 `::warning` (PR 차단 X). 분기 리뷰 트리거 신호.
- **F 유지보수 절차 명문화**: `docs/docs-maintenance.md` 신규 — PR 시점 doc 동기화 표 / 분기 리뷰 체크리스트 / CI 게이트 정리 / 신규 모듈 추가 체크리스트.

## Test plan

- [ ] CI `link-check` (lychee) 통과 — 신규 `docs/docs-maintenance.md` 의 cross-link (`workflow.md`, `ARCHITECTURE.md`, `../.github/workflows/docs-check.yml`, `../CLAUDE.md`) 모두 유효
- [ ] CI `context-doc-lint` 통과 — 변경된 6개 모듈 CLAUDE.md 모두 80줄 이내 (58~69줄)
- [ ] CI `context-doc-freshness` 신규 job 정상 실행 — 현재 모든 CLAUDE.md 가 최근 수정이라 warning 0건 예상
- [ ] 머지 후 `/ai-ready-audit:audit-codebase` 재실행 → 총점 77 도달 확인

Closes MP-16

🤖 Generated by Padosol