### PR TITLE
chore: MP-45 챔피언 통계 응답에서 null/공백 skillBuild 필터링

### DIFF
--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/championstats/application/ChampionStatsService.java
@@ -154,7 +154,9 @@ public class ChampionStatsService implements ChampionStatsQueryUseCase {
                         ChampionSpellStatsReadModel::winRate, ChampionSpellStatsReadModel::withConfidence));
         CompletableFuture<List<ChampionSkillBuildReadModel>> skillBuildsF = async(() ->
                 withConfidence(championStatsQueryPort.getChampionSkillBuilds(
-                        championId, patch, platformId, tierFilter, position),
+                                championId, patch, platformId, tierFilter, position).stream()
+                                .filter(b -> b.skillBuild() != null && !b.skillBuild().isBlank())
+                                .toList(),
                         totalSamples, ChampionSkillBuildReadModel::games,
                         ChampionSkillBuildReadModel::winRate, ChampionSkillBuildReadModel::withConfidence));
         CompletableFuture<List<ChampionStartItemBuildReadModel>> startItemBuildsF = async(() ->

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/championstats/application/ChampionStatsServiceTest.java
@@ -183,6 +183,53 @@ class ChampionStatsServiceTest {
             then(championStatsMetricsPort).should(never()).recordSingleFlightFallback(anyString());
         }
 
+        @DisplayName("skillBuild 가 null/공백인 항목은 응답에서 제외한다")
+        @Test
+        void getChampionStats_filtersNullOrBlankSkillBuilds() {
+            // given
+            ChampionStatsService service = createService(false);
+            int championId = 13;
+            String patch = "16.1";
+            String platformId = "KR";
+            TierFilter tierFilter = TierFilter.of("EMERALD");
+
+            ChampionWinRateReadModel middleWinRate = new ChampionWinRateReadModel("MIDDLE", 1000, 520, 0.52);
+            given(championStatsQueryPort.getChampionWinRates(championId, patch, platformId, tierFilter))
+                .willReturn(List.of(middleWinRate));
+
+            // skillBuilds: 정상 1건 + null 1건 + 공백 1건 → 정상 1건만 남아야 함
+            List<ChampionSkillBuildReadModel> skillBuildsWithNoise = List.of(
+                new ChampionSkillBuildReadModel("QWEQEEREQEQWWWW", 400, 0.525, 0.4),
+                new ChampionSkillBuildReadModel(null, 100, 0.5, 0.1),
+                new ChampionSkillBuildReadModel("   ", 50, 0.48, 0.05)
+            );
+
+            given(championStatsQueryPort.getChampionMatchups(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionRuneBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionSpellStats(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionSkillBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(skillBuildsWithNoise);
+            given(championStatsQueryPort.getChampionStartItemBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionBootBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(List.of());
+            given(championStatsQueryPort.getChampionItemBuilds(championId, patch, platformId, tierFilter, "MIDDLE"))
+                .willReturn(List.of());
+
+            // when
+            ChampionStatsReadModel result = service.getChampionStats(
+                championId, patch, platformId, tierFilter);
+
+            // then
+            assertThat(result.positions()).hasSize(1);
+            ChampionPositionStatsReadModel middleStats = result.positions().get(0);
+            assertThat(middleStats.skillBuilds()).hasSize(1);
+            assertThat(middleStats.skillBuilds().get(0).skillBuild()).isEqualTo("QWEQEEREQEQWWWW");
+        }
+
         @DisplayName("승률 데이터가 없으면 빈 포지션 리스트를 반환한다")
         @Test
         void getChampionStats_returnsEmptyPositions_whenNoWinRateData() {


### PR DESCRIPTION
## 변경 유형
chore (런타임 동작 변화 없는 정합성 cleanup — null/공백 항목만 응답에서 제외)

## 변경 사항
- `ChampionStatsService.computeChampionStats` 의 skillBuilds CompletableFuture 에서 `withConfidence` 호출 전 `skillBuild` 가 `null` 이거나 `isBlank()` 인 항목을 stream filter 로 제외.
- `ChampionStatsServiceTest` 에 정상 1건 + null 1건 + 공백 1건 입력 시 정상 1건만 남는 회귀 테스트 추가.

## 변경 이유
- lol-ui CLAUDE.md 원칙 "데이터 정렬·가공은 server 에서" 준수 — 프론트의 type-predicate 안전망(`skillBuild` 빈 문자열 fallback)을 server 단에서 선제적으로 제거.
- BigQuery 결과에 빈 `skill_build` 레코드가 끼더라도 응답 정합성 유지.
- 정상 데이터 응답 형태·필드 시그니처는 그대로 (positions[].skillBuilds[] 길이만 줄어듦).

## 테스트
- [x] 단위 테스트 통과 (`./gradlew :module:core:lol-server-domain:test --tests ChampionStatsServiceTest`) — 9 tests pass
- [x] Checkstyle 통과 (`./gradlew :module:core:lol-server-domain:checkstyleMain checkstyleTest`)
- [ ] 로컬 빌드 확인 (`./gradlew build`) — 변경 범위 한정, CI 에서 검증

## 리뷰 포인트
- 필터 위치: BQ 어댑터(infra) 가 아닌 `ChampionStatsService`(application) 단 — leader 가 지정한 "BQ 결과 → DTO 매핑 단" 해석. infra 어댑터는 BQ 원본을 그대로 노출하고, 정합성은 application 이 책임지는 헥사고날 흐름 유지.
- `ChampionSkillBuildReadModel` 레코드의 `skillBuild` 필드는 현재 nullable 어노테이션이 없어 "표기 제거" 대상 없음 — 단순 `String` 필드라 syntactic 변화 불필요. 필터로 server 가 non-null·non-blank 보장하므로 OpenAPI/asciidoc 단계에서 명시 가능.
- ChampionStatsService 의 single-flight / 캐시 / 병렬 호출 로직 변경 없음 (MP-38 영역, 본 PR 범위 밖).

Closes MP-45

Parent: MP-37
선행 머지: MP-38 (PR #97)