### PR TITLE
[MP-38] fix: 챔피언 통계 상세 BQ 첫 호출 timeout 해소

### DIFF
--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
@@ -19,9 +19,11 @@ import com.example.lolserver.domain.championstats.application.model.PositionTime
 import com.example.lolserver.domain.championstats.application.model.TimelineFrameReadModel;
 import com.example.lolserver.domain.championstats.application.port.in.ChampionStatsQueryUseCase;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsMetricsPort;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsQueryPort;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsTimelineQueryPort;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,6 +31,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -36,19 +43,28 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ChampionStatsService implements ChampionStatsQueryUseCase {
 
+    private static final int CACHE_POLL_ATTEMPTS = 15;
+    private static final long CACHE_POLL_INTERVAL_MS = 200L;
+
     private final ChampionStatsQueryPort championStatsQueryPort;
     private final ChampionStatsTimelineQueryPort championStatsTimelineQueryPort;
     private final ChampionStatsCachePort championStatsCachePort;
+    private final ChampionStatsMetricsPort championStatsMetricsPort;
+    private final Executor queryExecutor;
     private final boolean cacheEnabled;
 
     public ChampionStatsService(
             ChampionStatsQueryPort championStatsQueryPort,
             ChampionStatsTimelineQueryPort championStatsTimelineQueryPort,
             ChampionStatsCachePort championStatsCachePort,
+            ChampionStatsMetricsPort championStatsMetricsPort,
+            @Qualifier("queryExecutor") Executor queryExecutor,
             @Value("${champion-stats.cache.enabled:true}") boolean cacheEnabled) {
         this.championStatsQueryPort = championStatsQueryPort;
         this.championStatsTimelineQueryPort = championStatsTimelineQueryPort;
         this.championStatsCachePort = championStatsCachePort;
+        this.championStatsMetricsPort = championStatsMetricsPort;
+        this.queryExecutor = queryExecutor;
         this.cacheEnabled = cacheEnabled;
     }
 
@@ -57,42 +73,193 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
 
         String tierDisplay = tierFilter.toDisplayString();
 
-        if (cacheEnabled) {
-            ChampionStatsReadModel cached = championStatsCachePort
-                    .findChampionStats(championId, patch, platformId, tierDisplay);
-            if (cached != null) {
-                log.debug("캐시 히트 - championId: {}, patch: {}, tier: {}", championId, patch, tierDisplay);
-                return cached;
-            }
+        if (!cacheEnabled) {
+            return computeChampionStats(championId, patch, platformId, tierFilter, tierDisplay);
         }
 
-        List<ChampionWinRateReadModel> winRates =
-            championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter);
+        return loadWithSingleFlight(
+                () -> championStatsCachePort.findChampionStats(championId, patch, platformId, tierDisplay),
+                () -> championStatsCachePort.tryLockDetail(championId, patch, platformId, tierDisplay),
+                () -> championStatsCachePort.unlockDetail(championId, patch, platformId, tierDisplay),
+                () -> computeChampionStats(championId, patch, platformId, tierFilter, tierDisplay),
+                value -> championStatsCachePort.saveChampionStats(championId, patch, platformId, tierDisplay, value),
+                ChampionStatsMetricsPort.ENDPOINT_DETAIL
+        );
+    }
 
-        // pickRate/banRate/tier 는 by-position 결과와 일관성 유지를 위해 같은 데이터를 lookup.
-        // by-position 쪽은 별도 캐시 키 — hit 시 무비용, miss 면 한 번 BQ 호출.
-        Map<String, ChampionRateReadModel> rateByPosition =
-                lookupChampionRateByPosition(championId, patch, platformId, tierFilter);
+    public List<PositionChampionStatsReadModel> getChampionStatsByPosition(
+            String patch, String platformId, TierFilter tierFilter) {
 
-        Map<String, ChampionAverageStatsReadModel> averagesByPosition =
-                championStatsQueryPort.getChampionAverageStats(championId, patch, platformId, tierFilter)
-                        .stream()
-                        .collect(Collectors.toMap(
-                                ChampionAverageStatsReadModel::teamPosition, a -> a));
+        String tierDisplay = tierFilter.toDisplayString();
 
-        List<ChampionPositionStatsReadModel> positions = winRates.stream()
-            .map(wr -> buildPositionStats(championId, patch, platformId, tierFilter, wr,
-                    rateByPosition.get(wr.teamPosition()),
-                    averagesByPosition.get(wr.teamPosition())))
-            .toList();
-
-        ChampionStatsReadModel result = new ChampionStatsReadModel(tierDisplay, positions);
-
-        if (cacheEnabled) {
-            championStatsCachePort.saveChampionStats(championId, patch, platformId, tierDisplay, result);
+        if (!cacheEnabled) {
+            return computeChampionStatsByPosition(patch, platformId, tierFilter);
         }
 
-        return result;
+        return loadWithSingleFlight(
+                () -> championStatsCachePort.findChampionStatsByPosition(patch, platformId, tierDisplay),
+                () -> championStatsCachePort.tryLockByPosition(patch, platformId, tierDisplay),
+                () -> championStatsCachePort.unlockByPosition(patch, platformId, tierDisplay),
+                () -> computeChampionStatsByPosition(patch, platformId, tierFilter),
+                value -> championStatsCachePort.saveChampionStatsByPosition(patch, platformId, tierDisplay, value),
+                ChampionStatsMetricsPort.ENDPOINT_POSITIONS
+        );
+    }
+
+    public ChampionTimelineReadModel getChampionTimeline(
+            int championId, String patch, String platformId, TierFilter tierFilter) {
+
+        String tierDisplay = tierFilter.toDisplayString();
+
+        if (!cacheEnabled) {
+            return computeChampionTimeline(championId, patch, platformId, tierFilter, tierDisplay);
+        }
+
+        return loadWithSingleFlight(
+                () -> championStatsCachePort.findChampionTimeline(championId, patch, platformId, tierDisplay),
+                () -> championStatsCachePort.tryLockTimeline(championId, patch, platformId, tierDisplay),
+                () -> championStatsCachePort.unlockTimeline(championId, patch, platformId, tierDisplay),
+                () -> computeChampionTimeline(championId, patch, platformId, tierFilter, tierDisplay),
+                value -> championStatsCachePort.saveChampionTimeline(championId, patch, platformId, tierDisplay, value),
+                ChampionStatsMetricsPort.ENDPOINT_TIMELINE
+        );
+    }
+
+    private ChampionStatsReadModel computeChampionStats(
+            int championId, String patch, String platformId, TierFilter tierFilter, String tierDisplay) {
+
+        CompletableFuture<List<ChampionWinRateReadModel>> winRatesFuture =
+                CompletableFuture.supplyAsync(() ->
+                        championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter),
+                        queryExecutor);
+        CompletableFuture<Map<String, ChampionRateReadModel>> ratesFuture =
+                CompletableFuture.supplyAsync(() ->
+                        lookupChampionRateByPosition(championId, patch, platformId, tierFilter),
+                        queryExecutor);
+        CompletableFuture<Map<String, ChampionAverageStatsReadModel>> averagesFuture =
+                CompletableFuture.supplyAsync(() ->
+                        championStatsQueryPort.getChampionAverageStats(championId, patch, platformId, tierFilter)
+                                .stream()
+                                .collect(Collectors.toMap(ChampionAverageStatsReadModel::teamPosition, a -> a)),
+                        queryExecutor);
+
+        List<ChampionWinRateReadModel> winRates = winRatesFuture.join();
+
+        List<CompletableFuture<ChampionPositionStatsReadModel>> positionFutures = winRates.stream()
+                .map(wr -> buildPositionStatsAsync(
+                        championId, patch, platformId, tierFilter, wr, ratesFuture, averagesFuture))
+                .toList();
+
+        List<ChampionPositionStatsReadModel> positions = positionFutures.stream()
+                .map(CompletableFuture::join)
+                .toList();
+
+        return new ChampionStatsReadModel(tierDisplay, positions);
+    }
+
+    private CompletableFuture<ChampionPositionStatsReadModel> buildPositionStatsAsync(
+            int championId, String patch, String platformId, TierFilter tierFilter,
+            ChampionWinRateReadModel winRate,
+            CompletableFuture<Map<String, ChampionRateReadModel>> ratesFuture,
+            CompletableFuture<Map<String, ChampionAverageStatsReadModel>> averagesFuture) {
+
+        String position = winRate.teamPosition();
+        long totalSamples = winRate.totalGames();
+
+        CompletableFuture<List<ChampionMatchupReadModel>> matchupsF = async(() ->
+                championStatsQueryPort.getChampionMatchups(championId, patch, platformId, tierFilter, position));
+        CompletableFuture<List<ChampionRuneBuildReadModel>> runeBuildsF = async(() ->
+                withConfidence(championStatsQueryPort.getChampionRuneBuilds(
+                        championId, patch, platformId, tierFilter, position),
+                        totalSamples, ChampionRuneBuildReadModel::games,
+                        ChampionRuneBuildReadModel::winRate, ChampionRuneBuildReadModel::withConfidence));
+        CompletableFuture<List<ChampionSpellStatsReadModel>> spellStatsF = async(() ->
+                withConfidence(championStatsQueryPort.getChampionSpellStats(
+                        championId, patch, platformId, tierFilter, position),
+                        totalSamples, ChampionSpellStatsReadModel::games,
+                        ChampionSpellStatsReadModel::winRate, ChampionSpellStatsReadModel::withConfidence));
+        CompletableFuture<List<ChampionSkillBuildReadModel>> skillBuildsF = async(() ->
+                withConfidence(championStatsQueryPort.getChampionSkillBuilds(
+                        championId, patch, platformId, tierFilter, position),
+                        totalSamples, ChampionSkillBuildReadModel::games,
+                        ChampionSkillBuildReadModel::winRate, ChampionSkillBuildReadModel::withConfidence));
+        CompletableFuture<List<ChampionStartItemBuildReadModel>> startItemBuildsF = async(() ->
+                withConfidence(championStatsQueryPort.getChampionStartItemBuilds(
+                        championId, patch, platformId, tierFilter, position),
+                        totalSamples, ChampionStartItemBuildReadModel::games,
+                        ChampionStartItemBuildReadModel::winRate, ChampionStartItemBuildReadModel::withConfidence));
+        CompletableFuture<List<ChampionBootBuildReadModel>> bootBuildsF = async(() ->
+                withConfidence(championStatsQueryPort.getChampionBootBuilds(
+                        championId, patch, platformId, tierFilter, position),
+                        totalSamples, ChampionBootBuildReadModel::games,
+                        ChampionBootBuildReadModel::winRate, ChampionBootBuildReadModel::withConfidence));
+        CompletableFuture<List<ChampionItemBuildReadModel>> itemBuildsF = async(() ->
+                withConfidence(championStatsQueryPort.getChampionItemBuilds(
+                        championId, patch, platformId, tierFilter, position),
+                        totalSamples, ChampionItemBuildReadModel::games,
+                        ChampionItemBuildReadModel::winRate, ChampionItemBuildReadModel::withConfidence));
+
+        return CompletableFuture.allOf(matchupsF, runeBuildsF, spellStatsF, skillBuildsF,
+                        startItemBuildsF, bootBuildsF, itemBuildsF, ratesFuture, averagesFuture)
+                .thenApply(__ -> {
+                    ChampionRateReadModel rate = ratesFuture.join().get(position);
+                    return new ChampionPositionStatsReadModel(
+                            position, winRate.totalWinRate(),
+                            rate != null ? rate.pickRate() : 0.0,
+                            rate != null ? rate.banRate() : 0.0,
+                            rate != null ? rate.tier() : null,
+                            winRate.totalGames(),
+                            averagesFuture.join().get(position),
+                            matchupsF.join(), runeBuildsF.join(), spellStatsF.join(), skillBuildsF.join(),
+                            startItemBuildsF.join(), bootBuildsF.join(), itemBuildsF.join());
+                });
+    }
+
+    private <T> CompletableFuture<T> async(Supplier<T> supplier) {
+        return CompletableFuture.supplyAsync(supplier, queryExecutor);
+    }
+
+    private static <T> List<T> withConfidence(
+            List<T> source, long totalSamples,
+            java.util.function.ToLongFunction<T> gamesGetter,
+            java.util.function.ToDoubleFunction<T> winRateGetter,
+            ConfidenceApplier<T> applier) {
+        return source.stream()
+                .map(b -> applier.apply(b, totalSamples,
+                        wilson(gamesGetter.applyAsLong(b), winRateGetter.applyAsDouble(b))))
+                .toList();
+    }
+
+    @FunctionalInterface
+    private interface ConfidenceApplier<T> {
+        T apply(T source, long totalSamples, double confidence);
+    }
+
+    private List<PositionChampionStatsReadModel> computeChampionStatsByPosition(
+            String patch, String platformId, TierFilter tierFilter) {
+
+        Map<String, List<ChampionRateReadModel>> groupedByPosition =
+                championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter);
+
+        return groupedByPosition.entrySet().stream()
+                .map(entry -> new PositionChampionStatsReadModel(
+                        entry.getKey(),
+                        assignTiersIfMissing(entry.getValue())))
+                .toList();
+    }
+
+    private ChampionTimelineReadModel computeChampionTimeline(
+            int championId, String patch, String platformId, TierFilter tierFilter, String tierDisplay) {
+
+        Map<String, List<TimelineFrameReadModel>> grouped =
+                championStatsTimelineQueryPort.aggregateChampionTimeline(
+                        championId, patch, platformId, tierFilter);
+
+        List<PositionTimelineReadModel> positions = grouped.entrySet().stream()
+                .map(entry -> new PositionTimelineReadModel(entry.getKey(), entry.getValue()))
+                .toList();
+
+        return new ChampionTimelineReadModel(championId, tierDisplay, positions);
     }
 
     private Map<String, ChampionRateReadModel> lookupChampionRateByPosition(
@@ -112,119 +279,57 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
         return result;
     }
 
-    private ChampionPositionStatsReadModel buildPositionStats(
-            int championId, String patch, String platformId, TierFilter tierFilter,
-            ChampionWinRateReadModel winRate, ChampionRateReadModel rate,
-            ChampionAverageStatsReadModel averages) {
-        String position = winRate.teamPosition();
-        long totalSamples = winRate.totalGames();
+    private <T> T loadWithSingleFlight(
+            Supplier<T> cacheLookup,
+            BooleanSupplier tryAcquireLock,
+            Runnable releaseLock,
+            Supplier<T> computeFresh,
+            Consumer<T> saveCache,
+            String endpoint) {
 
-        List<ChampionMatchupReadModel> matchups =
-            championStatsQueryPort.getChampionMatchups(championId, patch, platformId, tierFilter, position);
-        List<ChampionRuneBuildReadModel> runeBuilds =
-            championStatsQueryPort.getChampionRuneBuilds(championId, patch, platformId, tierFilter, position)
-                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
-        List<ChampionSpellStatsReadModel> spellStats =
-            championStatsQueryPort.getChampionSpellStats(championId, patch, platformId, tierFilter, position)
-                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
-        List<ChampionSkillBuildReadModel> skillBuilds =
-            championStatsQueryPort.getChampionSkillBuilds(championId, patch, platformId, tierFilter, position)
-                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
-        List<ChampionStartItemBuildReadModel> startItemBuilds =
-            championStatsQueryPort.getChampionStartItemBuilds(championId, patch, platformId, tierFilter, position)
-                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
-        List<ChampionBootBuildReadModel> bootBuilds =
-            championStatsQueryPort.getChampionBootBuilds(championId, patch, platformId, tierFilter, position)
-                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
-        List<ChampionItemBuildReadModel> itemBuilds =
-            championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, position)
-                    .stream().map(b -> b.withConfidence(totalSamples, wilson(b.games(), b.winRate()))).toList();
+        T cached = cacheLookup.get();
+        if (cached != null) {
+            return cached;
+        }
 
-        double pickRate = rate != null ? rate.pickRate() : 0.0;
-        double banRate = rate != null ? rate.banRate() : 0.0;
-        String tier = rate != null ? rate.tier() : null;
+        boolean acquired = tryAcquireLock.getAsBoolean();
+        if (acquired) {
+            try {
+                T doubleCheck = cacheLookup.get();
+                if (doubleCheck != null) {
+                    return doubleCheck;
+                }
+                T fresh = computeFresh.get();
+                saveCache.accept(fresh);
+                return fresh;
+            } finally {
+                releaseLock.run();
+            }
+        }
 
-        return new ChampionPositionStatsReadModel(
-            position,
-            winRate.totalWinRate(),
-            pickRate,
-            banRate,
-            tier,
-            winRate.totalGames(),
-            averages,
-            matchups, runeBuilds, spellStats, skillBuilds,
-            startItemBuilds, bootBuilds, itemBuilds
-        );
+        for (int attempt = 0; attempt < CACHE_POLL_ATTEMPTS; attempt++) {
+            try {
+                Thread.sleep(CACHE_POLL_INTERVAL_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+            cached = cacheLookup.get();
+            if (cached != null) {
+                return cached;
+            }
+        }
+
+        log.warn("Single-flight fallback - endpoint: {}", endpoint);
+        championStatsMetricsPort.recordSingleFlightFallback(endpoint);
+        T fresh = computeFresh.get();
+        saveCache.accept(fresh);
+        return fresh;
     }
 
     private static double wilson(long games, double winRate) {
         long wins = Math.round(winRate * games);
         return WilsonScore.lowerBound95(wins, games);
-    }
-
-    public List<PositionChampionStatsReadModel> getChampionStatsByPosition(
-            String patch, String platformId, TierFilter tierFilter) {
-
-        String tierDisplay = tierFilter.toDisplayString();
-
-        if (cacheEnabled) {
-            List<PositionChampionStatsReadModel> cached = championStatsCachePort
-                    .findChampionStatsByPosition(patch, platformId, tierDisplay);
-            if (cached != null) {
-                log.debug("캐시 히트 - positions, patch: {}, tier: {}", patch, tierDisplay);
-                return cached;
-            }
-        }
-
-        Map<String, List<ChampionRateReadModel>> groupedByPosition =
-                championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter);
-
-        List<PositionChampionStatsReadModel> result = groupedByPosition.entrySet().stream()
-                .map(entry -> new PositionChampionStatsReadModel(
-                        entry.getKey(),
-                        assignTiersIfMissing(entry.getValue())
-                ))
-                .toList();
-
-        if (cacheEnabled) {
-            championStatsCachePort.saveChampionStatsByPosition(patch, platformId, tierDisplay, result);
-        }
-
-        return result;
-    }
-
-    public ChampionTimelineReadModel getChampionTimeline(
-            int championId, String patch, String platformId, TierFilter tierFilter) {
-
-        String tierDisplay = tierFilter.toDisplayString();
-
-        if (cacheEnabled) {
-            ChampionTimelineReadModel cached = championStatsCachePort
-                    .findChampionTimeline(championId, patch, platformId, tierDisplay);
-            if (cached != null) {
-                log.debug("캐시 히트 - timeline championId: {}, patch: {}, tier: {}",
-                        championId, patch, tierDisplay);
-                return cached;
-            }
-        }
-
-        Map<String, List<TimelineFrameReadModel>> grouped =
-                championStatsTimelineQueryPort.aggregateChampionTimeline(
-                        championId, patch, platformId, tierFilter);
-
-        List<PositionTimelineReadModel> positions = grouped.entrySet().stream()
-                .map(entry -> new PositionTimelineReadModel(entry.getKey(), entry.getValue()))
-                .toList();
-
-        ChampionTimelineReadModel result =
-                new ChampionTimelineReadModel(championId, tierDisplay, positions);
-
-        if (cacheEnabled) {
-            championStatsCachePort.saveChampionTimeline(
-                    championId, patch, platformId, tierDisplay, result);
-        }
-
-        return result;
     }
 
     private static List<ChampionRateReadModel> assignTiersIfMissing(List<ChampionRateReadModel> champions) {

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsCachePort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsCachePort.java
@@ -25,4 +25,16 @@ public interface ChampionStatsCachePort {
 
     void saveChampionTimeline(int championId, String patch, String platformId,
                               String tierDisplay, ChampionTimelineReadModel timeline);
+
+    boolean tryLockDetail(int championId, String patch, String platformId, String tierDisplay);
+
+    void unlockDetail(int championId, String patch, String platformId, String tierDisplay);
+
+    boolean tryLockByPosition(String patch, String platformId, String tierDisplay);
+
+    void unlockByPosition(String patch, String platformId, String tierDisplay);
+
+    boolean tryLockTimeline(int championId, String patch, String platformId, String tierDisplay);
+
+    void unlockTimeline(int championId, String patch, String platformId, String tierDisplay);
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsMetricsPort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/port/out/ChampionStatsMetricsPort.java
@@ -1,0 +1,10 @@
+package com.example.lolserver.domain.championstats.application.port.out;
+
+public interface ChampionStatsMetricsPort {
+
+    String ENDPOINT_DETAIL = "detail";
+    String ENDPOINT_POSITIONS = "positions";
+    String ENDPOINT_TIMELINE = "timeline";
+
+    void recordSingleFlightFallback(String endpoint);
+}

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceConcurrencyTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceConcurrencyTest.java
@@ -1,0 +1,276 @@
+package com.example.lolserver.domain.championstats.application;
+
+import com.example.lolserver.TierFilter;
+import com.example.lolserver.domain.championstats.application.model.ChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.model.ChampionTimelineReadModel;
+import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsMetricsPort;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsQueryPort;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsTimelineQueryPort;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class ChampionStatsServiceConcurrencyTest {
+
+    @Mock
+    private ChampionStatsTimelineQueryPort championStatsTimelineQueryPort;
+
+    @Mock
+    private ChampionStatsMetricsPort championStatsMetricsPort;
+
+    private CountingQueryPort queryPort;
+    private InMemoryCachePort cachePort;
+    private ChampionStatsService service;
+    private ExecutorService callerExecutor;
+
+    @BeforeEach
+    void setUp() {
+        queryPort = new CountingQueryPort();
+        cachePort = new InMemoryCachePort();
+        service = new ChampionStatsService(
+                queryPort, championStatsTimelineQueryPort, cachePort, championStatsMetricsPort,
+                Runnable::run, true);
+        callerExecutor = Executors.newFixedThreadPool(16);
+    }
+
+    @AfterEach
+    void tearDown() {
+        callerExecutor.shutdownNow();
+    }
+
+    @DisplayName("동시에 cache miss 로 진입한 N 요청은 BQ 를 단 1회만 호출한다 (single-flight)")
+    @Test
+    void concurrentCacheMiss_invokesBigQueryOnce() throws InterruptedException {
+        // given
+        int callers = 10;
+        int championId = 13;
+        String patch = "16.1";
+        String platformId = "KR";
+        TierFilter tierFilter = TierFilter.of("EMERALD");
+
+        // by-position 캐시 hit 으로 nested single-flight 단락
+        cachePort.seedByPosition(patch, platformId, "EMERALD", List.of());
+
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch finishGate = new CountDownLatch(callers);
+
+        // when
+        for (int i = 0; i < callers; i++) {
+            callerExecutor.submit(() -> {
+                try {
+                    startGate.await();
+                    service.getChampionStats(championId, patch, platformId, tierFilter);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    finishGate.countDown();
+                }
+            });
+        }
+        startGate.countDown();
+        boolean done = finishGate.await(10, TimeUnit.SECONDS);
+
+        // then
+        assertThat(done).isTrue();
+        assertThat(queryPort.winRatesCalls.get())
+                .as("동시 진입 N 요청에 대해 getChampionWinRates 는 단일 호출자만 실행해야 한다")
+                .isEqualTo(1);
+    }
+
+    private static class CountingQueryPort implements ChampionStatsQueryPort {
+        final AtomicInteger winRatesCalls = new AtomicInteger();
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionWinRateReadModel>
+                getChampionWinRates(int championId, String patch, String platformId, TierFilter tierFilter) {
+            winRatesCalls.incrementAndGet();
+            // 모방: BQ 호출이 잠시 걸린다고 가정 — 다른 caller 들이 폴링/락 대기에 진입하도록
+            try {
+                Thread.sleep(50L);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            return List.of();
+        }
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionAverageStatsReadModel>
+                getChampionAverageStats(int championId, String patch, String platformId, TierFilter tierFilter) {
+            return List.of();
+        }
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionMatchupReadModel>
+                getChampionMatchups(int championId, String patch, String platformId, TierFilter tierFilter, String position) {
+            return List.of();
+        }
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionRuneBuildReadModel>
+                getChampionRuneBuilds(int championId, String patch, String platformId, TierFilter tierFilter, String position) {
+            return List.of();
+        }
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionSpellStatsReadModel>
+                getChampionSpellStats(int championId, String patch, String platformId, TierFilter tierFilter, String position) {
+            return List.of();
+        }
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionSkillBuildReadModel>
+                getChampionSkillBuilds(int championId, String patch, String platformId, TierFilter tierFilter, String position) {
+            return List.of();
+        }
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionStartItemBuildReadModel>
+                getChampionStartItemBuilds(int championId, String patch, String platformId, TierFilter tierFilter, String position) {
+            return List.of();
+        }
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionBootBuildReadModel>
+                getChampionBootBuilds(int championId, String patch, String platformId, TierFilter tierFilter, String position) {
+            return List.of();
+        }
+
+        @Override
+        public List<com.example.lolserver.domain.championstats.application.model.ChampionItemBuildReadModel>
+                getChampionItemBuilds(int championId, String patch, String platformId, TierFilter tierFilter, String position) {
+            return List.of();
+        }
+
+        @Override
+        public Map<String, List<com.example.lolserver.domain.championstats.application.model.ChampionRateReadModel>>
+                getChampionStatsByPosition(String patch, String platformId, TierFilter tierFilter) {
+            return Map.of();
+        }
+    }
+
+    private static class InMemoryCachePort implements ChampionStatsCachePort {
+        private final ConcurrentHashMap<String, ChampionStatsReadModel> detailCache = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<String, List<PositionChampionStatsReadModel>> positionsCache = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<String, ChampionTimelineReadModel> timelineCache = new ConcurrentHashMap<>();
+        private final ConcurrentHashMap<String, ReentrantLock> locks = new ConcurrentHashMap<>();
+
+        void seedByPosition(String patch, String platformId, String tierDisplay,
+                            List<PositionChampionStatsReadModel> value) {
+            positionsCache.put(positionsKey(patch, platformId, tierDisplay), value);
+        }
+
+        @Override
+        public ChampionStatsReadModel findChampionStats(
+                int championId, String patch, String platformId, String tierDisplay) {
+            return detailCache.get(detailKey(championId, patch, platformId, tierDisplay));
+        }
+
+        @Override
+        public void saveChampionStats(int championId, String patch, String platformId,
+                                       String tierDisplay, ChampionStatsReadModel stats) {
+            detailCache.put(detailKey(championId, patch, platformId, tierDisplay), stats);
+        }
+
+        @Override
+        public List<PositionChampionStatsReadModel> findChampionStatsByPosition(
+                String patch, String platformId, String tierDisplay) {
+            return positionsCache.get(positionsKey(patch, platformId, tierDisplay));
+        }
+
+        @Override
+        public void saveChampionStatsByPosition(String patch, String platformId, String tierDisplay,
+                                                 List<PositionChampionStatsReadModel> stats) {
+            positionsCache.put(positionsKey(patch, platformId, tierDisplay), stats);
+        }
+
+        @Override
+        public ChampionTimelineReadModel findChampionTimeline(
+                int championId, String patch, String platformId, String tierDisplay) {
+            return timelineCache.get(timelineKey(championId, patch, platformId, tierDisplay));
+        }
+
+        @Override
+        public void saveChampionTimeline(int championId, String patch, String platformId,
+                                          String tierDisplay, ChampionTimelineReadModel timeline) {
+            timelineCache.put(timelineKey(championId, patch, platformId, tierDisplay), timeline);
+        }
+
+        @Override
+        public boolean tryLockDetail(int championId, String patch, String platformId, String tierDisplay) {
+            return tryLock("detail:" + detailKey(championId, patch, platformId, tierDisplay));
+        }
+
+        @Override
+        public void unlockDetail(int championId, String patch, String platformId, String tierDisplay) {
+            unlock("detail:" + detailKey(championId, patch, platformId, tierDisplay));
+        }
+
+        @Override
+        public boolean tryLockByPosition(String patch, String platformId, String tierDisplay) {
+            return tryLock("positions:" + positionsKey(patch, platformId, tierDisplay));
+        }
+
+        @Override
+        public void unlockByPosition(String patch, String platformId, String tierDisplay) {
+            unlock("positions:" + positionsKey(patch, platformId, tierDisplay));
+        }
+
+        @Override
+        public boolean tryLockTimeline(int championId, String patch, String platformId, String tierDisplay) {
+            return tryLock("timeline:" + timelineKey(championId, patch, platformId, tierDisplay));
+        }
+
+        @Override
+        public void unlockTimeline(int championId, String patch, String platformId, String tierDisplay) {
+            unlock("timeline:" + timelineKey(championId, patch, platformId, tierDisplay));
+        }
+
+        private boolean tryLock(String key) {
+            ReentrantLock lock = locks.computeIfAbsent(key, k -> new ReentrantLock());
+            try {
+                return lock.tryLock(3L, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return false;
+            }
+        }
+
+        private void unlock(String key) {
+            ReentrantLock lock = locks.get(key);
+            if (lock != null && lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        }
+
+        private String detailKey(int championId, String patch, String platformId, String tierDisplay) {
+            return platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
+        }
+
+        private String positionsKey(String patch, String platformId, String tierDisplay) {
+            return platformId + ":" + patch + ":" + tierDisplay;
+        }
+
+        private String timelineKey(int championId, String patch, String platformId, String tierDisplay) {
+            return platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
+        }
+    }
+}

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceTest.java
@@ -14,6 +14,7 @@ import com.example.lolserver.domain.championstats.application.model.ChampionRate
 import com.example.lolserver.domain.championstats.application.model.ChampionWinRateReadModel;
 import com.example.lolserver.domain.championstats.application.model.PositionChampionStatsReadModel;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsMetricsPort;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsQueryPort;
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsTimelineQueryPort;
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,9 +49,14 @@ class ChampionStatsServiceTest {
     @Mock
     private ChampionStatsCachePort championStatsCachePort;
 
+    @Mock
+    private ChampionStatsMetricsPort championStatsMetricsPort;
+
+    private final Executor synchronousExecutor = Runnable::run;
+
     private ChampionStatsService createService(boolean cacheEnabled) {
         return new ChampionStatsService(championStatsQueryPort, championStatsTimelineQueryPort,
-                championStatsCachePort, cacheEnabled);
+                championStatsCachePort, championStatsMetricsPort, synchronousExecutor, cacheEnabled);
     }
 
     @Nested
@@ -68,6 +75,11 @@ class ChampionStatsServiceTest {
 
             given(championStatsCachePort.findChampionStats(championId, patch, platformId, "EMERALD"))
                 .willReturn(null);
+            given(championStatsCachePort.tryLockDetail(championId, patch, platformId, "EMERALD"))
+                .willReturn(true);
+            // by-position 캐시 hit 으로 nested single-flight 단락
+            given(championStatsCachePort.findChampionStatsByPosition(patch, platformId, "EMERALD"))
+                .willReturn(List.of());
 
             ChampionWinRateReadModel middleWinRate = new ChampionWinRateReadModel("MIDDLE", 1000, 520, 0.52);
             ChampionWinRateReadModel topWinRate = new ChampionWinRateReadModel("TOP", 200, 110, 0.55);
@@ -171,6 +183,8 @@ class ChampionStatsServiceTest {
 
             then(championStatsCachePort).should().saveChampionStats(
                 eq(championId), eq(patch), eq(platformId), eq("EMERALD"), any(ChampionStatsReadModel.class));
+            then(championStatsCachePort).should().unlockDetail(championId, patch, platformId, "EMERALD");
+            then(championStatsMetricsPort).should(never()).recordSingleFlightFallback(anyString());
         }
 
         @DisplayName("승률 데이터가 없으면 빈 포지션 리스트를 반환한다")
@@ -185,6 +199,10 @@ class ChampionStatsServiceTest {
 
             given(championStatsCachePort.findChampionStats(championId, patch, platformId, "EMERALD"))
                 .willReturn(null);
+            given(championStatsCachePort.tryLockDetail(championId, patch, platformId, "EMERALD"))
+                .willReturn(true);
+            given(championStatsCachePort.findChampionStatsByPosition(patch, platformId, "EMERALD"))
+                .willReturn(List.of());
 
             given(championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter))
                 .willReturn(List.of());
@@ -196,6 +214,7 @@ class ChampionStatsServiceTest {
             // then
             assertThat(result.tier()).isEqualTo("EMERALD");
             assertThat(result.positions()).isEmpty();
+            then(championStatsCachePort).should().unlockDetail(championId, patch, platformId, "EMERALD");
         }
 
         @DisplayName("포지션별 챔피언 승률/픽률/밴률을 반환한다")
@@ -209,6 +228,8 @@ class ChampionStatsServiceTest {
 
             given(championStatsCachePort.findChampionStatsByPosition(patch, platformId, "EMERALD"))
                 .willReturn(null);
+            given(championStatsCachePort.tryLockByPosition(patch, platformId, "EMERALD"))
+                .willReturn(true);
 
             Map<String, List<ChampionRateReadModel>> grouped = Map.of(
                 "TOP", List.of(
@@ -240,6 +261,7 @@ class ChampionStatsServiceTest {
 
             then(championStatsCachePort).should().saveChampionStatsByPosition(
                 eq(patch), eq(platformId), eq("EMERALD"), any());
+            then(championStatsCachePort).should().unlockByPosition(patch, platformId, "EMERALD");
         }
 
         @DisplayName("포지션별 챔피언 통계 조회 시 데이터가 없으면 빈 리스트를 반환한다")
@@ -253,6 +275,8 @@ class ChampionStatsServiceTest {
 
             given(championStatsCachePort.findChampionStatsByPosition(patch, platformId, "EMERALD"))
                 .willReturn(null);
+            given(championStatsCachePort.tryLockByPosition(patch, platformId, "EMERALD"))
+                .willReturn(true);
 
             given(championStatsQueryPort.getChampionStatsByPosition(patch, platformId, tierFilter))
                 .willReturn(Map.of());
@@ -270,9 +294,9 @@ class ChampionStatsServiceTest {
     @DisplayName("캐시 히트 시나리오 (cacheEnabled=true)")
     class CacheHitTests {
 
-        @DisplayName("캐시 히트 시 QueryPort를 호출하지 않는다")
+        @DisplayName("캐시 히트 시 QueryPort 와 락을 호출하지 않는다")
         @Test
-        void getChampionStats_cacheHit_skipsQueryPort() {
+        void getChampionStats_cacheHit_skipsQueryPortAndLock() {
             // given
             ChampionStatsService service = createService(true);
             int championId = 13;
@@ -291,11 +315,12 @@ class ChampionStatsServiceTest {
             // then
             assertThat(result).isSameAs(cached);
             then(championStatsQueryPort).should(never()).getChampionWinRates(anyInt(), anyString(), anyString(), any());
+            then(championStatsCachePort).should(never()).tryLockDetail(anyInt(), anyString(), anyString(), anyString());
         }
 
-        @DisplayName("포지션별 캐시 히트 시 QueryPort를 호출하지 않는다")
+        @DisplayName("포지션별 캐시 히트 시 QueryPort 와 락을 호출하지 않는다")
         @Test
-        void getChampionStatsByPosition_cacheHit_skipsQueryPort() {
+        void getChampionStatsByPosition_cacheHit_skipsQueryPortAndLock() {
             // given
             ChampionStatsService service = createService(true);
             String patch = "16.1";
@@ -315,6 +340,7 @@ class ChampionStatsServiceTest {
             // then
             assertThat(result).isSameAs(cached);
             then(championStatsQueryPort).should(never()).getChampionStatsByPosition(anyString(), anyString(), any());
+            then(championStatsCachePort).should(never()).tryLockByPosition(anyString(), anyString(), anyString());
         }
     }
 
@@ -322,9 +348,9 @@ class ChampionStatsServiceTest {
     @DisplayName("캐시 OFF 시나리오 (cacheEnabled=false)")
     class CacheDisabledTests {
 
-        @DisplayName("캐시 OFF 시 캐시 포트를 호출하지 않는다")
+        @DisplayName("캐시 OFF 시 캐시 포트와 락을 호출하지 않는다")
         @Test
-        void getChampionStats_cacheDisabled_skipsCachePort() {
+        void getChampionStats_cacheDisabled_skipsCachePortAndLock() {
             // given
             ChampionStatsService service = createService(false);
             int championId = 13;
@@ -343,11 +369,12 @@ class ChampionStatsServiceTest {
             assertThat(result.positions()).isEmpty();
             then(championStatsCachePort).should(never()).findChampionStats(anyInt(), anyString(), anyString(), anyString());
             then(championStatsCachePort).should(never()).saveChampionStats(anyInt(), anyString(), anyString(), anyString(), any());
+            then(championStatsCachePort).should(never()).tryLockDetail(anyInt(), anyString(), anyString(), anyString());
         }
 
-        @DisplayName("캐시 OFF 시 포지션별 조회에서도 캐시 포트를 호출하지 않는다")
+        @DisplayName("캐시 OFF 시 포지션별 조회에서도 캐시 포트와 락을 호출하지 않는다")
         @Test
-        void getChampionStatsByPosition_cacheDisabled_skipsCachePort() {
+        void getChampionStatsByPosition_cacheDisabled_skipsCachePortAndLock() {
             // given
             ChampionStatsService service = createService(false);
             String patch = "16.1";
@@ -364,6 +391,106 @@ class ChampionStatsServiceTest {
             assertThat(result).isEmpty();
             then(championStatsCachePort).should(never()).findChampionStatsByPosition(anyString(), anyString(), anyString());
             then(championStatsCachePort).should(never()).saveChampionStatsByPosition(anyString(), anyString(), anyString(), any());
+            then(championStatsCachePort).should(never()).tryLockByPosition(anyString(), anyString(), anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("Single-flight 시나리오 (cacheEnabled=true)")
+    class SingleFlightTests {
+
+        @DisplayName("락 획득 실패 후 폴링 중 캐시 hit 발생 시 BQ 를 호출하지 않는다")
+        @Test
+        void getChampionStats_lockFailedThenCachePopulated_skipsBigQuery() {
+            // given
+            ChampionStatsService service = createService(true);
+            int championId = 13;
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
+
+            ChampionStatsReadModel populated = new ChampionStatsReadModel("EMERALD", List.of());
+
+            // 첫 호출 null, 폴링 첫 시도에서 hit
+            given(championStatsCachePort.findChampionStats(championId, patch, platformId, "EMERALD"))
+                .willReturn(null, populated);
+            given(championStatsCachePort.tryLockDetail(championId, patch, platformId, "EMERALD"))
+                .willReturn(false);
+
+            // when
+            ChampionStatsReadModel result = service.getChampionStats(championId, patch, platformId, tierFilter);
+
+            // then
+            assertThat(result).isSameAs(populated);
+            then(championStatsQueryPort).should(never()).getChampionWinRates(anyInt(), anyString(), anyString(), any());
+            then(championStatsMetricsPort).should(never()).recordSingleFlightFallback(anyString());
+        }
+
+        @DisplayName("락 획득 실패 + 폴링 timeout → fallback BQ 호출 + 캐시 set + counter 증가")
+        @Test
+        void getChampionStats_lockFailedAndPollExhausted_fallsBackAndRecordsMetric() {
+            // given
+            ChampionStatsService service = createService(true);
+            int championId = 13;
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
+
+            given(championStatsCachePort.findChampionStats(championId, patch, platformId, "EMERALD"))
+                .willReturn(null);
+            given(championStatsCachePort.tryLockDetail(championId, patch, platformId, "EMERALD"))
+                .willReturn(false);
+            // by-position 캐시 hit 으로 nested single-flight 단락
+            given(championStatsCachePort.findChampionStatsByPosition(patch, platformId, "EMERALD"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter))
+                .willReturn(List.of());
+
+            // when (interrupt early to skip polling sleeps)
+            Thread.currentThread().interrupt();
+            ChampionStatsReadModel result;
+            try {
+                result = service.getChampionStats(championId, patch, platformId, tierFilter);
+            } finally {
+                Thread.interrupted();
+            }
+
+            // then
+            assertThat(result.tier()).isEqualTo("EMERALD");
+            then(championStatsQueryPort).should().getChampionWinRates(championId, patch, platformId, tierFilter);
+            then(championStatsCachePort).should().saveChampionStats(
+                eq(championId), eq(patch), eq(platformId), eq("EMERALD"), any(ChampionStatsReadModel.class));
+            then(championStatsMetricsPort).should().recordSingleFlightFallback(
+                ChampionStatsMetricsPort.ENDPOINT_DETAIL);
+            then(championStatsCachePort).should(never()).unlockDetail(anyInt(), anyString(), anyString(), anyString());
+        }
+
+        @DisplayName("락 획득 후 double-check 캐시 hit 시 BQ 를 호출하지 않고 unlock 한다")
+        @Test
+        void getChampionStats_lockAcquiredButCachePopulatedDuringWait_skipsBigQuery() {
+            // given
+            ChampionStatsService service = createService(true);
+            int championId = 13;
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
+
+            ChampionStatsReadModel populated = new ChampionStatsReadModel("EMERALD", List.of());
+
+            given(championStatsCachePort.findChampionStats(championId, patch, platformId, "EMERALD"))
+                .willReturn(null, populated);
+            given(championStatsCachePort.tryLockDetail(championId, patch, platformId, "EMERALD"))
+                .willReturn(true);
+
+            // when
+            ChampionStatsReadModel result = service.getChampionStats(championId, patch, platformId, tierFilter);
+
+            // then
+            assertThat(result).isSameAs(populated);
+            then(championStatsQueryPort).should(never()).getChampionWinRates(anyInt(), anyString(), anyString(), any());
+            then(championStatsCachePort).should(never()).saveChampionStats(
+                anyInt(), anyString(), anyString(), anyString(), any());
+            then(championStatsCachePort).should().unlockDetail(championId, patch, platformId, "EMERALD");
         }
     }
 }

--- a/module/infra/persistence/redis/build.gradle
+++ b/module/infra/persistence/redis/build.gradle
@@ -7,4 +7,7 @@ dependencies {
 
     // redisson
     implementation 'org.redisson:redisson-spring-boot-starter:3.46.0'
+
+    // micrometer (single-flight fallback counter)
+    implementation 'io.micrometer:micrometer-core'
 }

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapter.java
@@ -6,12 +6,15 @@ import com.example.lolserver.domain.championstats.application.model.PositionCham
 import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsCachePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.SerializationException;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -19,11 +22,17 @@ import java.util.List;
 public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
 
     private final RedisTemplate<String, Object> redisTemplate;
+    private final RedissonClient redissonClient;
 
     private static final String DETAIL_KEY_PREFIX = "champion-stats:v7:detail:";
     private static final String POSITIONS_KEY_PREFIX = "champion-stats:v4:positions:";
     private static final String TIMELINE_KEY_PREFIX = "champion-stats:v1:timeline:";
+    private static final String DETAIL_LOCK_PREFIX = "champion-stats:lock:detail:";
+    private static final String POSITIONS_LOCK_PREFIX = "champion-stats:lock:positions:";
+    private static final String TIMELINE_LOCK_PREFIX = "champion-stats:lock:timeline:";
     private static final Duration CACHE_TTL = Duration.ofHours(6);
+    private static final long LOCK_WAIT_TIME_SECONDS = 3L;
+    private static final long LOCK_LEASE_TIME_SECONDS = 30L;
 
     @Override
     public ChampionStatsReadModel findChampionStats(
@@ -113,6 +122,58 @@ public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
         }
     }
 
+    @Override
+    public boolean tryLockDetail(int championId, String patch, String platformId, String tierDisplay) {
+        return tryLock(buildDetailLockKey(championId, patch, platformId, tierDisplay));
+    }
+
+    @Override
+    public void unlockDetail(int championId, String patch, String platformId, String tierDisplay) {
+        unlock(buildDetailLockKey(championId, patch, platformId, tierDisplay));
+    }
+
+    @Override
+    public boolean tryLockByPosition(String patch, String platformId, String tierDisplay) {
+        return tryLock(buildPositionsLockKey(patch, platformId, tierDisplay));
+    }
+
+    @Override
+    public void unlockByPosition(String patch, String platformId, String tierDisplay) {
+        unlock(buildPositionsLockKey(patch, platformId, tierDisplay));
+    }
+
+    @Override
+    public boolean tryLockTimeline(int championId, String patch, String platformId, String tierDisplay) {
+        return tryLock(buildTimelineLockKey(championId, patch, platformId, tierDisplay));
+    }
+
+    @Override
+    public void unlockTimeline(int championId, String patch, String platformId, String tierDisplay) {
+        unlock(buildTimelineLockKey(championId, patch, platformId, tierDisplay));
+    }
+
+    private boolean tryLock(String lockKey) {
+        RLock lock = redissonClient.getLock(lockKey);
+        try {
+            return lock.tryLock(LOCK_WAIT_TIME_SECONDS, LOCK_LEASE_TIME_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.warn("Lock acquisition interrupted - key: {}", lockKey, e);
+            return false;
+        }
+    }
+
+    private void unlock(String lockKey) {
+        try {
+            RLock lock = redissonClient.getLock(lockKey);
+            if (lock.isHeldByCurrentThread()) {
+                lock.unlock();
+            }
+        } catch (Exception e) {
+            log.warn("Lock release failed - key: {}", lockKey, e);
+        }
+    }
+
     private String buildDetailKey(int championId, String patch, String platformId, String tierDisplay) {
         return DETAIL_KEY_PREFIX + platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
     }
@@ -123,5 +184,17 @@ public class ChampionStatsCacheAdapter implements ChampionStatsCachePort {
 
     private String buildTimelineKey(int championId, String patch, String platformId, String tierDisplay) {
         return TIMELINE_KEY_PREFIX + platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
+    }
+
+    private String buildDetailLockKey(int championId, String patch, String platformId, String tierDisplay) {
+        return DETAIL_LOCK_PREFIX + platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
+    }
+
+    private String buildPositionsLockKey(String patch, String platformId, String tierDisplay) {
+        return POSITIONS_LOCK_PREFIX + platformId + ":" + patch + ":" + tierDisplay;
+    }
+
+    private String buildTimelineLockKey(int championId, String patch, String platformId, String tierDisplay) {
+        return TIMELINE_LOCK_PREFIX + platformId + ":" + championId + ":" + patch + ":" + tierDisplay;
     }
 }

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsMicrometerMetricsAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/championstats/ChampionStatsMicrometerMetricsAdapter.java
@@ -1,0 +1,24 @@
+package com.example.lolserver.repository.championstats;
+
+import com.example.lolserver.domain.championstats.application.port.out.ChampionStatsMetricsPort;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChampionStatsMicrometerMetricsAdapter implements ChampionStatsMetricsPort {
+
+    private static final String COUNTER_NAME = "lol.bq.single_flight.fallback";
+
+    private final MeterRegistry meterRegistry;
+
+    @Override
+    public void recordSingleFlightFallback(String endpoint) {
+        Counter.builder(COUNTER_NAME)
+                .tag("endpoint", endpoint)
+                .register(meterRegistry)
+                .increment();
+    }
+}

--- a/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
+++ b/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/championstats/ChampionStatsCacheAdapterTest.java
@@ -8,16 +8,20 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class ChampionStatsCacheAdapterTest {
@@ -28,13 +32,19 @@ class ChampionStatsCacheAdapterTest {
     @Mock
     private ValueOperations<String, Object> valueOperations;
 
+    @Mock
+    private RedissonClient redissonClient;
+
+    @Mock
+    private RLock rLock;
+
     private ChampionStatsCacheAdapter adapter;
 
     private static final Duration CACHE_TTL = Duration.ofHours(6);
 
     @BeforeEach
     void setUp() {
-        adapter = new ChampionStatsCacheAdapter(redisTemplate);
+        adapter = new ChampionStatsCacheAdapter(redisTemplate, redissonClient);
     }
 
     @DisplayName("챔피언 상세 통계 캐시 히트 시 데이터를 반환한다")
@@ -233,5 +243,97 @@ class ChampionStatsCacheAdapterTest {
 
         // when & then
         adapter.saveChampionStatsByPosition("16.1", "KR", "EMERALD", stats);
+    }
+
+    @DisplayName("tryLockDetail 은 단일 키 prefix 와 wait 3s / lease 30s 로 RLock 을 획득한다")
+    @Test
+    void tryLockDetail_acquiresRedissonLockWithExpectedKeyAndTimings() throws InterruptedException {
+        // given
+        String expectedLockKey = "champion-stats:lock:detail:KR:13:16.1:EMERALD";
+        given(redissonClient.getLock(expectedLockKey)).willReturn(rLock);
+        given(rLock.tryLock(3L, 30L, TimeUnit.SECONDS)).willReturn(true);
+
+        // when
+        boolean acquired = adapter.tryLockDetail(13, "16.1", "KR", "EMERALD");
+
+        // then
+        assertThat(acquired).isTrue();
+        then(rLock).should().tryLock(3L, 30L, TimeUnit.SECONDS);
+    }
+
+    @DisplayName("tryLockDetail 이 InterruptedException 을 받으면 false 를 반환하고 인터럽트 플래그를 복원한다")
+    @Test
+    void tryLockDetail_interruptedReturnsFalseAndRestoresFlag() throws InterruptedException {
+        // given
+        String expectedLockKey = "champion-stats:lock:detail:KR:13:16.1:EMERALD";
+        given(redissonClient.getLock(expectedLockKey)).willReturn(rLock);
+        given(rLock.tryLock(3L, 30L, TimeUnit.SECONDS)).willThrow(new InterruptedException("interrupted"));
+
+        // when
+        boolean acquired = adapter.tryLockDetail(13, "16.1", "KR", "EMERALD");
+
+        // then
+        assertThat(acquired).isFalse();
+        assertThat(Thread.interrupted()).isTrue();
+    }
+
+    @DisplayName("unlockDetail 은 현재 스레드가 락 보유자일 때만 unlock 을 호출한다")
+    @Test
+    void unlockDetail_releasesOnlyWhenHeldByCurrentThread() {
+        // given
+        String expectedLockKey = "champion-stats:lock:detail:KR:13:16.1:EMERALD";
+        given(redissonClient.getLock(expectedLockKey)).willReturn(rLock);
+        given(rLock.isHeldByCurrentThread()).willReturn(true);
+
+        // when
+        adapter.unlockDetail(13, "16.1", "KR", "EMERALD");
+
+        // then
+        then(rLock).should().unlock();
+    }
+
+    @DisplayName("unlockDetail 은 현재 스레드가 락 보유자가 아니면 unlock 을 호출하지 않는다")
+    @Test
+    void unlockDetail_skipsWhenNotHeld() {
+        // given
+        String expectedLockKey = "champion-stats:lock:detail:KR:13:16.1:EMERALD";
+        given(redissonClient.getLock(expectedLockKey)).willReturn(rLock);
+        given(rLock.isHeldByCurrentThread()).willReturn(false);
+
+        // when
+        adapter.unlockDetail(13, "16.1", "KR", "EMERALD");
+
+        // then
+        then(rLock).should(never()).unlock();
+    }
+
+    @DisplayName("tryLockByPosition 은 positions 락 키 prefix 를 사용한다")
+    @Test
+    void tryLockByPosition_acquiresRedissonLockWithPositionsKey() throws InterruptedException {
+        // given
+        String expectedLockKey = "champion-stats:lock:positions:KR:16.1:EMERALD";
+        given(redissonClient.getLock(expectedLockKey)).willReturn(rLock);
+        given(rLock.tryLock(3L, 30L, TimeUnit.SECONDS)).willReturn(true);
+
+        // when
+        boolean acquired = adapter.tryLockByPosition("16.1", "KR", "EMERALD");
+
+        // then
+        assertThat(acquired).isTrue();
+    }
+
+    @DisplayName("tryLockTimeline 은 timeline 락 키 prefix 를 사용한다")
+    @Test
+    void tryLockTimeline_acquiresRedissonLockWithTimelineKey() throws InterruptedException {
+        // given
+        String expectedLockKey = "champion-stats:lock:timeline:KR:13:16.1:EMERALD";
+        given(redissonClient.getLock(expectedLockKey)).willReturn(rLock);
+        given(rLock.tryLock(3L, 30L, TimeUnit.SECONDS)).willReturn(true);
+
+        // when
+        boolean acquired = adapter.tryLockTimeline(13, "16.1", "KR", "EMERALD");
+
+        // then
+        assertThat(acquired).isTrue();
     }
 }


### PR DESCRIPTION
## 변경 유형
fix

## 변경 사항
- ChampionStatsService: queryExecutor(Virtual Thread) 기반 BQ 쿼리 병렬 fan-out — winRates / by-position / averages 1차 wave 동시 시작 + 포지션별 7쿼리 (matchups/runeBuilds/spellStats/skillBuilds/startItemBuilds/bootBuilds/itemBuilds) 2차 wave 동시 fan-out
- Cache stampede 방지: Redisson 분산 락 기반 single-flight (tryLock wait 3s, lease 30s) + double-check + polling fallback (200ms × 15 = 3s) + A안 fallback BQ 직접 호출 + fallback 결과도 캐시 set
- ChampionStatsCachePort 확장: tryLock/unlock 6 메서드 (detail / by-position / timeline 3쌍) — 어댑터(Redis)가 락 키 합성 책임
- ChampionStatsMetricsPort 신설: lol.bq.single_flight.fallback Counter (tag endpoint=detail|positions|timeline) — Micrometer 어댑터 (infra/persistence/redis)

## 변경 이유
- 챔피언 통계 상세 페이지 첫 호출 시 BigQuery 호출이 약 10개 직렬 발사되어 10초 timeout 발생
- 추가로 캐시 만료 직후 동시 다발 요청 시 동일 쿼리가 N회 중복 발사되는 cache stampede 위험 존재
- (1) 병렬화로 평균 응답 단축, (2) Redis 분산 락 기반 single-flight 로 다중 인스턴스 환경에서도 BQ 호출을 1회로 수렴

## 테스트
- [x] 단위 테스트 통과 (\`:module:core:lol-server-domain:test\`, \`:module:infra:persistence:redis:test\`)
- [x] Checkstyle 통과 (\`:module:core:lol-server-domain:checkstyleMain checkstyleTest\`, \`:module:infra:persistence:redis:checkstyleMain checkstyleTest\`)
- [x] 동시성 통합 테스트 추가: 10 caller 동시 cache miss → ChampionStatsQueryPort.getChampionWinRates 호출 횟수 == 1 검증 (ChampionStatsServiceConcurrencyTest)
- [x] 로컬 빌드 확인 — 변경 모듈 한정 \`compileJava\` (worktree 정책상 전체 build 는 CI 에서)

## 리뷰 포인트
- single-flight 락 wait 3s / lease 30s / polling 200ms × 15 — 운영 BQ p95 모르는 상태에서의 초기값. 실 데이터로 후속 튜닝 예정
- fallback 정책 A안 (BQ 직접 호출 + 캐시 set + counter 증가). 락 보유자 사망/lease 만료 코너 케이스 보호. fallback 빈도는 lol.bq.single_flight.fallback 메트릭으로 추적
- ChampionStatsService 가 Executor (JDK) + @Qualifier("queryExecutor") 만 의존 — 도메인 boundary (infra import 금지) 유지

Closes MP-38