### PR TITLE
fix(MP-72): bigquery-prod.yml credentials-location ${BIGQUERY_CREDENTIALS} no-default

### DIFF
--- a/module/infra/persistence/bigquery/src/main/resources/bigquery-prod.yml
+++ b/module/infra/persistence/bigquery/src/main/resources/bigquery-prod.yml
@@ -4,4 +4,4 @@ stats:
 bigquery:
   project-id: ${BIGQUERY_PROJECT_ID}
   dataset: ${BIGQUERY_DATASET}
-  credentials-location: ""
+  credentials-location: ${BIGQUERY_CREDENTIALS}


### PR DESCRIPTION
## Summary
- `bigquery-prod.yml` 의 `credentials-location: ""` → `${BIGQUERY_CREDENTIALS}` 로 변경.
- MP-68 시크릿 정책 (prod = `${VAR}` no-default fail-fast) 위배였던 silent fallback 차단.
- 기본값 (`${VAR:default}`) 패턴 미사용 → env 미주입 시 Spring `PlaceholderResolutionException` 으로 부팅이 차단된다.

## Scope
- 단일 파일 단일 라인: `module/infra/persistence/bigquery/src/main/resources/bigquery-prod.yml` line 7
- `bigquery-local.yml` / `bigquery-dev.yml` 미수정 (task scope 외).
- 다른 키 / 다른 모듈 미수정.

## Test plan
변경분 한정 smoke (격리 Spring `YamlPropertySourceLoader` + `PropertySourcesPropertyResolver` + `SystemEnvironmentPropertySource` 로 양방향 검증):

- [x] Path A — `BIGQUERY_CREDENTIALS` 미주입 → `IllegalArgumentException: Could not resolve placeholder 'BIGQUERY_CREDENTIALS' in value "${BIGQUERY_CREDENTIALS}"` (Spring 의 `PlaceholderResolutionException` 와 동등한 fail-fast)
- [x] Path B — `BIGQUERY_CREDENTIALS=/tmp/dummy.json` 주입 → placeholder 가 `/tmp/dummy.json` 으로 resolve. 이후 파일 IO 단계 실패는 본 작업 범위 외.

### 대체 검증
- 수동 시나리오: prod 부팅 시 BIGQUERY_CREDENTIALS env 미주입 / 주입 두 경로의 부팅 동작.
- 단위/통합 테스트 커버 범위: 격리 Spring placeholder resolver smoke (위 양방향) — 변경 라인이 yml 1줄이라 변경 표면 자체가 framework 수준 placeholder 강제 동작에 한정됨.
- E2E 자동화 불가 사유: prod profile 풀 부팅은 PostgreSQL / Redis / RabbitMQ Docker 서비스 및 다수 `${VAR}` env (PROJECT_ID, DATASET 등 multi-module) 필요 — 워크트리 환경에서 비현실적. 변경 표면이 yml 1줄이라 placeholder 강제 동작은 framework 보장 + 위 격리 smoke 로 동치 검증.

Closes MP-72