### PR TITLE
feat(match): add Redis read-through cache for match list

### DIFF
--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/MatchService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/MatchService.java
@@ -8,6 +8,7 @@ import com.example.lolserver.domain.match.application.model.GameReadModel;
 import com.example.lolserver.domain.match.domain.MSChampionByQueue;
 import com.example.lolserver.domain.match.domain.TimelineData;
 import com.example.lolserver.domain.match.application.port.in.MatchQueryUseCase;
+import com.example.lolserver.domain.match.application.port.out.MatchCachePort;
 import com.example.lolserver.domain.match.application.port.out.MatchPersistencePort;
 import com.example.lolserver.support.PaginationRequest;
 import com.example.lolserver.support.SliceResult;
@@ -33,6 +34,7 @@ public class MatchService implements MatchQueryUseCase {
     private static final String DEFAULT_SORT_FIELD = "match";
 
     private final MatchPersistencePort matchPersistencePort;
+    private final MatchCachePort matchCachePort;
 
     public SliceResult<GameReadModel> getMatches(MatchCommand matchCommand) {
         PaginationRequest paginationRequest = new PaginationRequest(
@@ -56,11 +58,24 @@ public class MatchService implements MatchQueryUseCase {
 
     @LogExecutionTime
     public SliceResult<GameReadModel> getMatchesBatch(MatchCommand matchCommand) {
-        PaginationRequest paginationRequest = new PaginationRequest(
-                matchCommand.getPageNo(), DEFAULT_PAGE_SIZE, DEFAULT_SORT_FIELD, PaginationRequest.SortDirection.DESC);
+        String puuid = matchCommand.getPuuid();
+        Integer season = matchCommand.getSeason();
+        Integer queueId = matchCommand.getQueueId();
+        Integer pageNo = matchCommand.getPageNo();
 
-        return matchPersistencePort.getMatchesBatch(
-                matchCommand.getPuuid(), matchCommand.getSeason(), matchCommand.getQueueId(), paginationRequest);
+        SliceResult<GameReadModel> cached = matchCachePort.findMatchesBatch(puuid, season, queueId, pageNo);
+        if (cached != null) {
+            return cached;
+        }
+
+        PaginationRequest paginationRequest = new PaginationRequest(
+                pageNo, DEFAULT_PAGE_SIZE, DEFAULT_SORT_FIELD, PaginationRequest.SortDirection.DESC);
+
+        SliceResult<GameReadModel> result = matchPersistencePort.getMatchesBatch(
+                puuid, season, queueId, paginationRequest);
+
+        matchCachePort.saveMatchesBatch(puuid, season, queueId, pageNo, result);
+        return result;
     }
 
     public SliceResult<String> findAllMatchIds(MatchCommand matchCommand) {

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/port/out/MatchCachePort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/port/out/MatchCachePort.java
@@ -1,0 +1,13 @@
+package com.example.lolserver.domain.match.application.port.out;
+
+import com.example.lolserver.domain.match.application.model.GameReadModel;
+import com.example.lolserver.support.SliceResult;
+
+public interface MatchCachePort {
+
+    SliceResult<GameReadModel> findMatchesBatch(String puuid, Integer season, Integer queueId, Integer pageNo);
+
+    void saveMatchesBatch(
+            String puuid, Integer season, Integer queueId, Integer pageNo,
+            SliceResult<GameReadModel> matches);
+}

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/match/application/MatchServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/match/application/MatchServiceTest.java
@@ -2,6 +2,7 @@ package com.example.lolserver.domain.match.application;
 
 import com.example.lolserver.domain.match.application.command.MSChampionCommand;
 import com.example.lolserver.domain.match.application.command.MatchCommand;
+import com.example.lolserver.domain.match.application.port.out.MatchCachePort;
 import com.example.lolserver.domain.match.application.port.out.MatchPersistencePort;
 import com.example.lolserver.domain.match.application.model.GameReadModel;
 import com.example.lolserver.domain.match.domain.MSChampion;
@@ -29,12 +30,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class MatchServiceTest {
 
     @Mock
     private MatchPersistencePort matchPersistencePort;
+
+    @Mock
+    private MatchCachePort matchCachePort;
 
     @InjectMocks
     private MatchService matchService;
@@ -210,5 +215,75 @@ class MatchServiceTest {
         assertThat(result.getContent()).containsExactly("KR_111", "KR_222", "KR_333");
         assertThat(result.isHasNext()).isTrue();
         then(matchPersistencePort).should().findAllMatchIds(eq("test-puuid"), eq(420), any(PaginationRequest.class));
+    }
+
+    @DisplayName("getMatchesBatch 캐시 히트 시 DB 조회 없이 캐시 결과를 반환한다")
+    @Test
+    void getMatchesBatch_cacheHit_returnsCachedWithoutDbCall() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .season(14)
+                .queueId(420)
+                .pageNo(0)
+                .build();
+
+        SliceResult<GameReadModel> cached = new SliceResult<>(List.of(new GameReadModel()), false);
+        given(matchCachePort.findMatchesBatch("test-puuid", 14, 420, 0)).willReturn(cached);
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result).isSameAs(cached);
+        then(matchPersistencePort).should(never()).getMatchesBatch(any(), any(), any(), any(PaginationRequest.class));
+        then(matchCachePort).should(never()).saveMatchesBatch(any(), any(), any(), any(), any());
+    }
+
+    @DisplayName("getMatchesBatch 캐시 미스 시 DB 조회 후 캐시에 저장한다")
+    @Test
+    void getMatchesBatch_cacheMiss_loadsFromDbAndCaches() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .season(14)
+                .queueId(420)
+                .pageNo(0)
+                .build();
+
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(List.of(new GameReadModel(), new GameReadModel()), true);
+        given(matchCachePort.findMatchesBatch("test-puuid", 14, 420, 0)).willReturn(null);
+        given(matchPersistencePort.getMatchesBatch(eq("test-puuid"), eq(14), eq(420), any(PaginationRequest.class)))
+                .willReturn(dbResult);
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result).isSameAs(dbResult);
+        then(matchCachePort).should().saveMatchesBatch("test-puuid", 14, 420, 0, dbResult);
+    }
+
+    @DisplayName("getMatchesBatch 는 season/queueId 가 null 이어도 캐시 포트에 그대로 전달한다")
+    @Test
+    void getMatchesBatch_nullSeasonAndQueueId_passesNullsToCachePort() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .pageNo(2)
+                .build();
+
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(Collections.emptyList(), false);
+        given(matchCachePort.findMatchesBatch("test-puuid", null, null, 2)).willReturn(null);
+        given(matchPersistencePort.getMatchesBatch(eq("test-puuid"), eq(null), eq(null), any(PaginationRequest.class)))
+                .willReturn(dbResult);
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result).isSameAs(dbResult);
+        then(matchCachePort).should().findMatchesBatch("test-puuid", null, null, 2);
+        then(matchCachePort).should().saveMatchesBatch("test-puuid", null, null, 2, dbResult);
     }
 }

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/match/MatchCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/match/MatchCacheAdapter.java
@@ -1,0 +1,86 @@
+package com.example.lolserver.repository.match;
+
+import com.example.lolserver.domain.match.application.model.GameReadModel;
+import com.example.lolserver.domain.match.application.port.out.MatchCachePort;
+import com.example.lolserver.support.SliceResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.SerializationException;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MatchCacheAdapter implements MatchCachePort {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String KEY_PREFIX = "match:list:v1:";
+    private static final String NULL_TOKEN = "_";
+    private static final Duration CACHE_TTL = Duration.ofMinutes(30);
+
+    @Override
+    public SliceResult<GameReadModel> findMatchesBatch(
+            String puuid, Integer season, Integer queueId, Integer pageNo) {
+        String key = buildKey(puuid, season, queueId, pageNo);
+        try {
+            log.debug("매치 목록 캐시 조회 - key: {}", key);
+            Object raw = redisTemplate.opsForValue().get(key);
+            if (raw == null) {
+                return null;
+            }
+            if (raw instanceof CachedSlice cached) {
+                return new SliceResult<>(cached.content(), cached.hasNext());
+            }
+            log.info("매치 목록 캐시 stale 타입 감지 - 키 삭제: {}", key);
+            evictQuietly(key);
+            return null;
+        } catch (SerializationException e) {
+            log.info("매치 목록 캐시 stale 감지 - 키 삭제 후 재생성: {}", key);
+            evictQuietly(key);
+            return null;
+        } catch (Exception e) {
+            log.debug("매치 목록 캐시 조회 실패 - key: {}, message: {}", key, e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public void saveMatchesBatch(
+            String puuid, Integer season, Integer queueId, Integer pageNo,
+            SliceResult<GameReadModel> matches) {
+        if (matches == null) {
+            return;
+        }
+        String key = buildKey(puuid, season, queueId, pageNo);
+        try {
+            log.debug("매치 목록 캐시 저장 - key: {}", key);
+            CachedSlice payload = new CachedSlice(matches.getContent(), matches.isHasNext());
+            redisTemplate.opsForValue().set(key, payload, CACHE_TTL);
+        } catch (Exception e) {
+            log.warn("매치 목록 캐시 저장 실패 - puuid: {}, season: {}, queueId: {}, pageNo: {}",
+                    puuid, season, queueId, pageNo, e);
+        }
+    }
+
+    private void evictQuietly(String key) {
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception ignored) {
+        }
+    }
+
+    private String buildKey(String puuid, Integer season, Integer queueId, Integer pageNo) {
+        return KEY_PREFIX + puuid
+                + ":" + (season == null ? NULL_TOKEN : season)
+                + ":" + (queueId == null ? NULL_TOKEN : queueId)
+                + ":" + pageNo;
+    }
+
+    public record CachedSlice(List<GameReadModel> content, boolean hasNext) {
+    }
+}

--- a/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/match/MatchCacheAdapterTest.java
+++ b/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/match/MatchCacheAdapterTest.java
@@ -1,0 +1,180 @@
+package com.example.lolserver.repository.match;
+
+import com.example.lolserver.domain.match.application.model.GameReadModel;
+import com.example.lolserver.support.SliceResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class MatchCacheAdapterTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
+    private MatchCacheAdapter adapter;
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(30);
+
+    @BeforeEach
+    void setUp() {
+        adapter = new MatchCacheAdapter(redisTemplate);
+    }
+
+    @DisplayName("캐시 키는 season/queueId null 을 _ 토큰으로 채운다")
+    @Test
+    void findMatchesBatch_nullSeasonAndQueueId_usesUnderscoreToken() {
+        // given
+        String expectedKey = "match:list:v1:test-puuid:_:_:0";
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn(null);
+
+        // when
+        SliceResult<GameReadModel> result = adapter.findMatchesBatch("test-puuid", null, null, 0);
+
+        // then
+        assertThat(result).isNull();
+        then(valueOperations).should().get(expectedKey);
+    }
+
+    @DisplayName("캐시 히트 시 CachedSlice 를 SliceResult 로 복원해 반환한다")
+    @Test
+    void findMatchesBatch_cacheHit_returnsSliceResult() {
+        // given
+        String expectedKey = "match:list:v1:test-puuid:14:420:0";
+        List<GameReadModel> games = List.of(new GameReadModel(), new GameReadModel());
+        MatchCacheAdapter.CachedSlice cached = new MatchCacheAdapter.CachedSlice(games, true);
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn(cached);
+
+        // when
+        SliceResult<GameReadModel> result = adapter.findMatchesBatch("test-puuid", 14, 420, 0);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEqualTo(games);
+        assertThat(result.isHasNext()).isTrue();
+    }
+
+    @DisplayName("캐시 미스 시 null 을 반환한다")
+    @Test
+    void findMatchesBatch_cacheMiss_returnsNull() {
+        // given
+        String expectedKey = "match:list:v1:test-puuid:14:420:0";
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn(null);
+
+        // when
+        SliceResult<GameReadModel> result = adapter.findMatchesBatch("test-puuid", 14, 420, 0);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @DisplayName("Redis 장애 시 조회는 null 을 반환한다")
+    @Test
+    void findMatchesBatch_redisFailure_returnsNull() {
+        // given
+        given(redisTemplate.opsForValue()).willThrow(new RuntimeException("Redis connection failed"));
+
+        // when
+        SliceResult<GameReadModel> result = adapter.findMatchesBatch("test-puuid", 14, 420, 0);
+
+        // then
+        assertThat(result).isNull();
+    }
+
+    @DisplayName("SliceResult 를 CachedSlice 페이로드로 저장하며 TTL 30 분을 적용한다")
+    @Test
+    void saveMatchesBatch_validData_savesWithTtl() {
+        // given
+        String expectedKey = "match:list:v1:test-puuid:14:420:0";
+        List<GameReadModel> games = List.of(new GameReadModel());
+        SliceResult<GameReadModel> matches = new SliceResult<>(games, true);
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        adapter.saveMatchesBatch("test-puuid", 14, 420, 0, matches);
+
+        // then
+        ArgumentCaptor<MatchCacheAdapter.CachedSlice> captor =
+                ArgumentCaptor.forClass(MatchCacheAdapter.CachedSlice.class);
+        then(valueOperations).should().set(eq(expectedKey), captor.capture(), eq(CACHE_TTL));
+        MatchCacheAdapter.CachedSlice saved = captor.getValue();
+        assertThat(saved.content()).isEqualTo(games);
+        assertThat(saved.hasNext()).isTrue();
+    }
+
+    @DisplayName("null SliceResult 는 캐시에 저장하지 않는다")
+    @Test
+    void saveMatchesBatch_nullData_doesNotSave() {
+        // when
+        adapter.saveMatchesBatch("test-puuid", 14, 420, 0, null);
+
+        // then
+        then(redisTemplate).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("Redis 장애 시 저장은 예외를 전파하지 않는다")
+    @Test
+    void saveMatchesBatch_redisFailure_doesNotThrow() {
+        // given
+        SliceResult<GameReadModel> matches = new SliceResult<>(List.of(new GameReadModel()), false);
+        given(redisTemplate.opsForValue()).willThrow(new RuntimeException("Redis connection failed"));
+
+        // when & then
+        adapter.saveMatchesBatch("test-puuid", 14, 420, 0, matches);
+    }
+
+    @DisplayName("저장된 값 타입이 예상과 다르면 키를 삭제하고 null 을 반환한다")
+    @Test
+    void findMatchesBatch_unexpectedType_evictsAndReturnsNull() {
+        // given
+        String expectedKey = "match:list:v1:test-puuid:14:420:0";
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn("stale-string");
+
+        // when
+        SliceResult<GameReadModel> result = adapter.findMatchesBatch("test-puuid", 14, 420, 0);
+
+        // then
+        assertThat(result).isNull();
+        then(redisTemplate).should().delete(expectedKey);
+    }
+
+    @DisplayName("페이지 번호와 큐 ID 가 키에 정확히 반영된다")
+    @Test
+    void findMatchesBatch_keyIncludesAllParams() {
+        // given
+        String expectedKey = "match:list:v1:puuid-X:13:440:5";
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(expectedKey)).willReturn(null);
+
+        // when
+        adapter.findMatchesBatch("puuid-X", 13, 440, 5);
+
+        // then
+        then(valueOperations).should().get(expectedKey);
+        then(valueOperations).should(never()).get("match:list:v1:puuid-X:13:440:0");
+    }
+}


### PR DESCRIPTION
## Summary

매치 리스트 조회 (`GET /api/v1/{platformId}/summoners/{puuid}/matches`) 에 Redis read-through 캐시 도입. cache hit 시 PostgreSQL 3-way 쿼리(matches + participants + timeline)를 통째로 생략해 응답 latency 감소.

## Changes

- **신규**: `MatchCachePort` (port) + `MatchCacheAdapter` (Redis adapter, `RedisTemplate<String, Object>` + Jackson)
- **변경**: `MatchService.getMatchesBatch()` 만 read-through 로 wrap (다른 메서드 미변경)
- 직렬화 우회: `SliceResult` 가 no-arg constructor 없어 adapter 내부 `record CachedSlice` 로 round-trip
- 키: `match:list:v1:{puuid}:{season|_}:{queueId|_}:{pageNo}`, TTL 30분
- 기존 `MatchServiceTest` 8개 byte-identical 유지, 새 케이스 3개 추가 (cache hit / miss / null params)

## Test plan

- [x] `./gradlew check` BUILD SUCCESSFUL (75 actionable tasks)
- [x] 기존 테스트 전체 통과 (수정 없음)
- [x] `MatchCacheAdapterTest` 신규 추가
- [ ] 로컬 dev 환경에서 cache hit/miss latency 실측
- [ ] 운영 hit ratio Micrometer counter (follow-up PR)

## Out of scope

- 단건 매치 캐시 (`match:detail:v1:{matchId}`) — 별도 PR 로 분리
- `MatchService.getGameData()` 도 같은 패턴 적용 가능하나 본 PR 에서는 제외 (기존 테스트 영향 회피)

## Related

- lol-repository 캐시 무효화 PR: padosol/lol-repository#65
- 두 PR 은 독립 deploy 가능. 권장 순서: lol-server 먼저(캐시 효과 시작) → lol-repository(invalidation 활성화)
