### PR TITLE
chore: MP-41 CLAUDE.md 브랜치 prefix 표 정리 (예시 열 + 비대칭 명시)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,14 +49,16 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 - 커밋 메시지: `<type>: MP-<번호> <한글 설명>` (Linear 키 필수; 타입 `feat`, `fix`, `refactor`, `docs`, `chore`)
 - 브랜치: `<type>/MP-<번호>-*` 형식. 기본 흐름은 `develop` → `main`, `hotfix`만 `main` → `develop` 역반영. type 6종:
 
-  | prefix | 용도 |
-  |---|---|
-  | `feature` | 새 기능·요구사항 추가 |
-  | `fix` | 버그 수정 |
-  | `refactor` | 동작 변화 없는 내부 구조 개선 |
-  | `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (예: 의존 업그레이드, audit 산출물, lint 룰 추가) |
-  | `docs` | 문서 추가·갱신 |
-  | `hotfix` | 긴급 수정 (`main` 직접 → `develop` 역반영) |
+  | prefix | 용도 | 예시 |
+  |---|---|---|
+  | `feature` | 새 기능·요구사항 추가 | `feature/MP-7-summoner-search` |
+  | `fix` | 버그 수정 | `fix/MP-12-match-null-check` |
+  | `refactor` | 동작 변화 없는 내부 구조 개선 | `refactor/MP-7-mapper-cleanup` |
+  | `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (예: 의존 업그레이드, audit 산출물, lint 룰 추가) | `chore/MP-41` |
+  | `docs` | 문서 추가·갱신 | `docs/MP-20-workflow-guide` |
+  | `hotfix` | 긴급 수정 (`main` 직접 → `develop` 역반영) | `hotfix/MP-34-login-500` |
+
+  > 커밋 type 과 브랜치 prefix 는 의도적으로 다름 — commit `feat:`, branch `feature/...` (관용).
 
 ## See Also
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
   | `feature` | 새 기능·요구사항 추가 | `feature/MP-7-summoner-search` |
   | `fix` | 버그 수정 | `fix/MP-12-match-null-check` |
   | `refactor` | 동작 변화 없는 내부 구조 개선 | `refactor/MP-7-mapper-cleanup` |
-  | `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (예: 의존 업그레이드, audit 산출물, lint 룰 추가) | `chore/MP-41` |
+  | `chore` | 코드 영향 없는 산출물·문서·CI·도구 변경 (예: 의존 업그레이드, audit 산출물, lint 룰 추가) | `chore/MP-41-claude-md-prefix-table` |
   | `docs` | 문서 추가·갱신 | `docs/MP-20-workflow-guide` |
   | `hotfix` | 긴급 수정 (`main` 직접 → `develop` 역반영) | `hotfix/MP-34-login-500` |
 


### PR DESCRIPTION
## Summary

- CLAUDE.md 의 브랜치 prefix 표를 2열(`prefix | 용도`) → 3열(`prefix | 용도 | 예시`) 로 확장.
  - 각 type 행에 실제 브랜치명 형태 예시 한 개씩 (`feature/MP-7-summoner-search` / `fix/MP-12-match-null-check` / `refactor/MP-7-mapper-cleanup` / `chore/MP-41` / `docs/MP-20-workflow-guide` / `hotfix/MP-34-login-500`).
- 표 직후에 commit type 과 branch prefix 비대칭(`feat:` vs `feature/...`) 한 줄 명시 — 신규 컨트리뷰터가 헷갈리지 않게.

## Why

- `feat` (commit) vs `feature/...` (branch) 가 의도적인지 실수인지 표만 봐서는 판단 불가. 한 줄 주석으로 의도임을 박아둠.
- `docs/workflow.md` 는 이미 `feature` / `feat` 패턴 일관 (line 33, 42, 71) — 변경 불필요. 추가 어긋남도 발견되지 않음.

## Test plan

- [x] CLAUDE.md 마크다운 표 렌더링 확인 (3열 정상)
- [x] docs/workflow.md 와 prefix/commit-type 일관성 재확인 (변경 없음)
- [ ] CI lint/build 통과 (docs-only, 빌드 영향 0)

Closes MP-41