### PR TITLE
[MP-13] fix: 챔피언 통계 BigQuery 정렬을 tier_score 기준으로 변경

### DIFF
--- a/module/infra/persistence/bigquery/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsBigQuerySqls.java
+++ b/module/infra/persistence/bigquery/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsBigQuerySqls.java
@@ -300,6 +300,7 @@ final class ChampionStatsBigQuerySqls {
                    COALESCE(ROUND(pick_rate, 4), 0)               AS pick_rate,
                    COALESCE(ROUND(ban_rate, 4), 0)                AS ban_rate,
                    pick_count                                     AS total_games,
+                   (0.6 * pct_wilson_wr + 0.4 * pct_presence)     AS tier_score,
                    CASE
                        WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.97 THEN 'S+'
                        WHEN 0.6 * pct_wilson_wr + 0.4 * pct_presence >= 0.90 THEN 'S'
@@ -309,7 +310,7 @@ final class ChampionStatsBigQuerySqls {
                        ELSE 'D'
                    END                                            AS tier
             FROM ranked
-            ORDER BY individual_position, pick_count DESC
+            ORDER BY individual_position, tier_score DESC
             """;
 
     private ChampionStatsBigQuerySqls() {


### PR DESCRIPTION
## 변경 유형
fix

## 변경 사항
- `ChampionStatsBigQuerySqls.STATS_BY_POSITION` 의 `ORDER BY` 를 `pick_count DESC` → `tier_score DESC` 로 변경
- SELECT 에 `tier_score` 컬럼 alias 노출 (`(0.6 * pct_wilson_wr + 0.4 * pct_presence)`)

## 변경 이유
`/api/v1/{platformId}/champion-stats/positions` 엔드포인트 응답에서 챔피언 목록이 tier 순으로 정렬되지 않던 버그(MP-13). 기존 SQL 의 `ORDER BY individual_position, pick_count DESC` 는 픽률 정렬이라 OP/S+ 티어 챔피언이 픽률 낮으면 아래로 밀려 UI 가 받는 응답 순서가 의도와 어긋남. tier 산정에 사용하는 동일한 표현식 `0.6 * pct_wilson_wr + 0.4 * pct_presence` 를 `tier_score` 로 alias 하고 그 기준으로 정렬해 tier 라벨과 순서 일관성 확보.

## 테스트
- [x] BigQuery adapter 단위 테스트 통과 (`./gradlew :module:infra:persistence:bigquery:test --tests ChampionStatsBigQueryAdapterTest` — 17s SUCCESS, 모든 케이스 그린)
- [ ] 단위 테스트 통과 (`./gradlew test`)
- [ ] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
- [ ] 로컬 빌드 확인 (`./gradlew build`)

## 리뷰 포인트
- SELECT 에 추가된 `tier_score` 컬럼은 row reader 에서 읽지 않아 ChampionRateReadModel 에 영향 없음 (호환성 유지)
- `(0.6 * pct_wilson_wr + 0.4 * pct_presence)` 표현식이 SELECT alias 와 CASE 내 둘 다 등장 — tier 산정 로직과 정렬 키가 같다는 invariant 가 명시적이지만 약간의 중복. 추후 ranked CTE 안으로 끌어내려 한 번만 정의하는 리팩터 가능
- ORDER BY 가 alias `tier_score` 를 참조하는 것은 BigQuery 표준 동작 (SELECT 후 정렬 시점에 alias 가시)

Closes MP-13

🤖 Generated by Padosol