### PR TITLE
[MP-9] feat: 챔피언 분석 페이지 데이터 보강 (pickRate/banRate/tier · 평균 통계 · 빌드 신뢰도 · timeline)

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -12,6 +12,9 @@
     <suppress files=".*DTO\.java$" checks="ParameterNumber"/>
     <suppress files=".*DTO\.java$" checks="LineLength"/>
 
+    <!-- ReadModel: 도메인 출력 record 의 다중 파라미터 허용 -->
+    <suppress files=".*ReadModel\.java$" checks="ParameterNumber"/>
+
     <!-- Test: 한글 메서드명, 긴 테스트 메서드, 긴 줄, RestDocs 스타 임포트, 파일 크기 허용 -->
     <suppress files=".*Test\.java$" checks="MethodName"/>
     <suppress files=".*Test\.java$" checks="MethodLength"/>

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.domain.championstats.application;
 
 import com.example.lolserver.TierFilter;
+import com.example.lolserver.domain.championstats.application.model.ChampionAverageStatsReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionItemBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionMatchupReadModel;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -65,9 +67,16 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
         Map<String, ChampionRateReadModel> rateByPosition =
                 lookupChampionRateByPosition(championId, patch, platformId, tierFilter);
 
+        Map<String, ChampionAverageStatsReadModel> averagesByPosition =
+                championStatsQueryPort.getChampionAverageStats(championId, patch, platformId, tierFilter)
+                        .stream()
+                        .collect(Collectors.toMap(
+                                ChampionAverageStatsReadModel::teamPosition, a -> a));
+
         List<ChampionPositionStatsReadModel> positions = winRates.stream()
             .map(wr -> buildPositionStats(championId, patch, platformId, tierFilter, wr,
-                    rateByPosition.get(wr.teamPosition())))
+                    rateByPosition.get(wr.teamPosition()),
+                    averagesByPosition.get(wr.teamPosition())))
             .toList();
 
         ChampionStatsReadModel result = new ChampionStatsReadModel(tierDisplay, positions);
@@ -98,7 +107,8 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
 
     private ChampionPositionStatsReadModel buildPositionStats(
             int championId, String patch, String platformId, TierFilter tierFilter,
-            ChampionWinRateReadModel winRate, ChampionRateReadModel rate) {
+            ChampionWinRateReadModel winRate, ChampionRateReadModel rate,
+            ChampionAverageStatsReadModel averages) {
         String position = winRate.teamPosition();
 
         List<ChampionMatchupReadModel> matchups =
@@ -127,6 +137,7 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
             banRate,
             tier,
             winRate.totalGames(),
+            averages,
             matchups, runeBuilds, spellStats, skillBuilds,
             startItemBuilds, bootBuilds, itemBuilds
         );

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
@@ -21,6 +21,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -59,8 +60,14 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
         List<ChampionWinRateReadModel> winRates =
             championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter);
 
+        // pickRate/banRate/tier 는 by-position 결과와 일관성 유지를 위해 같은 데이터를 lookup.
+        // by-position 쪽은 별도 캐시 키 — hit 시 무비용, miss 면 한 번 BQ 호출.
+        Map<String, ChampionRateReadModel> rateByPosition =
+                lookupChampionRateByPosition(championId, patch, platformId, tierFilter);
+
         List<ChampionPositionStatsReadModel> positions = winRates.stream()
-            .map(wr -> buildPositionStats(championId, patch, platformId, tierFilter, wr))
+            .map(wr -> buildPositionStats(championId, patch, platformId, tierFilter, wr,
+                    rateByPosition.get(wr.teamPosition())))
             .toList();
 
         ChampionStatsReadModel result = new ChampionStatsReadModel(tierDisplay, positions);
@@ -72,9 +79,26 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
         return result;
     }
 
+    private Map<String, ChampionRateReadModel> lookupChampionRateByPosition(
+            int championId, String patch, String platformId, TierFilter tierFilter) {
+        List<PositionChampionStatsReadModel> byPosition =
+                getChampionStatsByPosition(patch, platformId, tierFilter);
+
+        Map<String, ChampionRateReadModel> result = new HashMap<>();
+        for (PositionChampionStatsReadModel position : byPosition) {
+            for (ChampionRateReadModel rate : position.champions()) {
+                if (rate.championId() == championId) {
+                    result.put(position.teamPosition(), rate);
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
     private ChampionPositionStatsReadModel buildPositionStats(
             int championId, String patch, String platformId, TierFilter tierFilter,
-            ChampionWinRateReadModel winRate) {
+            ChampionWinRateReadModel winRate, ChampionRateReadModel rate) {
         String position = winRate.teamPosition();
 
         List<ChampionMatchupReadModel> matchups =
@@ -92,9 +116,16 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
         List<ChampionItemBuildReadModel> itemBuilds =
             championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, position);
 
+        double pickRate = rate != null ? rate.pickRate() : 0.0;
+        double banRate = rate != null ? rate.banRate() : 0.0;
+        String tier = rate != null ? rate.tier() : null;
+
         return new ChampionPositionStatsReadModel(
             position,
             winRate.totalWinRate(),
+            pickRate,
+            banRate,
+            tier,
             winRate.totalGames(),
             matchups, runeBuilds, spellStats, skillBuilds,
             startItemBuilds, bootBuilds, itemBuilds

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
@@ -12,11 +12,15 @@ import com.example.lolserver.domain.championstats.application.model.ChampionSpel
 import com.example.lolserver.domain.championstats.application.model.ChampionStartItemBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionRateReadModel;
+import com.example.lolserver.domain.championstats.application.model.ChampionTimelineReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionWinRateReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.PositionTimelineReadModel;
+import com.example.lolserver.domain.championstats.application.model.TimelineFrameReadModel;
 import com.example.lolserver.domain.championstats.application.port.in.ChampionStatsQueryUseCase;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsQueryPort;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsTimelineQueryPort;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -33,14 +37,17 @@ import java.util.stream.Collectors;
 public class ChampionStatsService implements ChampionStatsQueryUseCase {
 
     private final ChampionStatsQueryPort championStatsQueryPort;
+    private final ChampionStatsTimelineQueryPort championStatsTimelineQueryPort;
     private final ChampionStatsCachePort championStatsCachePort;
     private final boolean cacheEnabled;
 
     public ChampionStatsService(
             ChampionStatsQueryPort championStatsQueryPort,
+            ChampionStatsTimelineQueryPort championStatsTimelineQueryPort,
             ChampionStatsCachePort championStatsCachePort,
             @Value("${champion-stats.cache.enabled:true}") boolean cacheEnabled) {
         this.championStatsQueryPort = championStatsQueryPort;
+        this.championStatsTimelineQueryPort = championStatsTimelineQueryPort;
         this.championStatsCachePort = championStatsCachePort;
         this.cacheEnabled = cacheEnabled;
     }
@@ -181,6 +188,40 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
 
         if (cacheEnabled) {
             championStatsCachePort.saveChampionStatsByPosition(patch, platformId, tierDisplay, result);
+        }
+
+        return result;
+    }
+
+    public ChampionTimelineReadModel getChampionTimeline(
+            int championId, String patch, String platformId, TierFilter tierFilter) {
+
+        String tierDisplay = tierFilter.toDisplayString();
+
+        if (cacheEnabled) {
+            ChampionTimelineReadModel cached = championStatsCachePort
+                    .findChampionTimeline(championId, patch, platformId, tierDisplay);
+            if (cached != null) {
+                log.debug("캐시 히트 - timeline championId: {}, patch: {}, tier: {}",
+                        championId, patch, tierDisplay);
+                return cached;
+            }
+        }
+
+        Map<String, List<TimelineFrameReadModel>> grouped =
+                championStatsTimelineQueryPort.aggregateChampionTimeline(
+                        championId, patch, platformId, tierFilter);
+
+        List<PositionTimelineReadModel> positions = grouped.entrySet().stream()
+                .map(entry -> new PositionTimelineReadModel(entry.getKey(), entry.getValue()))
+                .toList();
+
+        ChampionTimelineReadModel result =
+                new ChampionTimelineReadModel(championId, tierDisplay, positions);
+
+        if (cacheEnabled) {
+            championStatsCachePort.saveChampionTimeline(
+                    championId, patch, platformId, tierDisplay, result);
         }
 
         return result;

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
@@ -110,21 +110,28 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
             ChampionWinRateReadModel winRate, ChampionRateReadModel rate,
             ChampionAverageStatsReadModel averages) {
         String position = winRate.teamPosition();
+        long totalSamples = winRate.totalGames();
 
         List<ChampionMatchupReadModel> matchups =
             championStatsQueryPort.getChampionMatchups(championId, patch, platformId, tierFilter, position);
         List<ChampionRuneBuildReadModel> runeBuilds =
-            championStatsQueryPort.getChampionRuneBuilds(championId, patch, platformId, tierFilter, position);
+            championStatsQueryPort.getChampionRuneBuilds(championId, patch, platformId, tierFilter, position)
+                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
         List<ChampionSpellStatsReadModel> spellStats =
-            championStatsQueryPort.getChampionSpellStats(championId, patch, platformId, tierFilter, position);
+            championStatsQueryPort.getChampionSpellStats(championId, patch, platformId, tierFilter, position)
+                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
         List<ChampionSkillBuildReadModel> skillBuilds =
-            championStatsQueryPort.getChampionSkillBuilds(championId, patch, platformId, tierFilter, position);
+            championStatsQueryPort.getChampionSkillBuilds(championId, patch, platformId, tierFilter, position)
+                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
         List<ChampionStartItemBuildReadModel> startItemBuilds =
-            championStatsQueryPort.getChampionStartItemBuilds(championId, patch, platformId, tierFilter, position);
+            championStatsQueryPort.getChampionStartItemBuilds(championId, patch, platformId, tierFilter, position)
+                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
         List<ChampionBootBuildReadModel> bootBuilds =
-            championStatsQueryPort.getChampionBootBuilds(championId, patch, platformId, tierFilter, position);
+            championStatsQueryPort.getChampionBootBuilds(championId, patch, platformId, tierFilter, position)
+                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
         List<ChampionItemBuildReadModel> itemBuilds =
-            championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, position);
+            championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, position)
+                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
 
         double pickRate = rate != null ? rate.pickRate() : 0.0;
         double banRate = rate != null ? rate.banRate() : 0.0;
@@ -141,6 +148,11 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
             matchups, runeBuilds, spellStats, skillBuilds,
             startItemBuilds, bootBuilds, itemBuilds
         );
+    }
+
+    private static double wilson(long games, double winRate) {
+        long wins = Math.round(winRate * games);
+        return WilsonScore.lowerBound95(wins, games);
     }
 
     public List<PositionChampionStatsReadModel> getChampionStatsByPosition(

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/WilsonScore.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/WilsonScore.java
@@ -1,0 +1,26 @@
+package com.example.lolserver.domain.championstats.application;
+
+public final class WilsonScore {
+
+    // 95% 신뢰구간 (alpha=0.05) 의 정규분포 분위수.
+    private static final double Z = 1.959964;
+
+    private WilsonScore() {
+    }
+
+    public static double lowerBound95(long successes, long total) {
+        if (total <= 0) {
+            return 0.0;
+        }
+        double p = (double) successes / total;
+        double z2 = Z * Z;
+        double denom = 1.0 + z2 / total;
+        double center = p + z2 / (2.0 * total);
+        double margin = Z * Math.sqrt((p * (1.0 - p) + z2 / (4.0 * total)) / total);
+        double lower = (center - margin) / denom;
+        if (lower < 0.0) {
+            return 0.0;
+        }
+        return lower;
+    }
+}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionAverageStatsReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionAverageStatsReadModel.java
@@ -1,0 +1,12 @@
+package com.example.lolserver.domain.championstats.application.model;
+
+public record ChampionAverageStatsReadModel(
+    String teamPosition,
+    double avgKills,
+    double avgDeaths,
+    double avgAssists,
+    double kda,
+    double avgGoldPerMinute,
+    double avgLaneCs10m,
+    double avgJungleCs10m
+) {}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionBootBuildReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionBootBuildReadModel.java
@@ -4,5 +4,18 @@ public record ChampionBootBuildReadModel(
     int bootId,
     long games,
     double winRate,
-    double pickRate
-) {}
+    double pickRate,
+    long sampleSize,
+    long totalSampleSize,
+    double confidenceLowerBound
+) {
+    public ChampionBootBuildReadModel(int bootId, long games, double winRate, double pickRate) {
+        this(bootId, games, winRate, pickRate, games, 0L, 0.0);
+    }
+
+    public ChampionBootBuildReadModel withConfidence(long totalSampleSize, double confidenceLowerBound) {
+        return new ChampionBootBuildReadModel(
+                bootId, games, winRate, pickRate,
+                games, totalSampleSize, confidenceLowerBound);
+    }
+}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionItemBuildReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionItemBuildReadModel.java
@@ -6,5 +6,19 @@ public record ChampionItemBuildReadModel(
     List<Integer> itemBuild,
     long games,
     double winRate,
-    double pickRate
-) {}
+    double pickRate,
+    long sampleSize,
+    long totalSampleSize,
+    double confidenceLowerBound
+) {
+    public ChampionItemBuildReadModel(List<Integer> itemBuild,
+                                      long games, double winRate, double pickRate) {
+        this(itemBuild, games, winRate, pickRate, games, 0L, 0.0);
+    }
+
+    public ChampionItemBuildReadModel withConfidence(long totalSampleSize, double confidenceLowerBound) {
+        return new ChampionItemBuildReadModel(
+                itemBuild, games, winRate, pickRate,
+                games, totalSampleSize, confidenceLowerBound);
+    }
+}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionPositionStatsReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionPositionStatsReadModel.java
@@ -9,6 +9,7 @@ public record ChampionPositionStatsReadModel(
     double banRate,
     String tier,
     long totalGames,
+    ChampionAverageStatsReadModel averages,
     List<ChampionMatchupReadModel> matchups,
     List<ChampionRuneBuildReadModel> runeBuilds,
     List<ChampionSpellStatsReadModel> spellStats,

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionPositionStatsReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionPositionStatsReadModel.java
@@ -5,6 +5,9 @@ import java.util.List;
 public record ChampionPositionStatsReadModel(
     String teamPosition,
     double winRate,
+    double pickRate,
+    double banRate,
+    String tier,
     long totalGames,
     List<ChampionMatchupReadModel> matchups,
     List<ChampionRuneBuildReadModel> runeBuilds,

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionRuneBuildReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionRuneBuildReadModel.java
@@ -11,5 +11,29 @@ public record ChampionRuneBuildReadModel(
     int subPerk1,
     long games,
     double winRate,
-    double pickRate
-) {}
+    double pickRate,
+    long sampleSize,
+    long totalSampleSize,
+    double confidenceLowerBound
+) {
+    public ChampionRuneBuildReadModel(
+            int primaryStyleId, int subStyleId,
+            int primaryPerk0, int primaryPerk1, int primaryPerk2, int primaryPerk3,
+            int subPerk0, int subPerk1,
+            long games, double winRate, double pickRate) {
+        this(primaryStyleId, subStyleId,
+             primaryPerk0, primaryPerk1, primaryPerk2, primaryPerk3,
+             subPerk0, subPerk1,
+             games, winRate, pickRate,
+             games, 0L, 0.0);
+    }
+
+    public ChampionRuneBuildReadModel withConfidence(long totalSampleSize, double confidenceLowerBound) {
+        return new ChampionRuneBuildReadModel(
+                primaryStyleId, subStyleId,
+                primaryPerk0, primaryPerk1, primaryPerk2, primaryPerk3,
+                subPerk0, subPerk1,
+                games, winRate, pickRate,
+                games, totalSampleSize, confidenceLowerBound);
+    }
+}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionSkillBuildReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionSkillBuildReadModel.java
@@ -4,5 +4,18 @@ public record ChampionSkillBuildReadModel(
     String skillBuild,
     long games,
     double winRate,
-    double pickRate
-) {}
+    double pickRate,
+    long sampleSize,
+    long totalSampleSize,
+    double confidenceLowerBound
+) {
+    public ChampionSkillBuildReadModel(String skillBuild, long games, double winRate, double pickRate) {
+        this(skillBuild, games, winRate, pickRate, games, 0L, 0.0);
+    }
+
+    public ChampionSkillBuildReadModel withConfidence(long totalSampleSize, double confidenceLowerBound) {
+        return new ChampionSkillBuildReadModel(
+                skillBuild, games, winRate, pickRate,
+                games, totalSampleSize, confidenceLowerBound);
+    }
+}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionSpellStatsReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionSpellStatsReadModel.java
@@ -5,5 +5,19 @@ public record ChampionSpellStatsReadModel(
     int summoner2Id,
     long games,
     double winRate,
-    double pickRate
-) {}
+    double pickRate,
+    long sampleSize,
+    long totalSampleSize,
+    double confidenceLowerBound
+) {
+    public ChampionSpellStatsReadModel(int summoner1Id, int summoner2Id,
+                                       long games, double winRate, double pickRate) {
+        this(summoner1Id, summoner2Id, games, winRate, pickRate, games, 0L, 0.0);
+    }
+
+    public ChampionSpellStatsReadModel withConfidence(long totalSampleSize, double confidenceLowerBound) {
+        return new ChampionSpellStatsReadModel(
+                summoner1Id, summoner2Id, games, winRate, pickRate,
+                games, totalSampleSize, confidenceLowerBound);
+    }
+}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionStartItemBuildReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionStartItemBuildReadModel.java
@@ -6,5 +6,19 @@ public record ChampionStartItemBuildReadModel(
     List<Integer> startItems,
     long games,
     double winRate,
-    double pickRate
-) {}
+    double pickRate,
+    long sampleSize,
+    long totalSampleSize,
+    double confidenceLowerBound
+) {
+    public ChampionStartItemBuildReadModel(List<Integer> startItems,
+                                           long games, double winRate, double pickRate) {
+        this(startItems, games, winRate, pickRate, games, 0L, 0.0);
+    }
+
+    public ChampionStartItemBuildReadModel withConfidence(long totalSampleSize, double confidenceLowerBound) {
+        return new ChampionStartItemBuildReadModel(
+                startItems, games, winRate, pickRate,
+                games, totalSampleSize, confidenceLowerBound);
+    }
+}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionTimelineReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/ChampionTimelineReadModel.java
@@ -1,0 +1,9 @@
+package com.example.lolserver.domain.championstats.application.model;
+
+import java.util.List;
+
+public record ChampionTimelineReadModel(
+    int championId,
+    String tier,
+    List<PositionTimelineReadModel> positions
+) {}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/PositionTimelineReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/PositionTimelineReadModel.java
@@ -1,0 +1,8 @@
+package com.example.lolserver.domain.championstats.application.model;
+
+import java.util.List;
+
+public record PositionTimelineReadModel(
+    String teamPosition,
+    List<TimelineFrameReadModel> frames
+) {}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/TimelineFrameReadModel.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/model/TimelineFrameReadModel.java
@@ -1,0 +1,9 @@
+package com.example.lolserver.domain.championstats.application.model;
+
+public record TimelineFrameReadModel(
+    int minute,
+    double avgGold,
+    double avgCs,
+    double avgXp,
+    long sampleSize
+) {}

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/in/ChampionStatsQueryUseCase.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/in/ChampionStatsQueryUseCase.java
@@ -2,6 +2,7 @@ package com.example.lolserver.domain.championstats.application.port.in;
 
 import com.example.lolserver.TierFilter;
 import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.ChampionTimelineReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
 
 import java.util.List;
@@ -12,4 +13,7 @@ public interface ChampionStatsQueryUseCase {
 
     List<PositionChampionStatsReadModel> getChampionStatsByPosition(
             String patch, String platformId, TierFilter tierFilter);
+
+    ChampionTimelineReadModel getChampionTimeline(
+            int championId, String patch, String platformId, TierFilter tierFilter);
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsCachePort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsCachePort.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.domain.championstats.application.port.out;
 
 import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.ChampionTimelineReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
 
 import java.util.List;
@@ -18,4 +19,10 @@ public interface ChampionStatsCachePort {
     void saveChampionStatsByPosition(String patch, String platformId,
                                      String tierDisplay,
                                      List<PositionChampionStatsReadModel> stats);
+
+    ChampionTimelineReadModel findChampionTimeline(
+            int championId, String patch, String platformId, String tierDisplay);
+
+    void saveChampionTimeline(int championId, String patch, String platformId,
+                              String tierDisplay, ChampionTimelineReadModel timeline);
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsQueryPort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsQueryPort.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.domain.championstats.application.port.out;
 
 import com.example.lolserver.TierFilter;
+import com.example.lolserver.domain.championstats.application.model.ChampionAverageStatsReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionItemBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionMatchupReadModel;
@@ -20,6 +21,9 @@ public interface ChampionStatsQueryPort {
             String patch, String platformId, TierFilter tierFilter);
 
     List<ChampionWinRateReadModel> getChampionWinRates(
+            int championId, String patch, String platformId, TierFilter tierFilter);
+
+    List<ChampionAverageStatsReadModel> getChampionAverageStats(
             int championId, String patch, String platformId, TierFilter tierFilter);
 
     List<ChampionMatchupReadModel> getChampionMatchups(

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsTimelineQueryPort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsTimelineQueryPort.java
@@ -1,0 +1,13 @@
+package com.example.lolserver.domain.championstats.application.port.out;
+
+import com.example.lolserver.TierFilter;
+import com.example.lolserver.domain.championstats.application.model.TimelineFrameReadModel;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ChampionStatsTimelineQueryPort {
+
+    Map<String, List<TimelineFrameReadModel>> aggregateChampionTimeline(
+            int championId, String patch, String platformId, TierFilter tierFilter);
+}

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceTest.java
@@ -15,6 +15,7 @@ import com.example.lolserver.domain.championstats.application.model.ChampionWinR
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsQueryPort;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsTimelineQueryPort;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,10 +42,14 @@ class ChampionStatsServiceTest {
     private ChampionStatsQueryPort championStatsQueryPort;
 
     @Mock
+    private ChampionStatsTimelineQueryPort championStatsTimelineQueryPort;
+
+    @Mock
     private ChampionStatsCachePort championStatsCachePort;
 
     private ChampionStatsService createService(boolean cacheEnabled) {
-        return new ChampionStatsService(championStatsQueryPort, championStatsCachePort, cacheEnabled);
+        return new ChampionStatsService(championStatsQueryPort, championStatsTimelineQueryPort,
+                championStatsCachePort, cacheEnabled);
     }
 
     @Nested

--- a/module/infra/api/src/docs/asciidoc/api/championstats/champion-stats-timeline.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/championstats/champion-stats-timeline.adoc
@@ -1,0 +1,11 @@
+[[champion-stats-timeline]]
+=== 챔피언 시간대별 평균 곡선 조회
+
+==== HTTP Request
+include::{snippets}/champion-stats-timeline/http-request.adoc[]
+include::{snippets}/champion-stats-timeline/path-parameters.adoc[]
+include::{snippets}/champion-stats-timeline/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/champion-stats-timeline/http-response.adoc[]
+include::{snippets}/champion-stats-timeline/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/index.adoc
+++ b/module/infra/api/src/docs/asciidoc/index.adoc
@@ -67,6 +67,8 @@ include::api/championstats/champion-stats-get.adoc[]
 
 include::api/championstats/champion-stats-positions.adoc[]
 
+include::api/championstats/champion-stats-timeline.adoc[]
+
 [[Rank-API]]
 == Rank API
 

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/championstats/ChampionStatsController.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/championstats/ChampionStatsController.java
@@ -5,6 +5,7 @@ import com.example.lolserver.TierFilter;
 import com.example.lolserver.controller.support.response.ApiResponse;
 import com.example.lolserver.domain.championstats.application.port.in.ChampionStatsQueryUseCase;
 import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.ChampionTimelineReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
 import com.example.lolserver.support.error.CoreException;
 import com.example.lolserver.support.error.ErrorType;
@@ -37,6 +38,20 @@ public class ChampionStatsController {
         String riotPlatformId = Platform.valueOfName(platformId).getPlatformId();
         TierFilter tierFilter = parseTierFilter(tier);
         ChampionStatsReadModel response = championStatsService.getChampionStats(
+                championId, patch, riotPlatformId, tierFilter);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @GetMapping("/timeline")
+    public ResponseEntity<ApiResponse<ChampionTimelineReadModel>> getChampionTimeline(
+            @PathVariable("platformId") String platformId,
+            @RequestParam("championId") int championId,
+            @RequestParam("patch") String patch,
+            @RequestParam("tier") String tier
+    ) {
+        String riotPlatformId = Platform.valueOfName(platformId).getPlatformId();
+        TierFilter tierFilter = parseTierFilter(tier);
+        ChampionTimelineReadModel response = championStatsService.getChampionTimeline(
                 championId, patch, riotPlatformId, tierFilter);
         return ResponseEntity.ok(ApiResponse.success(response));
     }

--- a/module/infra/api/src/main/resources/api-local.yml
+++ b/module/infra/api/src/main/resources/api-local.yml
@@ -45,6 +45,8 @@ app:
 cors:
   allowed-origins:
     - http://localhost:3000
+    - http://localhost:3001
+    - http://localhost:3002
     - http://localhost:8080
     - http://lol-ui:3000
     - https://metapick.me

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/ChampionStatsControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/ChampionStatsControllerTest.java
@@ -14,7 +14,10 @@ import com.example.lolserver.domain.championstats.application.model.ChampionSpel
 import com.example.lolserver.domain.championstats.application.model.ChampionStartItemBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionRateReadModel;
+import com.example.lolserver.domain.championstats.application.model.ChampionTimelineReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.PositionTimelineReadModel;
+import com.example.lolserver.domain.championstats.application.model.TimelineFrameReadModel;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -227,6 +230,65 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.positions[].itemBuilds[].sampleSize").type(JsonFieldType.NUMBER).description("이 빌드의 표본 크기 (= games)"),
                                 fieldWithPath("data.positions[].itemBuilds[].totalSampleSize").type(JsonFieldType.NUMBER).description("챔프-라인 총 표본 크기"),
                                 fieldWithPath("data.positions[].itemBuilds[].confidenceLowerBound").type(JsonFieldType.NUMBER).description("Wilson 신뢰구간(95%) 하한")
+                        )
+                ));
+    }
+
+    @DisplayName("챔피언 시간대별 평균 곡선 조회 API")
+    @Test
+    void getChampionTimeline() throws Exception {
+        // given
+        String platformId = "kr";
+        ChampionTimelineReadModel response = new ChampionTimelineReadModel(
+                266,
+                "EMERALD",
+                List.of(
+                        new PositionTimelineReadModel("TOP", List.of(
+                                new TimelineFrameReadModel(10, 4520.5, 78.2, 4810.0, 1500),
+                                new TimelineFrameReadModel(15, 7210.4, 121.6, 7950.5, 1480),
+                                new TimelineFrameReadModel(20, 10210.7, 168.9, 11460.0, 1310),
+                                new TimelineFrameReadModel(25, 13150.0, 213.4, 15010.5, 980),
+                                new TimelineFrameReadModel(30, 16290.2, 259.1, 18790.5, 540)
+                        ))
+                ));
+
+        given(championStatsService.getChampionTimeline(anyInt(), anyString(), anyString(), any(TierFilter.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/{platformId}/champion-stats/timeline", platformId)
+                                .param("championId", "266")
+                                .param("patch", "14.24")
+                                .param("tier", "EMERALD")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("champion-stats-timeline",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("platformId").description("플랫폼 ID (e.g., kr)")
+                        ),
+                        queryParameters(
+                                parameterWithName("championId").description("챔피언 ID"),
+                                parameterWithName("patch").description("패치 버전 (e.g., 14.24)"),
+                                parameterWithName("tier").description("티어 필터. 단일 또는 범위 (e.g., MASTER+).")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("API 응답 결과"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.NULL).description("에러 메시지 (정상 응답 시 null)"),
+                                fieldWithPath("data.championId").type(JsonFieldType.NUMBER).description("챔피언 ID"),
+                                fieldWithPath("data.tier").type(JsonFieldType.STRING).description("티어 표시 (e.g., EMERALD, MASTER+)"),
+                                fieldWithPath("data.positions[]").type(JsonFieldType.ARRAY).description("포지션별 시계열 목록"),
+                                fieldWithPath("data.positions[].teamPosition").type(JsonFieldType.STRING).description("포지션 (TOP/JUNGLE/MIDDLE/BOTTOM/UTILITY)"),
+                                fieldWithPath("data.positions[].frames[]").type(JsonFieldType.ARRAY).description("시간대별 프레임 (10/15/20/25/30분)"),
+                                fieldWithPath("data.positions[].frames[].minute").type(JsonFieldType.NUMBER).description("분 단위 시각 (10/15/20/25/30)"),
+                                fieldWithPath("data.positions[].frames[].avgGold").type(JsonFieldType.NUMBER).description("평균 누적 골드"),
+                                fieldWithPath("data.positions[].frames[].avgCs").type(JsonFieldType.NUMBER).description("평균 CS (라인 + 정글 미니언)"),
+                                fieldWithPath("data.positions[].frames[].avgXp").type(JsonFieldType.NUMBER).description("평균 누적 경험치"),
+                                fieldWithPath("data.positions[].frames[].sampleSize").type(JsonFieldType.NUMBER).description("이 프레임에 도달한 게임 수")
                         )
                 ));
     }

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/ChampionStatsControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/ChampionStatsControllerTest.java
@@ -84,7 +84,7 @@ class ChampionStatsControllerTest extends RestDocsSupport {
         );
 
         ChampionPositionStatsReadModel positionStats = new ChampionPositionStatsReadModel(
-                "TOP", 0.55, 1500,
+                "TOP", 0.55, 0.075, 0.04, "S", 1500,
                 List.of(topMatchup, bottomMatchup),
                 List.of(runeBuild),
                 List.of(spellStats),
@@ -130,6 +130,9 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.positions[]").type(JsonFieldType.ARRAY).description("포지션별 통계 목록"),
                                 fieldWithPath("data.positions[].teamPosition").type(JsonFieldType.STRING).description("포지션"),
                                 fieldWithPath("data.positions[].winRate").type(JsonFieldType.NUMBER).description("승률"),
+                                fieldWithPath("data.positions[].pickRate").type(JsonFieldType.NUMBER).description("픽률 (해당 라인 기준)"),
+                                fieldWithPath("data.positions[].banRate").type(JsonFieldType.NUMBER).description("밴률 (라인 무관)"),
+                                fieldWithPath("data.positions[].tier").type(JsonFieldType.STRING).description("티어 등급 (S+, S, A, B, C, D — /champion-stats/positions 와 동일 룰)"),
                                 fieldWithPath("data.positions[].totalGames").type(JsonFieldType.NUMBER).description("총 게임 수"),
 
                                 // matchups (rankType=TOP: 잘 잡는 상대 / BOTTOM: 카운터)

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/ChampionStatsControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/ChampionStatsControllerTest.java
@@ -3,6 +3,7 @@ package com.example.lolserver.docs.controller;
 import com.example.lolserver.controller.championstats.ChampionStatsController;
 import com.example.lolserver.docs.RestDocsSupport;
 import com.example.lolserver.domain.championstats.application.port.in.ChampionStatsQueryUseCase;
+import com.example.lolserver.domain.championstats.application.model.ChampionAverageStatsReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionItemBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionMatchupReadModel;
@@ -83,8 +84,13 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                 List.of(3078, 3053, 3065), 300, 0.5667, 0.3
         );
 
+        ChampionAverageStatsReadModel averages = new ChampionAverageStatsReadModel(
+                "TOP", 6.2, 5.4, 7.8, 2.59, 380.5, 65.3, 12.1
+        );
+
         ChampionPositionStatsReadModel positionStats = new ChampionPositionStatsReadModel(
                 "TOP", 0.55, 0.075, 0.04, "S", 1500,
+                averages,
                 List.of(topMatchup, bottomMatchup),
                 List.of(runeBuild),
                 List.of(spellStats),
@@ -134,6 +140,17 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.positions[].banRate").type(JsonFieldType.NUMBER).description("밴률 (라인 무관)"),
                                 fieldWithPath("data.positions[].tier").type(JsonFieldType.STRING).description("티어 등급 (S+, S, A, B, C, D — /champion-stats/positions 와 동일 룰)"),
                                 fieldWithPath("data.positions[].totalGames").type(JsonFieldType.NUMBER).description("총 게임 수"),
+
+                                // averages (챔피언 단위 평균 통계)
+                                fieldWithPath("data.positions[].averages").type(JsonFieldType.OBJECT).description("챔피언 단위 평균 통계 (BQ 미적재 시 null)").optional(),
+                                fieldWithPath("data.positions[].averages.teamPosition").type(JsonFieldType.STRING).description("포지션").optional(),
+                                fieldWithPath("data.positions[].averages.avgKills").type(JsonFieldType.NUMBER).description("평균 킬").optional(),
+                                fieldWithPath("data.positions[].averages.avgDeaths").type(JsonFieldType.NUMBER).description("평균 데스").optional(),
+                                fieldWithPath("data.positions[].averages.avgAssists").type(JsonFieldType.NUMBER).description("평균 어시스트").optional(),
+                                fieldWithPath("data.positions[].averages.kda").type(JsonFieldType.NUMBER).description("KDA = (킬+어시) / max(데스, 1)").optional(),
+                                fieldWithPath("data.positions[].averages.avgGoldPerMinute").type(JsonFieldType.NUMBER).description("분당 평균 골드 (gold_per_minute)").optional(),
+                                fieldWithPath("data.positions[].averages.avgLaneCs10m").type(JsonFieldType.NUMBER).description("10분 시점 평균 라인 CS").optional(),
+                                fieldWithPath("data.positions[].averages.avgJungleCs10m").type(JsonFieldType.NUMBER).description("10분 시점 평균 정글 CS").optional(),
 
                                 // matchups (rankType=TOP: 잘 잡는 상대 / BOTTOM: 카운터)
                                 fieldWithPath("data.positions[].matchups[]").type(JsonFieldType.ARRAY).description("매치업 목록 (rankType=TOP: 잘 잡는 상대, BOTTOM: 카운터)"),

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/ChampionStatsControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/ChampionStatsControllerTest.java
@@ -173,6 +173,9 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.positions[].runeBuilds[].games").type(JsonFieldType.NUMBER).description("게임 수"),
                                 fieldWithPath("data.positions[].runeBuilds[].winRate").type(JsonFieldType.NUMBER).description("승률"),
                                 fieldWithPath("data.positions[].runeBuilds[].pickRate").type(JsonFieldType.NUMBER).description("픽률"),
+                                fieldWithPath("data.positions[].runeBuilds[].sampleSize").type(JsonFieldType.NUMBER).description("이 빌드의 표본 크기 (= games)"),
+                                fieldWithPath("data.positions[].runeBuilds[].totalSampleSize").type(JsonFieldType.NUMBER).description("챔프-라인 총 표본 크기"),
+                                fieldWithPath("data.positions[].runeBuilds[].confidenceLowerBound").type(JsonFieldType.NUMBER).description("Wilson 신뢰구간(95%) 하한 — 추천 신뢰도 정렬 기준"),
 
                                 // spellStats
                                 fieldWithPath("data.positions[].spellStats[]").type(JsonFieldType.ARRAY).description("소환사 주문 조합 목록"),
@@ -181,6 +184,9 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.positions[].spellStats[].games").type(JsonFieldType.NUMBER).description("게임 수"),
                                 fieldWithPath("data.positions[].spellStats[].winRate").type(JsonFieldType.NUMBER).description("승률"),
                                 fieldWithPath("data.positions[].spellStats[].pickRate").type(JsonFieldType.NUMBER).description("픽률"),
+                                fieldWithPath("data.positions[].spellStats[].sampleSize").type(JsonFieldType.NUMBER).description("이 조합의 표본 크기 (= games)"),
+                                fieldWithPath("data.positions[].spellStats[].totalSampleSize").type(JsonFieldType.NUMBER).description("챔프-라인 총 표본 크기"),
+                                fieldWithPath("data.positions[].spellStats[].confidenceLowerBound").type(JsonFieldType.NUMBER).description("Wilson 신뢰구간(95%) 하한"),
 
                                 // skillBuilds
                                 fieldWithPath("data.positions[].skillBuilds[]").type(JsonFieldType.ARRAY).description("스킬 빌드 목록"),
@@ -188,6 +194,9 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.positions[].skillBuilds[].games").type(JsonFieldType.NUMBER).description("게임 수"),
                                 fieldWithPath("data.positions[].skillBuilds[].winRate").type(JsonFieldType.NUMBER).description("승률"),
                                 fieldWithPath("data.positions[].skillBuilds[].pickRate").type(JsonFieldType.NUMBER).description("픽률"),
+                                fieldWithPath("data.positions[].skillBuilds[].sampleSize").type(JsonFieldType.NUMBER).description("이 빌드의 표본 크기 (= games)"),
+                                fieldWithPath("data.positions[].skillBuilds[].totalSampleSize").type(JsonFieldType.NUMBER).description("챔프-라인 총 표본 크기"),
+                                fieldWithPath("data.positions[].skillBuilds[].confidenceLowerBound").type(JsonFieldType.NUMBER).description("Wilson 신뢰구간(95%) 하한"),
 
                                 // startItemBuilds
                                 fieldWithPath("data.positions[].startItemBuilds[]").type(JsonFieldType.ARRAY).description("시작 아이템 빌드 목록"),
@@ -195,6 +204,9 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.positions[].startItemBuilds[].games").type(JsonFieldType.NUMBER).description("게임 수"),
                                 fieldWithPath("data.positions[].startItemBuilds[].winRate").type(JsonFieldType.NUMBER).description("승률"),
                                 fieldWithPath("data.positions[].startItemBuilds[].pickRate").type(JsonFieldType.NUMBER).description("픽률"),
+                                fieldWithPath("data.positions[].startItemBuilds[].sampleSize").type(JsonFieldType.NUMBER).description("이 빌드의 표본 크기 (= games)"),
+                                fieldWithPath("data.positions[].startItemBuilds[].totalSampleSize").type(JsonFieldType.NUMBER).description("챔프-라인 총 표본 크기"),
+                                fieldWithPath("data.positions[].startItemBuilds[].confidenceLowerBound").type(JsonFieldType.NUMBER).description("Wilson 신뢰구간(95%) 하한"),
 
                                 // bootBuilds (신발)
                                 fieldWithPath("data.positions[].bootBuilds[]").type(JsonFieldType.ARRAY).description("신발 빌드 목록"),
@@ -202,13 +214,19 @@ class ChampionStatsControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.positions[].bootBuilds[].games").type(JsonFieldType.NUMBER).description("게임 수"),
                                 fieldWithPath("data.positions[].bootBuilds[].winRate").type(JsonFieldType.NUMBER).description("승률"),
                                 fieldWithPath("data.positions[].bootBuilds[].pickRate").type(JsonFieldType.NUMBER).description("픽률"),
+                                fieldWithPath("data.positions[].bootBuilds[].sampleSize").type(JsonFieldType.NUMBER).description("이 빌드의 표본 크기 (= games)"),
+                                fieldWithPath("data.positions[].bootBuilds[].totalSampleSize").type(JsonFieldType.NUMBER).description("챔프-라인 총 표본 크기"),
+                                fieldWithPath("data.positions[].bootBuilds[].confidenceLowerBound").type(JsonFieldType.NUMBER).description("Wilson 신뢰구간(95%) 하한"),
 
                                 // itemBuilds (3코어)
                                 fieldWithPath("data.positions[].itemBuilds[]").type(JsonFieldType.ARRAY).description("3코어 아이템 빌드 목록"),
                                 fieldWithPath("data.positions[].itemBuilds[].itemBuild").type(JsonFieldType.ARRAY).description("아이템 ID 배열 (number[], 빌드 순서)"),
                                 fieldWithPath("data.positions[].itemBuilds[].games").type(JsonFieldType.NUMBER).description("게임 수"),
                                 fieldWithPath("data.positions[].itemBuilds[].winRate").type(JsonFieldType.NUMBER).description("승률"),
-                                fieldWithPath("data.positions[].itemBuilds[].pickRate").type(JsonFieldType.NUMBER).description("픽률")
+                                fieldWithPath("data.positions[].itemBuilds[].pickRate").type(JsonFieldType.NUMBER).description("픽률"),
+                                fieldWithPath("data.positions[].itemBuilds[].sampleSize").type(JsonFieldType.NUMBER).description("이 빌드의 표본 크기 (= games)"),
+                                fieldWithPath("data.positions[].itemBuilds[].totalSampleSize").type(JsonFieldType.NUMBER).description("챔프-라인 총 표본 크기"),
+                                fieldWithPath("data.positions[].itemBuilds[].confidenceLowerBound").type(JsonFieldType.NUMBER).description("Wilson 신뢰구간(95%) 하한")
                         )
                 ));
     }

--- a/module/infra/persistence/bigquery/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsBigQueryAdapter.java
+++ b/module/infra/persistence/bigquery/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsBigQueryAdapter.java
@@ -3,6 +3,7 @@ package com.example.lolserver.repository.championstats.adapter;
 import com.example.lolserver.Tier;
 import com.example.lolserver.TierFilter;
 import com.example.lolserver.config.BigQueryProperties;
+import com.example.lolserver.domain.championstats.application.model.ChampionAverageStatsReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionItemBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionMatchupReadModel;
@@ -68,6 +69,27 @@ public class ChampionStatsBigQueryAdapter implements ChampionStatsQueryPort {
                 row.get("total_games").getLongValue(),
                 row.get("total_wins").getLongValue(),
                 row.get("total_win_rate").getDoubleValue()
+        ));
+    }
+
+    @Override
+    public List<ChampionAverageStatsReadModel> getChampionAverageStats(
+            int championId, String patch, String platformId, TierFilter tierFilter) {
+        String sql = ChampionStatsBigQuerySqls.AVG_STATS.formatted(table("match_participant_fact"));
+
+        QueryJobConfiguration job = baseQuery(sql, patch, platformId, tierFilter)
+                .addNamedParameter("championId", QueryParameterValue.int64(championId))
+                .build();
+
+        return query(job, row -> new ChampionAverageStatsReadModel(
+                row.get("team_position").getStringValue(),
+                row.get("avg_kills").getDoubleValue(),
+                row.get("avg_deaths").getDoubleValue(),
+                row.get("avg_assists").getDoubleValue(),
+                row.get("kda").getDoubleValue(),
+                row.get("avg_gold_per_minute").getDoubleValue(),
+                row.get("avg_lane_cs_10m").getDoubleValue(),
+                row.get("avg_jungle_cs_10m").getDoubleValue()
         ));
     }
 

--- a/module/infra/persistence/bigquery/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsBigQuerySqls.java
+++ b/module/infra/persistence/bigquery/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsBigQuerySqls.java
@@ -225,6 +225,26 @@ final class ChampionStatsBigQuerySqls {
             LIMIT 5
             """;
 
+    static final String AVG_STATS = """
+            SELECT individual_position                                        AS team_position,
+                   AVG(kills)                                                 AS avg_kills,
+                   AVG(deaths)                                                AS avg_deaths,
+                   AVG(assists)                                               AS avg_assists,
+                   SAFE_DIVIDE(SUM(kills) + SUM(assists),
+                               GREATEST(SUM(deaths), 1))                      AS kda,
+                   AVG(gold_per_minute)                                       AS avg_gold_per_minute,
+                   AVG(lane_cs_10m)                                           AS avg_lane_cs_10m,
+                   AVG(jungle_cs_10m)                                         AS avg_jungle_cs_10m
+            FROM %s
+            WHERE patch_version_int = @patch
+              AND platform_id = @platform
+              AND tier_bucket IN UNNEST(@tierBuckets)
+              AND champion_id = @championId
+              AND individual_position IS NOT NULL
+            GROUP BY individual_position
+            HAVING COUNT(*) > 20
+            """;
+
     static final String STATS_BY_POSITION = """
             WITH
                 denom AS (

--- a/module/infra/persistence/bigquery/src/main/resources/bigquery-dev.yml
+++ b/module/infra/persistence/bigquery/src/main/resources/bigquery-dev.yml
@@ -1,5 +1,5 @@
 stats:
-  datasource: ${STATS_DATASOURCE:clickhouse}
+  datasource: ${STATS_DATASOURCE:bigquery}
 
 bigquery:
   project-id: ${BIGQUERY_PROJECT_ID}

--- a/module/infra/persistence/bigquery/src/main/resources/bigquery-local.yml
+++ b/module/infra/persistence/bigquery/src/main/resources/bigquery-local.yml
@@ -1,5 +1,5 @@
 stats:
-  datasource: ${STATS_DATASOURCE:clickhouse}
+  datasource: ${STATS_DATASOURCE:bigquery}
 
 bigquery:
   project-id: ${BIGQUERY_PROJECT_ID:lol-server-local}

--- a/module/infra/persistence/bigquery/src/main/resources/bigquery-prod.yml
+++ b/module/infra/persistence/bigquery/src/main/resources/bigquery-prod.yml
@@ -1,5 +1,5 @@
 stats:
-  datasource: ${STATS_DATASOURCE:clickhouse}
+  datasource: ${STATS_DATASOURCE:bigquery}
 
 bigquery:
   project-id: ${BIGQUERY_PROJECT_ID}

--- a/module/infra/persistence/clickhouse/src/main/java/com/example/lolserver/config/ClickHouseConfig.java
+++ b/module/infra/persistence/clickhouse/src/main/java/com/example/lolserver/config/ClickHouseConfig.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+// TODO(MP-9): ChampionStatsBigQueryAdapter 가 @Primary 로 활성화된 이후 ClickHouse adapter 는 dead code at runtime.
+//             ClickHouseConfig + ChampionStatsClickHouseAdapter + clickhouse 모듈 의존성 정리는 별도 cleanup PR 로 트래킹.
 @Configuration
 public class ClickHouseConfig {
 

--- a/module/infra/persistence/clickhouse/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsClickHouseAdapter.java
+++ b/module/infra/persistence/clickhouse/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsClickHouseAdapter.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.repository.championstats.adapter;
 
 import com.example.lolserver.TierFilter;
+import com.example.lolserver.domain.championstats.application.model.ChampionAverageStatsReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionItemBuildReadModel;
 import com.example.lolserver.domain.championstats.application.model.ChampionMatchupReadModel;
@@ -88,6 +89,14 @@ public class ChampionStatsClickHouseAdapter implements ChampionStatsQueryPort {
                         rs.getLong("total_games"),
                         rs.getLong("total_wins"),
                         rs.getDouble("total_win_rate")));
+    }
+
+    @Override
+    public List<ChampionAverageStatsReadModel> getChampionAverageStats(
+            int championId, String patch, String platformId, TierFilter tierFilter) {
+        // ClickHouse match_participant_local 에는 kills/deaths/assists/gold_per_minute/cs 컬럼이 없어 평균 계산 불가.
+        // BigQuery adapter 가 @Primary 로 활성화되어 있어 prod 에서는 호출되지 않음.
+        return List.of();
     }
 
     @Override

--- a/module/infra/persistence/postgresql/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsTimelinePostgresAdapter.java
+++ b/module/infra/persistence/postgresql/src/main/java/com/example/lolserver/repository/championstats/adapter/ChampionStatsTimelinePostgresAdapter.java
@@ -1,0 +1,87 @@
+package com.example.lolserver.repository.championstats.adapter;
+
+import com.example.lolserver.Tier;
+import com.example.lolserver.TierFilter;
+import com.example.lolserver.domain.championstats.application.model.TimelineFrameReadModel;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsTimelineQueryPort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.AbstractMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class ChampionStatsTimelinePostgresAdapter implements ChampionStatsTimelineQueryPort {
+
+    private static final List<Long> FRAME_TIMESTAMPS_MS =
+            List.of(600_000L, 900_000L, 1_200_000L, 1_500_000L, 1_800_000L);
+
+    private static final String SQL = """
+            SELECT mp.team_position                                          AS team_position,
+                   (pf.timestamp / 60000)                                    AS minute,
+                   AVG(pf.total_gold)                                        AS avg_gold,
+                   AVG(pf.minions_killed + pf.jungle_minions_killed)         AS avg_cs,
+                   AVG(pf.xp)                                                AS avg_xp,
+                   COUNT(*)                                                  AS sample_size
+            FROM match_participant mp
+                 JOIN match m              ON m.match_id  = mp.match_id
+                 JOIN participant_frame pf ON pf.match_id = mp.match_id
+                                          AND pf.participant_id = mp.participant_id
+            WHERE mp.champion_id = :championId
+              AND m.patch_version = :patch
+              AND m.platform_id   = :platformId
+              AND m.average_tier  IN (:tierScores)
+              AND pf.timestamp    IN (:frameTimestamps)
+              AND mp.team_position IS NOT NULL
+              AND mp.team_position <> ''
+            GROUP BY mp.team_position, pf.timestamp
+            ORDER BY mp.team_position, pf.timestamp
+            """;
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public ChampionStatsTimelinePostgresAdapter(NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Map<String, List<TimelineFrameReadModel>> aggregateChampionTimeline(
+            int championId, String patch, String platformId, TierFilter tierFilter) {
+        log.info("timeline 집계 — championId: {}, patch: {}, platformId: {}, tier: {}",
+                championId, patch, platformId, tierFilter);
+
+        MapSqlParameterSource params = new MapSqlParameterSource()
+                .addValue("championId", championId)
+                .addValue("patch", patch)
+                .addValue("platformId", platformId)
+                .addValue("tierScores", toTierScores(tierFilter))
+                .addValue("frameTimestamps", FRAME_TIMESTAMPS_MS);
+
+        return jdbcTemplate.query(SQL, params, (rs, rowNum) ->
+                        new AbstractMap.SimpleEntry<>(
+                                rs.getString("team_position"),
+                                new TimelineFrameReadModel(
+                                        rs.getInt("minute"),
+                                        rs.getDouble("avg_gold"),
+                                        rs.getDouble("avg_cs"),
+                                        rs.getDouble("avg_xp"),
+                                        rs.getLong("sample_size"))))
+                .stream()
+                .collect(Collectors.groupingBy(
+                        Map.Entry::getKey,
+                        LinkedHashMap::new,
+                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+    }
+
+    private static List<Integer> toTierScores(TierFilter tierFilter) {
+        return tierFilter.getTierNames().stream()
+                .map(name -> Tier.valueOf(name).getScore())
+                .toList();
+    }
+}

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
@@ -19,7 +19,7 @@ public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    private static final String DETAIL_KEY_PREFIX = "champion-stats:v6:detail:";
+    private static final String DETAIL_KEY_PREFIX = "champion-stats:v7:detail:";
     private static final String POSITIONS_KEY_PREFIX = "champion-stats:v4:positions:";
     private static final Duration CACHE_TTL = Duration.ofHours(6);
 

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.repository.championstats;
 
 import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.ChampionTimelineReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
 
     private static final String DETAIL_KEY_PREFIX = "champion-stats:v7:detail:";
     private static final String POSITIONS_KEY_PREFIX = "champion-stats:v4:positions:";
+    private static final String TIMELINE_KEY_PREFIX = "champion-stats:v1:timeline:";
     private static final Duration CACHE_TTL = Duration.ofHours(6);
 
     @Override
@@ -89,11 +91,37 @@ public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
         }
     }
 
+    @Override
+    public ChampionTimelineReadModel findChampionTimeline(
+            int championId, String patch, String platformId, String tierDisplay) {
+        return tryGetFromCache(buildTimelineKey(championId, patch, platformId, tierDisplay));
+    }
+
+    @Override
+    public void saveChampionTimeline(int championId, String patch, String platformId,
+                                     String tierDisplay, ChampionTimelineReadModel timeline) {
+        if (timeline == null) {
+            return;
+        }
+        try {
+            String key = buildTimelineKey(championId, patch, platformId, tierDisplay);
+            log.debug("캐시 저장 - key: {}", key);
+            redisTemplate.opsForValue().set(key, timeline, CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("캐시 저장 실패 - timeline championId: {}, patch: {}, tier: {}",
+                    championId, patch, tierDisplay, e);
+        }
+    }
+
     private String buildDetailKey(int championId, String patch, String platformId, String tierDisplay) {
         return DETAIL_KEY_PREFIX + platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
     }
 
     private String buildPositionsKey(String patch, String platformId, String tierDisplay) {
         return POSITIONS_KEY_PREFIX + platformId + ":" + patch + ":" + tierDisplay;
+    }
+
+    private String buildTimelineKey(int championId, String patch, String platformId, String tierDisplay) {
+        return TIMELINE_KEY_PREFIX + platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
     }
 }

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
@@ -19,7 +19,7 @@ public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    private static final String DETAIL_KEY_PREFIX = "champion-stats:v5:detail:";
+    private static final String DETAIL_KEY_PREFIX = "champion-stats:v6:detail:";
     private static final String POSITIONS_KEY_PREFIX = "champion-stats:v4:positions:";
     private static final Duration CACHE_TTL = Duration.ofHours(6);
 

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
@@ -19,7 +19,7 @@ public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    private static final String DETAIL_KEY_PREFIX = "champion-stats:v4:detail:";
+    private static final String DETAIL_KEY_PREFIX = "champion-stats:v5:detail:";
     private static final String POSITIONS_KEY_PREFIX = "champion-stats:v4:positions:";
     private static final Duration CACHE_TTL = Duration.ofHours(6);
 

--- a/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
+++ b/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
@@ -45,7 +45,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v6:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v7:detail:KR:13:16.1:EMERALD";
 
         ChampionStatsReadModel cached = new ChampionStatsReadModel("EMERALD", List.of());
 
@@ -68,7 +68,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v6:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v7:detail:KR:13:16.1:EMERALD";
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(expectedKey)).willReturn(null);
@@ -88,7 +88,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v6:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v7:detail:KR:13:16.1:EMERALD";
 
         ChampionStatsReadModel stats = new ChampionStatsReadModel("EMERALD", List.of());
 

--- a/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
+++ b/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
@@ -45,7 +45,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v4:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v5:detail:KR:13:16.1:EMERALD";
 
         ChampionStatsReadModel cached = new ChampionStatsReadModel("EMERALD", List.of());
 
@@ -68,7 +68,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v4:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v5:detail:KR:13:16.1:EMERALD";
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(expectedKey)).willReturn(null);
@@ -88,7 +88,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v4:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v5:detail:KR:13:16.1:EMERALD";
 
         ChampionStatsReadModel stats = new ChampionStatsReadModel("EMERALD", List.of());
 

--- a/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
+++ b/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
@@ -45,7 +45,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v5:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v6:detail:KR:13:16.1:EMERALD";
 
         ChampionStatsReadModel cached = new ChampionStatsReadModel("EMERALD", List.of());
 
@@ -68,7 +68,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v5:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v6:detail:KR:13:16.1:EMERALD";
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(expectedKey)).willReturn(null);
@@ -88,7 +88,7 @@ class ChampionStatsCacheAdapterTest {
         String patch = "16.1";
         String platformId = "KR";
         String tierDisplay = "EMERALD";
-        String expectedKey = "champion-stats:v5:detail:KR:13:16.1:EMERALD";
+        String expectedKey = "champion-stats:v6:detail:KR:13:16.1:EMERALD";
 
         ChampionStatsReadModel stats = new ChampionStatsReadModel("EMERALD", List.of());
 


### PR DESCRIPTION
## 변경 유형
feat

## 변경 사항
- **S1** STATS_DATASOURCE 기본값을 `bigquery` 로 변경. ClickHouse 어댑터·Config 는 runtime dead 상태(미호출) 라 본 PR 에서는 cleanup TODO 만 남기고 별도 후속.
- **S2** `/api/v1/{platformId}/champion-stats?championId&patch&tier` 응답에 per-position `pickRate / banRate / tier(S+/S/A/B/C/D)` 통합. 기존 `/champion-stats/positions` 와 동일 룰. detail 캐시 키 v4→v5 bump.
- **M1** `ChampionPositionStatsReadModel.averages: ChampionAverageStatsReadModel` 신설 (`teamPosition / avgKills / avgDeaths / avgAssists / kda / avgGoldPerMinute / avgLaneCs10m / avgJungleCs10m`). BigQuery `match_participant_fact` 에 클러스터 키 일치 AVG. 캐시 v5→v6.
- **M2** 6개 빌드 ReadModel(rune/spell/skill/startItem/boot/item) 모두 `sampleSize / totalSampleSize / confidenceLowerBound`(Wilson 95% lower bound) 추가. 캐시 v6→v7.
- **L1** 신규 endpoint `GET /api/v1/{platformId}/champion-stats/timeline?championId&patch&tier`. PostgreSQL `match_participant + match + participant_frame` JOIN 으로 5분 bucket(10/15/20/25/30분) 평균 곡선 (`avgGold / avgCs / avgXp / sampleSize`). Redis 캐시 6h, `champion-stats.cache.enabled` 토글 재사용.
- **CORS** local 프로파일 (`api-local.yml`) 의 `cors.allowed-origins` 에 `http://localhost:3001`, `http://localhost:3002` 추가 (prod 화이트리스트 변경 X).

## 변경 이유
- MP-9 "챔피언 분석 UI 전체적으로 수정" 의 server 측 데이터 보강. 기존 응답이 픽률·밴률·KDA·시간대별 곡선 등 op.gg/u.gg 류 핵심 지표를 노출하지 않아 UI 측이 정보 밀도를 올릴 수 없는 상태였음.
- L1 timeline 은 `participant_frame` 1분 단위 시계열이 PG 에 이미 적재되어 있어 신규 fact/MV 없이 즉시 가능. BigQuery 측 raw 컬럼은 슬림 fact 라 추후 별도 트랙으로 분리 (game-long CS · DPM · vision 등).

## 테스트
- [x] 단위 테스트 통과 (`./gradlew test` — `ChampionStatsServiceTest`, `ChampionStatsControllerTest`, `ChampionStatsCacheAdapterTest`, BigQuery/ClickHouse adapter test, PG `compileJava`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
- [x] 로컬 빌드 확인 (`./gradlew build`)
- [x] RestDocs asciidoctor 재생성
- `participant_frame` UNIQUE constraint `(match_id, timestamp, participant_id)` 가 leftmost prefix 로 L1 쿼리 cover — 추가 인덱스 마이그레이션 불필요 (V1__init.sql:588~652 검증).

## 리뷰 포인트
- **캐시 키 v4→v7 두 단계 bump**: TTL 6h 안에 자연 expire 후 점진 교체. 직렬화 호환 깨짐 (의도).
- **L1 PG 부담**: `champion-stats.cache.enabled=true` 가 아니면 PG OLAP 부담 큼. 운영 환경에서는 항상 ON.
- **STATS_DATASOURCE default 변경** 한 줄 — local 부팅 시 ClickHouse 호출이 사라짐 (이전엔 yml default 가 clickhouse 였음). dev 환경에서 BigQuery credentials 필요.

## 후속 이슈 (본 PR 범위 외)
- **Wilson 계산을 BigQuery SQL 단으로 이전**: 현재 M2 의 `confidenceLowerBound` 는 `WilsonScore.java` 유틸로 server-side 계산. 기존 코드베이스 (`ChampionStatsBigQuerySqls.java` `tier-list.sql` 의 `wilson_wr`) 와 일관성을 위해 6개 빌드 SQL 단으로 이전 권장. 행동 변화 없는 리팩터.
- **ClickHouse 어댑터·Config cleanup**: runtime dead 코드 제거 (S1 의 TODO 주석 추적).
- **M1 추가 지표** (game-long CS / DPM / vision): BigQuery `match_participant_fact` 에 raw 컬럼 부재 → repo 측 fact 컬럼 추가 후 별도 트랙.
- **L1 BQ MV 신규**: 시간대별 그래프를 BigQuery MV 로 옮기면 prod scale 에서 가벼움 (현재 PG 직접 집계 + Redis 6h 캐시).

Closes MP-9

Created-By: Padosol