### PR TITLE
docs: MP-27 BigQuery 전환 문서 sync + module-sync CI 룰

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, develop]
     paths:
       - '**/*.md'
+      - 'module/**/build.gradle'
       - '.github/workflows/docs-check.yml'
   schedule:
     # Weekly Monday 09:00 UTC — surfaces stale CLAUDE.md on code-only PRs
@@ -61,6 +62,51 @@ jobs:
               echo "ok  $f ($lines lines)"
             fi
           done < <(git ls-files '**/CLAUDE.md' 'CLAUDE.md')
+          exit $fail
+
+  module-sync:
+    name: Root CLAUDE.md ↔ module build.gradle sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify root CLAUDE.md module table matches module/**/build.gradle inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          fail=0
+
+          # Module paths from the root CLAUDE.md '## 모듈' table.
+          # Restrict to table rows ('| ...') so 'What to read first' links and
+          # other prose don't pollute the inventory; strip trailing /CLAUDE.md.
+          table_modules=$(grep -E '^\| ' CLAUDE.md \
+            | grep -oE 'module/[a-zA-Z0-9/._-]+' \
+            | sed -E 's|/CLAUDE\.md$||' \
+            | sort -u)
+
+          # Forward: every module/**/build.gradle must appear in the root table.
+          # Catches: new module added but its row is missing from CLAUDE.md.
+          while IFS= read -r gradle; do
+            mod=$(dirname "$gradle")
+            if ! grep -qx "$mod" <<< "$table_modules"; then
+              echo "::error file=CLAUDE.md::module '$mod' has $gradle but is missing from root CLAUDE.md '## 모듈' table — 새 모듈을 추가했다면 표에 행도 추가해 주세요."
+              fail=1
+            fi
+          done < <(find module -maxdepth 6 -name build.gradle | sort)
+
+          # Backward: every module path referenced in CLAUDE.md must exist on disk.
+          # Catches: module removed but its row was left in CLAUDE.md.
+          while IFS= read -r mod; do
+            [ -z "$mod" ] && continue
+            if [ ! -d "$mod" ]; then
+              echo "::error file=CLAUDE.md::root CLAUDE.md references '$mod' but the directory does not exist — stale 행을 제거해 주세요."
+              fail=1
+            fi
+          done <<< "$table_modules"
+
+          if [ "$fail" -eq 0 ]; then
+            echo "ok  build.gradle ↔ CLAUDE.md '## 모듈' 표 sync 통과"
+          fi
           exit $fail
 
   context-doc-freshness:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 | [`module/infra/api`](module/infra/api/CLAUDE.md) | REST 컨트롤러 + Spring Security/OAuth2 + RestDocs |
 | [`module/infra/persistence/postgresql`](module/infra/persistence/postgresql/CLAUDE.md) | JPA + QueryDSL + MapStruct + Flyway |
 | [`module/infra/persistence/redis`](module/infra/persistence/redis/CLAUDE.md) | 캐시, RefreshToken, OAuth State, Redisson 분산 락 |
-| [`module/infra/persistence/clickhouse`](module/infra/persistence/clickhouse/CLAUDE.md) | 챔피언 통계 OLAP 쿼리 |
+| [`module/infra/persistence/bigquery`](module/infra/persistence/bigquery/CLAUDE.md) | 챔피언 통계 OLAP — **`STATS_DATASOURCE=bigquery` (default)** |
+| [`module/infra/persistence/clickhouse`](module/infra/persistence/clickhouse/CLAUDE.md) | 챔피언 통계 OLAP — `STATS_DATASOURCE=clickhouse` 시 fallback (runtime dead by default) |
 | [`module/infra/client/lol-repository`](module/infra/client/lol-repository/CLAUDE.md) | Riot API `RestClient` + `@HttpExchange` + Bucket4j |
 | [`module/infra/client/oauth`](module/infra/client/oauth/CLAUDE.md) | RSO/OAuth2 토큰 교환 + 사용자 정보 조회 |
 | [`module/infra/message/rabbitmq`](module/infra/message/rabbitmq/CLAUDE.md) | 기본 메시지 broker (`message.broker=rabbitmq`) |
@@ -24,6 +25,7 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 - 새 도메인/비즈니스 규칙 추가 → [`core/lol-server-domain/CLAUDE.md`](module/core/lol-server-domain/CLAUDE.md)
 - 새 REST 엔드포인트 → [`infra/api/CLAUDE.md`](module/infra/api/CLAUDE.md)
 - 새 영속화/쿼리 → [`infra/persistence/postgresql/CLAUDE.md`](module/infra/persistence/postgresql/CLAUDE.md)
+- 챔피언 통계 OLAP 쿼리 → [`infra/persistence/bigquery/CLAUDE.md`](module/infra/persistence/bigquery/CLAUDE.md) (default), [`clickhouse/CLAUDE.md`](module/infra/persistence/clickhouse/CLAUDE.md) (fallback)
 - 외부 Riot/OAuth API 호출 → [`infra/client/lol-repository/CLAUDE.md`](module/infra/client/lol-repository/CLAUDE.md), [`infra/client/oauth/CLAUDE.md`](module/infra/client/oauth/CLAUDE.md)
 - 모듈 조립/프로파일/실행 → [`app/application/CLAUDE.md`](module/app/application/CLAUDE.md)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,8 @@ flowchart TB
       api["infra:api<br/>REST + Spring Security + RestDocs"]
       pg["infra:persistence:postgresql<br/>JPA + QueryDSL + MapStruct + Flyway"]
       redis["infra:persistence:redis<br/>Cache + RefreshToken + Redisson Lock"]
-      ch["infra:persistence:clickhouse<br/>OLAP 챔피언 통계"]
+      bq["infra:persistence:bigquery<br/>OLAP 챔피언 통계 (default, @Primary)"]
+      ch["infra:persistence:clickhouse<br/>OLAP fallback (runtime dead by default)"]
       lolClient["infra:client:lol-repository<br/>Riot API RestClient + Bucket4j"]
       oauth["infra:client:oauth<br/>RSO/OAuth2 토큰 교환"]
       rabbit["infra:message:rabbitmq<br/>기본 broker"]
@@ -36,6 +37,7 @@ flowchart TB
     application --> api
     application --> pg
     application --> redis
+    application --> bq
     application --> ch
     application --> lolClient
     application --> oauth
@@ -45,6 +47,7 @@ flowchart TB
     api --> domain
     pg --> domain
     redis --> domain
+    bq --> domain
     ch --> domain
     lolClient --> domain
     oauth --> domain
@@ -57,13 +60,14 @@ flowchart TB
     api --> coreEnum
     pg --> coreEnum
     redis --> coreEnum
+    bq --> coreEnum
     lolClient --> coreEnum
 
     classDef coreStyle fill:#dff5e1,stroke:#2d8f4f,color:#000
     classDef infraStyle fill:#e1eeff,stroke:#2d6cbf,color:#000
     classDef appStyle fill:#fff4d6,stroke:#bf922d,color:#000
     class domain,coreEnum,logging coreStyle
-    class api,pg,redis,ch,lolClient,oauth,rabbit,kafka infraStyle
+    class api,pg,redis,bq,ch,lolClient,oauth,rabbit,kafka infraStyle
     class application appStyle
 ```
 
@@ -130,25 +134,30 @@ sequenceDiagram
 
 자세한 시나리오·트러블슈팅은 [`docs/oauth2-login.md`](oauth2-login.md), [`docs/rso-oauth2-troubleshooting.md`](rso-oauth2-troubleshooting.md).
 
-### 3. 챔피언 통계 (ClickHouse OLAP)
+### 3. 챔피언 통계 (BigQuery OLAP — default, ClickHouse fallback)
 
 ```mermaid
 flowchart LR
     pg[("PostgreSQL<br/>matches, participants")]
-    ch[("ClickHouse<br/>materialized views")]
-    sql["docs/0[1-4]_*.sql<br/>스키마/뷰/쿼리"]
-    chAdapter["infra:persistence:clickhouse<br/>StatsClickHouseAdapter"]
-    svc["core:domain<br/>ChampionStatsService"]
+    bq[("BigQuery<br/>materialized views<br/>(default)")]
+    ch[("ClickHouse<br/>materialized views<br/>(legacy fallback)")]
+    sqlLegacy["docs/0[1-4]_*.sql<br/>ClickHouse 스키마/뷰/쿼리 (legacy)"]
+    bqAdapter["infra:persistence:bigquery<br/>ChampionStatsBigQueryAdapter<br/>@Primary @ConditionalOnProperty(stats.datasource=bigquery)"]
+    chAdapter["infra:persistence:clickhouse<br/>ChampionStatsClickHouseAdapter<br/>(runtime dead unless stats.datasource=clickhouse)"]
+    svc["core:domain<br/>ChampionStatsService<br/>(ChampionStatsQueryPort)"]
     api["infra:api<br/>StatsController"]
 
-    pg -.replicated.-> ch
-    sql -.정의.-> ch
+    pg -.consumer ETL.-> bq
+    pg -.consumer ETL (legacy).-> ch
+    sqlLegacy -.정의.-> ch
     api --> svc
-    svc --> chAdapter
+    svc --> bqAdapter
+    svc -. fallback only .-> chAdapter
+    bqAdapter --> bq
     chAdapter --> ch
 ```
 
-PostgreSQL OLTP 데이터를 ClickHouse 로 복제 후 materialized view 로 집계, 도메인 서비스는 `ChampionStatsClickHousePort` 를 통해서만 접근.
+PostgreSQL OLTP 데이터를 외부 ETL 파이프라인이 BigQuery 로 적재하고, 도메인 서비스는 `ChampionStatsQueryPort` 를 통해서만 접근한다. **`STATS_DATASOURCE` (default `bigquery`)** 가 어느 어댑터가 `@Primary` 로 빈 컨텍스트에 들어갈지 결정 — `bigquery` 면 BigQuery 어댑터만, `clickhouse` 면 ClickHouse 어댑터만 활성 (`@ConditionalOnProperty`). ClickHouse 경로는 BigQuery 장애 시 fallback / 검증용으로만 남아있고, 신규 통계 기능은 BigQuery 우선으로 추가하되 port 일치를 위해 양쪽에 동일 메서드를 구현한다 ([clickhouse/CLAUDE.md](../module/infra/persistence/clickhouse/CLAUDE.md), [bigquery/CLAUDE.md](../module/infra/persistence/bigquery/CLAUDE.md) 참조).
 
 ## "X 가 변경되면 어디가 영향받는가?" 빠른 답
 
@@ -162,6 +171,8 @@ PostgreSQL OLTP 데이터를 ClickHouse 로 복제 후 materialized view 로 집
 | Riot API VO (`restclient/.../model/*VO.java`) | `infra:client:lol-repository` 만 | Mapper 단위 테스트 (도메인은 모름) |
 | `application-*.yml` (프로파일) | `app:application` 런타임 | `local`/`dev`/`prod` 환경 차이 검증 |
 | `message.broker` 프로퍼티 | `app:application` | `infra:message:rabbitmq` ↔ `kafka` 활성 분기 |
+| `stats.datasource` (`STATS_DATASOURCE`, default `bigquery`) | `infra:persistence:bigquery` ↔ `clickhouse` 활성 분기 | 통계 API 응답 동등성 (양쪽 어댑터의 `ChampionStatsQueryPort` 메서드 일치) |
+| `ChampionStatsQueryPort` 메서드 추가/시그니처 | `infra:persistence:bigquery` (primary), `infra:persistence:clickhouse` (fallback) 양쪽 모두 | 한 쪽만 구현 시 fallback 전환 즉시 런타임 실패 |
 | `SecurityConfig` (`controller/security/`) | `infra:api` | 보호된 엔드포인트 화이트리스트, JWT 필터 체인 |
 
 ## See Also

--- a/module/infra/persistence/bigquery/CLAUDE.md
+++ b/module/infra/persistence/bigquery/CLAUDE.md
@@ -1,0 +1,60 @@
+# infra:persistence:bigquery
+
+BigQuery 분석 어댑터 (driven adapter). 챔피언 통계 (승률/픽률/밴률, 룬/스펠/아이템/매치업) OLAP 쿼리를 담당하는 **현재 default 통계 데이터소스**. `stats.datasource=bigquery` 일 때 활성화 (`STATS_DATASOURCE` 환경변수 기본값 `bigquery` — `application-{local,dev,prod}.yml` 모두 동일).
+
+## Boundaries
+
+- 허용: `core:lol-server-domain`, `core:enum`, `spring-boot-starter`, `com.google.cloud:google-cloud-bigquery` (libraries-bom 26.43.0)
+- 금지: JPA / Spring Data, JdbcTemplate, 트랜잭션 (BigQuery 는 read-only 분석 전용)
+- 활성화: `@ConditionalOnProperty(name = "stats.datasource", havingValue = "bigquery")` — Config + Adapter 양쪽 모두에 걸려있음. Adapter 는 `@Primary` 로 ClickHouse 어댑터를 압도
+
+## Layout
+
+- `repository/championstats/adapter/ChampionStatsBigQueryAdapter.java` — `ChampionStatsQueryPort` 구현체 전체
+- `repository/championstats/adapter/ChampionStatsBigQuerySqls.java` — Standard SQL 템플릿 상수 모음
+- `config/BigQueryConfig.java` — `BigQuery` 빈 (ADC 또는 `bigquery.credentials-location`)
+- `config/BigQueryProperties.java` — `bigquery.{projectId,dataset,credentialsLocation}` 바인딩 record
+
+## Key Files
+
+- `ChampionStatsBigQueryAdapter.java` — 모든 OLAP 쿼리. **named parameter** (`@patch`, `@platform`, `@tierBuckets`, `@championId`, `@position`) 로 안전 바인딩. 테이블명만 `dataset.<name>` 형태로 SQL 에 합성 (`table()` 헬퍼)
+- `BigQueryConfig.java` — credentials-location 가 비어있으면 ADC (`GOOGLE_APPLICATION_CREDENTIALS` 또는 워크로드 ID) 사용
+
+## Common Modifications
+
+- **새 통계 쿼리 추가**:
+  1. 도메인 `ChampionStatsQueryPort` 에 메서드 추가 (또는 신규 out port)
+  2. `ChampionStatsBigQuerySqls` 에 SQL 템플릿 상수 추가 (`%s` = 테이블명만, 값은 named parameter)
+  3. `ChampionStatsBigQueryAdapter` 에 `baseQuery(...)` / `championPositionQuery(...)` 호출 + `query(job, row -> new XxxReadModel(...))`
+  4. ClickHouse 어댑터에도 동일 메서드 추가 (port 구현 책임 일치 — fallback 경로 보존)
+- **새 BigQuery 테이블**: `BigQueryProperties.dataset` 하위 테이블명만 추가. 마이그레이션은 외부 ETL (`docs/0[1-4]_*.sql` 참조)
+
+## Failure Patterns / Gotchas
+
+- ❌ `String.formatted("%s", userInput)` 로 SQL 합성 — Injection
+  ✅ named parameter (`QueryParameterValue.int64/string/array`) 만 사용. 문자열 합성은 화이트리스트된 `dataset.<name>` 한정
+- ❌ Legacy SQL 활성화 — 함수/문법 호환성 깨짐
+  ✅ `setUseLegacySql(false)` 명시 (Standard SQL)
+- ❌ Tier enum 을 직접 string 으로 박기
+  ✅ `Tier.valueOf(name).getScore()` 정수 버킷 변환 (`toTierBuckets`) 후 `INT64` 배열로 전달
+- ❌ ClickHouse 어댑터에만 신규 메서드 추가 — `@Primary` 인 BigQuery 어댑터에 메서드 없으면 런타임 dispatch 실패
+
+## Cross-Module Dependencies
+
+- depends on: `core:lol-server-domain` (`ChampionStatsQueryPort`, `Champion*ReadModel`), `core:enum` (`Tier`, `TierFilter`)
+- consumed by: `app:application` 만 — `@Primary` 로 ClickHouse 어댑터를 가리고 빈 주입
+- BigQuery 데이터는 외부 ETL 파이프라인이 적재 — 이 모듈은 read-only
+
+## Quick Commands
+
+```bash
+./gradlew :module:infra:persistence:bigquery:test            # 어댑터 단위 테스트 (BigQuery 빈 mock)
+./gradlew :module:infra:persistence:bigquery:checkstyleMain  # checkstyle 단독 실행
+```
+
+## See Also
+
+- [core:lol-server-domain](../../../core/lol-server-domain/CLAUDE.md) — `ChampionStatsQueryPort` (구현 대상)
+- [clickhouse](../clickhouse/CLAUDE.md) — fallback 경로 (`stats.datasource=clickhouse` 시 활성)
+- [`docs/ARCHITECTURE.md`](../../../../docs/ARCHITECTURE.md) — 전체 OLAP 데이터 흐름
+- 테스트: `module/infra/persistence/bigquery/src/test/.../ChampionStatsBigQueryAdapterTest.java`

--- a/module/infra/persistence/clickhouse/CLAUDE.md
+++ b/module/infra/persistence/clickhouse/CLAUDE.md
@@ -1,6 +1,8 @@
 # infra:persistence:clickhouse
 
-ClickHouse 분석 어댑터 (driven adapter). 챔피언 통계 (승률/픽률/밴률, 룬/스펠/아이템/매치업) 같은 OLAP 쿼리만 담당한다. Postgres 와 별개의 데이터소스 (`clickHouseJdbcTemplate` qualifier).
+ClickHouse 분석 어댑터 (driven adapter). 챔피언 통계 (승률/픽률/밴률, 룬/스펠/아이템/매치업) OLAP 쿼리. Postgres 와 별개 데이터소스 (`clickHouseJdbcTemplate` qualifier).
+
+> **⚠️ Runtime status — fallback only.** MP-9 머지 이후 `STATS_DATASOURCE` 기본값이 `bigquery` 로 바뀌었다. BigQuery 어댑터가 `@Primary` 로 활성이면 이 모듈의 어댑터는 **runtime dead path** — `stats.datasource=clickhouse` 로 명시 override 한 환경에서만 호출된다 (BigQuery 장애 시 fallback 또는 비교 검증 용도). 코드/테스트는 유지하되 신규 통계 기능은 BigQuery 우선으로 작성하고 양쪽에 동일 메서드를 더한다 (port 일치 보장). 모듈 자체 제거 시점은 별도 결정 (MP-8 종료 후 N개월).
 
 ## Boundaries
 


### PR DESCRIPTION
## 변경 유형
docs (+ 부수 ci)

## 변경 사항
- `module/infra/persistence/bigquery/CLAUDE.md` 신규 — default 통계 데이터소스 (`stats.datasource=bigquery`) 어댑터의 5-Question 답
- 루트 `CLAUDE.md` 모듈 표에 `bigquery` 행 추가, `clickhouse` 는 fallback (runtime dead by default) 로 갱신
- `module/infra/persistence/clickhouse/CLAUDE.md` 에 runtime dead path / fallback only 명시 (MP-9 기준)
- `docs/ARCHITECTURE.md`
  - 모듈 의존 그래프에 `bq` 노드 추가, `ch` 라벨 갱신
  - 데이터 흐름 §3 OLAP 다이어그램을 BigQuery primary + ClickHouse legacy fallback 으로 재작성
  - "X 변경 시 영향" 표에 `stats.datasource` / `ChampionStatsQueryPort` 행 추가
- `.github/workflows/docs-check.yml` — `module-sync` 잡 신설:
  - `module/**/build.gradle` 인벤토리 ↔ 루트 `CLAUDE.md` `## 모듈` 표 양방향 일치 검증
  - PR 트리거 paths 에 `module/**/build.gradle` 추가
  - forward 단계는 settings.gradle include-only 모듈은 검증하지 못한다는 한계 주석

## 변경 이유
MP-9 머지로 `STATS_DATASOURCE` 기본값이 ClickHouse → BigQuery 로 바뀌었으나 문서 4곳이 그대로 남아 AI-Ready audit 점수가 77 → 66 으로 회귀 (A/C/D/F 4 카테고리에서 −11). 문서를 BigQuery default 사실에 맞춰 sync 하고, 동일한 회귀가 다시 발생하지 않도록 CI 가 모듈 표를 보호하게 만든다.

## 테스트
- [x] 로컬 sanity check: `module-sync` 룰 bash 스크립트 실행 → exit 0 (모듈 표 13행 = build.gradle 12개 + `module/core/enum` 1개 (settings.gradle include only — backward 검증으로만 보호))
- [x] CLAUDE.md 80줄 제한: bigquery 60줄 / clickhouse 60줄 / 루트 62줄
- [x] CI 1차: `Build & Test` / `Checkstyle` / `Docs Check` 4잡 (link/lint/freshness/module-sync) 모두 통과
- [ ] CI 2차 (리뷰 반영 커밋 이후) 통과 확인 예정

## 리뷰 라운드 1 (반영 완료, 추가 커밋 f5b0bda)
1. `docs/ARCHITECTURE.md` §3: BigQuery default 활성 메커니즘을 코드 기반으로 재기술. ClickHouse 어댑터/Config 는 조건 어노테이션 없이 항상 로드되며, yml 의 `${STATS_DATASOURCE:bigquery}` 가 default 값을 채워 BigQuery 어댑터 조건을 매치 → `@Primary` 가 단일 후보 선택. clickhouse override 시에는 BigQuery 빈 미생성으로 ClickHouse 단일 후보. (이전 표현은 양쪽 어댑터에 `@ConditionalOnProperty` 가 걸린 것처럼 들렸으나 사실 아님)
2. `clickhouse/CLAUDE.md`: "MP-8 종료 후 N개월" placeholder 제거 → "TBD — BigQuery 운영 안정성 확인 후 결정"
3. `bigquery/CLAUDE.md`: Boundaries 활성화 줄을 "이 모듈의 BigQueryConfig 와 Adapter 양쪽" 으로 명확화 + ClickHouse 쪽이 항상 로드되는 사실 함께 노출
4. `docs-check.yml`: module-sync 룰 forward 단계 한계 주석 추가 (settings.gradle include-only 모듈은 backward 만으로 보호)

## 후속 (이번 PR 범위 외)
- module-sync 룰의 settings.gradle include 사각지대를 정식으로 메우려면 `settings.gradle` 의 `include(...)` 모듈 인벤토리도 파싱하는 잡을 추가해야 함 — 별도 이슈로 검토 (현재 backward 검증으로 디렉토리 누락은 잡힘)

Closes MP-27