### PR TITLE
chore: MP-25 CLAUDE.md 브랜치 prefix 표에 chore/docs 명문화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,16 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 - ReadModel 변환은 `*ReadModel.of(domain)` 정적 팩토리에서만
 - 매직 스트링 금지: `OAuthProvider.RIOT.name()`, `QueueType.RANKED_SOLO_5x5.name()` 등 enum 사용
 - 커밋 메시지: `<type>: MP-<번호> <한글 설명>` (Linear 키 필수; 타입 `feat`, `fix`, `refactor`, `docs`, `chore`)
-- 브랜치: `feature/MP-<번호>-*`, `fix/MP-<번호>-*`, `refactor/MP-<번호>-*` → `develop` → `main`; hotfix 는 `hotfix/MP-<번호>-* → main → develop`
+- 브랜치: `<type>/MP-<번호>-*` 형식. 기본 흐름은 `develop` → `main`, `hotfix`만 `main` → `develop` 역반영. type 6종:
+
+  | prefix | 용도 |
+  |---|---|
+  | `feature` | 새 기능·요구사항 추가 |
+  | `fix` | 버그 수정 |
+  | `refactor` | 동작 변화 없는 내부 구조 개선 |
+  | `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (예: 의존 업그레이드, audit 산출물, lint 룰 추가) |
+  | `docs` | 문서 추가·갱신 |
+  | `hotfix` | 긴급 수정 (`main` 직접 → `develop` 역반영) |
 
 ## See Also
 


### PR DESCRIPTION
변경 타입: chore

## 변경 유형
chore

## 변경 사항
- `CLAUDE.md` line 51 인라인 한 줄을 짧은 표로 승격
- 브랜치 prefix 6종(`feature` / `fix` / `refactor` / `chore` / `docs` / `hotfix`)을 모두 노출하고 각 용도를 한 줄로 설명

## 변경 이유
- `docs/workflow.md` §3 은 이미 6종을 명시하고 있으나 `CLAUDE.md` 베이스라인 컨벤션에는 4종(feature/fix/refactor/hotfix)만 적혀 있어 동기화가 어긋나 있었음
- mp-23 lol-server chore PR 리뷰에서 reviewer 가 비차단 메모로 'CLAUDE.md 컨벤션에 `chore/*` prefix 미정의' 를 지적 → 본 이슈로 후속 정리
- mp-23 사고(브랜치 `fix/*` + 변경 타입 `chore` 불일치) 재발 방지를 위해 PR description 본문 첫 줄에도 `변경 타입: chore` 를 파싱 가능한 형태로 명시

## 테스트
- [x] 문서 단독 변경 — 빌드/테스트 영향 없음 (단위 테스트·Checkstyle·gradle build SKIP)
- [x] PR CI 의 필수 체크 통과 확인 (Checkstyle pass / Build & Test pass)

## 리뷰 포인트
- 인라인 vs 표 승격: prefix 가 6종으로 늘어 한 줄에 다 담으면 길어져 표(prefix | 용도)로 승격함 — lol-ui CLAUDE.md 와 일관성 유지
- `chore` 행 설명에 audit 산출물·의존 업그레이드·lint 룰 추가를 예시로 포함

Closes MP-25