### PR TITLE
docs: MP-27 review 반영 — ARCHITECTURE 메커니즘 정확화 + clickhouse TBD

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -86,6 +86,9 @@ jobs:
 
           # Forward: every module/**/build.gradle must appear in the root table.
           # Catches: new module added but its row is missing from CLAUDE.md.
+          # Limitation: modules included via settings.gradle without their own
+          # build.gradle (e.g. module/core/enum) are NOT iterated here — they
+          # are protected only by the backward check (directory existence).
           while IFS= read -r gradle; do
             mod=$(dirname "$gradle")
             if ! grep -qx "$mod" <<< "$table_modules"; then

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -157,7 +157,14 @@ flowchart LR
     chAdapter --> ch
 ```
 
-PostgreSQL OLTP 데이터를 외부 ETL 파이프라인이 BigQuery 로 적재하고, 도메인 서비스는 `ChampionStatsQueryPort` 를 통해서만 접근한다. **`STATS_DATASOURCE` (default `bigquery`)** 가 어느 어댑터가 `@Primary` 로 빈 컨텍스트에 들어갈지 결정 — `bigquery` 면 BigQuery 어댑터만, `clickhouse` 면 ClickHouse 어댑터만 활성 (`@ConditionalOnProperty`). ClickHouse 경로는 BigQuery 장애 시 fallback / 검증용으로만 남아있고, 신규 통계 기능은 BigQuery 우선으로 추가하되 port 일치를 위해 양쪽에 동일 메서드를 구현한다 ([clickhouse/CLAUDE.md](../module/infra/persistence/clickhouse/CLAUDE.md), [bigquery/CLAUDE.md](../module/infra/persistence/bigquery/CLAUDE.md) 참조).
+PostgreSQL OLTP 데이터를 외부 ETL 파이프라인이 BigQuery 로 적재하고, 도메인 서비스는 `ChampionStatsQueryPort` 를 통해서만 접근한다. 활성 어댑터 선택 메커니즘:
+
+- `BigQueryConfig` + `ChampionStatsBigQueryAdapter` 양쪽에 `@ConditionalOnProperty(name = "stats.datasource", havingValue = "bigquery")` 가 걸려있고, 어댑터에는 추가로 `@Primary`.
+- `ClickHouseConfig` 와 `ChampionStatsClickHouseAdapter` 는 조건 어노테이션 없는 평범한 `@Configuration`/`@Component` 라 **항상 로드**된다 (`matchIfMissing` 같은 기본값 분기 없음).
+- `application-{local,dev,prod}.yml` 의 `stats.datasource: ${STATS_DATASOURCE:bigquery}` 가 환경변수 미지정 시 default 값을 `bigquery` 로 채워준다 — 그 결과 두 어댑터 모두 빈으로 등록되지만 `@Primary` 가 BigQuery 어댑터를 단일 후보로 선택.
+- `STATS_DATASOURCE=clickhouse` 로 override 하면 BigQuery 어댑터/Config 의 조건이 깨져 빈 자체가 미생성 → ClickHouse 어댑터만 단일 후보로 주입된다 (`@Primary` 불필요).
+
+ClickHouse 경로는 BigQuery 장애 시 fallback / 검증용으로만 남아있고, 신규 통계 기능은 BigQuery 우선으로 추가하되 port 일치를 위해 양쪽에 동일 메서드를 구현한다 ([clickhouse/CLAUDE.md](../module/infra/persistence/clickhouse/CLAUDE.md), [bigquery/CLAUDE.md](../module/infra/persistence/bigquery/CLAUDE.md) 참조).
 
 ## "X 가 변경되면 어디가 영향받는가?" 빠른 답
 

--- a/module/infra/persistence/bigquery/CLAUDE.md
+++ b/module/infra/persistence/bigquery/CLAUDE.md
@@ -6,7 +6,7 @@ BigQuery 분석 어댑터 (driven adapter). 챔피언 통계 (승률/픽률/밴�
 
 - 허용: `core:lol-server-domain`, `core:enum`, `spring-boot-starter`, `com.google.cloud:google-cloud-bigquery` (libraries-bom 26.43.0)
 - 금지: JPA / Spring Data, JdbcTemplate, 트랜잭션 (BigQuery 는 read-only 분석 전용)
-- 활성화: `@ConditionalOnProperty(name = "stats.datasource", havingValue = "bigquery")` — Config + Adapter 양쪽 모두에 걸려있음. Adapter 는 `@Primary` 로 ClickHouse 어댑터를 압도
+- 활성화: 이 모듈의 `BigQueryConfig` 와 `ChampionStatsBigQueryAdapter` 양쪽에 `@ConditionalOnProperty(name = "stats.datasource", havingValue = "bigquery")` 가 걸려있고, 어댑터에는 추가로 `@Primary`. ClickHouse 어댑터는 항상 로드되지만 default(`STATS_DATASOURCE` 미지정 시 yml 이 `bigquery` 로 채움)에서는 `@Primary` 가 BigQuery 를 단일 후보로 선택
 
 ## Layout
 

--- a/module/infra/persistence/clickhouse/CLAUDE.md
+++ b/module/infra/persistence/clickhouse/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ClickHouse 분석 어댑터 (driven adapter). 챔피언 통계 (승률/픽률/밴률, 룬/스펠/아이템/매치업) OLAP 쿼리. Postgres 와 별개 데이터소스 (`clickHouseJdbcTemplate` qualifier).
 
-> **⚠️ Runtime status — fallback only.** MP-9 머지 이후 `STATS_DATASOURCE` 기본값이 `bigquery` 로 바뀌었다. BigQuery 어댑터가 `@Primary` 로 활성이면 이 모듈의 어댑터는 **runtime dead path** — `stats.datasource=clickhouse` 로 명시 override 한 환경에서만 호출된다 (BigQuery 장애 시 fallback 또는 비교 검증 용도). 코드/테스트는 유지하되 신규 통계 기능은 BigQuery 우선으로 작성하고 양쪽에 동일 메서드를 더한다 (port 일치 보장). 모듈 자체 제거 시점은 별도 결정 (MP-8 종료 후 N개월).
+> **⚠️ Runtime status — fallback only.** MP-9 머지 이후 `STATS_DATASOURCE` 기본값이 `bigquery` 로 바뀌었다. BigQuery 어댑터가 `@Primary` 로 활성이면 이 모듈의 어댑터는 **runtime dead path** — `stats.datasource=clickhouse` 로 명시 override 한 환경에서만 호출된다 (BigQuery 장애 시 fallback 또는 비교 검증 용도). 코드/테스트는 유지하되 신규 통계 기능은 BigQuery 우선으로 작성하고 양쪽에 동일 메서드를 더한다 (port 일치 보장). 모듈 자체 제거 시점은 별도 이슈로 관리 (TBD — BigQuery 운영 안정성 확인 후 결정).
 
 ## Boundaries
 


### PR DESCRIPTION
## 변경 유형
docs

## 배경
Follow-up to #88. PR #88 의 reviewer LGTM 라운드에서 받은 4건 코멘트를 반영한 추가 커밋을 push 했으나, GitHub PR 페이지의 HEAD 갱신 race 로 PR HEAD 가 1차 커밋(`2c758d7`)인 상태에서 머지되어 리뷰 반영분이 develop 에 흘러가지 못했다. 본 PR 은 그 4건 변경분만 깨끗하게 cherry-pick (`626505d`).

## 변경 사항
1. `docs/ARCHITECTURE.md` §3 — BigQuery default 활성 메커니즘을 코드 기반으로 재기술
   - 이전 표현은 양쪽 어댑터에 `@ConditionalOnProperty` 가 걸린 것처럼 들렸으나 사실 아님 — `BigQueryConfig` + `ChampionStatsBigQueryAdapter` 양쪽에만 조건이 걸려있고 `ClickHouseConfig`/`ChampionStatsClickHouseAdapter` 는 조건 없는 `@Configuration`/`@Component` 라 항상 로드됨
   - default 메커니즘은 `application-{local,dev,prod}.yml` 의 `stats.datasource: ${STATS_DATASOURCE:bigquery}` — 환경변수 미지정 시 기본 `bigquery` 가 채워져 BigQuery 어댑터 조건 매치 → `@Primary` 가 단일 후보 선택
   - `STATS_DATASOURCE=clickhouse` override 시에는 BigQuery 빈 미생성 → ClickHouse 단일 후보
2. `module/infra/persistence/clickhouse/CLAUDE.md` — "MP-8 종료 후 N개월" placeholder 제거 → "TBD — BigQuery 운영 안정성 확인 후 결정"
3. `module/infra/persistence/bigquery/CLAUDE.md` — Boundaries 활성화 줄을 "이 모듈의 BigQueryConfig 와 Adapter 양쪽" 으로 명확화 + ClickHouse 어댑터가 항상 로드되는 사실 함께 노출
4. `.github/workflows/docs-check.yml` — `module-sync` 룰 forward 단계에 settings.gradle include-only 모듈 (예: `module/core/enum`) 은 backward 검증으로만 보호된다는 한계 주석 추가

## 변경 이유
PR #88 본문은 BigQuery 전환 사실을 반영했지만 일부 어노테이션 메커니즘 설명이 부정확했고 (reviewer 지적), `N개월` placeholder 가 그대로 들어가 있어 stale 검출 후에도 의미가 살아남지 않는 상태였다. 본 PR 로 사실관계와 placeholder 청소를 마무리해 MP-27 의 "AI-Ready 점수 회복" 목적을 완성한다.

## 테스트
- [x] cherry-pick 충돌 없음 (4 files / +13 / -3)
- [x] 로컬 sanity: `module-sync` 룰 bash 스크립트 → exit 0 (현 상태에서도 통과)
- [x] CLAUDE.md 80줄 제한: bigquery 60 / clickhouse 60 / 루트 62 모두 변경 없음
- [ ] CI: `Build & Test` / `Checkstyle` / `Docs Check` (link/lint/freshness/module-sync) 통과 확인 예정

## 리뷰 포인트
- ARCHITECTURE.md §3 마지막 단락의 메커니즘 기술이 실제 어노테이션과 일치하는지 (`BigQueryConfig.java:20`, `ChampionStatsBigQueryAdapter.java:40-42`, `ClickHouseConfig.java:11`, `ChampionStatsClickHouseAdapter.java:29` 기준)
- clickhouse `TBD` 표현이 후속 결정 트리거 (BigQuery 운영 안정성 평가) 와 잘 연결되는지

Follow-up to #88