### PR TITLE
refactor(MP-105): YAML/Logback 설정 정리 및 RabbitMQ 키 코드 이관

### DIFF
--- a/module/infra/api/src/main/resources/api-dev.yml
+++ b/module/infra/api/src/main/resources/api-dev.yml
@@ -4,6 +4,10 @@ server:
     basedir: .
     accesslog:
       enabled: true
+      directory: /dev
+      prefix: stdout
+      suffix: ""
+      file-date-format: ""
       pattern: "%{yyyy-MM-dd HH:mm:ss}t %s [%r] [Remote: %a] [Size: %b]"
 
 spring:

--- a/module/infra/api/src/main/resources/api-local.yml
+++ b/module/infra/api/src/main/resources/api-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8085
+  port: 8100
   tomcat:
     basedir: .
     accesslog:
@@ -12,15 +12,15 @@ spring:
       client:
         registration:
           google:
-            client-id: ""
-            client-secret: ""
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: openid, email, profile
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
           riot:
-            client-id: ""
-            client-secret: ""
+            client-id: ${RIOT_RSO_CLIENT_ID}
+            client-secret: ${RIOT_RSO_CLIENT_SECRET}
             scope: openid, cpid
-            redirect-uri: http://local.metapick.me/login/oauth2/code/riot
+            redirect-uri: ${OAUTH_REDIRECT_BASE_URL}/login/oauth2/code/riot
             client-authentication-method: client_secret_basic
             authorization-grant-type: authorization_code
         provider:

--- a/module/infra/api/src/main/resources/api-prod.yml
+++ b/module/infra/api/src/main/resources/api-prod.yml
@@ -4,6 +4,10 @@ server:
     basedir: .
     accesslog:
       enabled: true
+      directory: /dev
+      prefix: stdout
+      suffix: ""
+      file-date-format: ""
       pattern: "%{yyyy-MM-dd HH:mm:ss}t %s [%r] [Remote: %a] [Size: %b]"
 
 spring:

--- a/module/infra/message/rabbitmq/src/main/java/com/example/lolserver/service/SummonerMessageAdapter.java
+++ b/module/infra/message/rabbitmq/src/main/java/com/example/lolserver/service/SummonerMessageAdapter.java
@@ -4,7 +4,6 @@ import com.example.lolserver.domain.summoner.application.port.out.SummonerMessag
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -16,11 +15,8 @@ import java.time.LocalDateTime;
 @ConditionalOnProperty(name = "message.broker", havingValue = "rabbitmq", matchIfMissing = true)
 public class SummonerMessageAdapter implements SummonerMessagePort {
 
-    @Value("${rabbitmq.exchange.name}")
-    private String exchangeName;
-
-    @Value("${rabbitmq.routing.key}")
-    private String routingKey;
+    private static final String EXCHANGE_NAME = "mmrtr.exchange";
+    private static final String ROUTING_KEY = "mmrtr.key";
 
     private final RabbitTemplate rabbitTemplate;
 
@@ -29,6 +25,6 @@ public class SummonerMessageAdapter implements SummonerMessagePort {
         SummonerMessage summonerMessage = new SummonerMessage(
                 platformId, puuid, revisionDate);
 
-        rabbitTemplate.convertAndSend(exchangeName, routingKey, summonerMessage);
+        rabbitTemplate.convertAndSend(EXCHANGE_NAME, ROUTING_KEY, summonerMessage);
     }
 }

--- a/module/infra/message/rabbitmq/src/main/resources/rabbitmq-dev.yml
+++ b/module/infra/message/rabbitmq/src/main/resources/rabbitmq-dev.yml
@@ -4,8 +4,3 @@ spring:
     port: 5672
     username: guest
     password: guest
-
-rabbitmq:
-  queue.name: mmrtr.queue
-  exchange.name: mmrtr.exchange
-  routing.key: mmrtr.key

--- a/module/infra/message/rabbitmq/src/main/resources/rabbitmq-local.yml
+++ b/module/infra/message/rabbitmq/src/main/resources/rabbitmq-local.yml
@@ -3,9 +3,4 @@ spring:
     host: localhost
     port: 5672
     username: guest
-    password: ""
-
-rabbitmq:
-  queue.name: mmrtr.queue
-  exchange.name: mmrtr.exchange
-  routing.key: mmrtr.key
+    password: guest

--- a/module/infra/message/rabbitmq/src/main/resources/rabbitmq-prod.yml
+++ b/module/infra/message/rabbitmq/src/main/resources/rabbitmq-prod.yml
@@ -4,8 +4,3 @@ spring:
     port: ${RABBITMQ_PORT}
     username: ${RABBITMQ_USERNAME}
     password: ${RABBITMQ_PASSWORD}
-
-rabbitmq:
-  queue.name: mmrtr.queue
-  exchange.name: mmrtr.exchange
-  routing.key: mmrtr.key

--- a/module/infra/persistence/postgresql/src/main/resources/postgresql-local.yml
+++ b/module/infra/persistence/postgresql/src/main/resources/postgresql-local.yml
@@ -20,10 +20,10 @@ spring:
     show-sql: false
 
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     driver-class-name: org.postgresql.Driver
-    username: postgres
-    password: ""
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
     hikari:
       register-mbeans: true
       maximum-pool-size: 30

--- a/module/support/logging/src/main/resources/logback/logback-dev.xml
+++ b/module/support/logging/src/main/resources/logback/logback-dev.xml
@@ -2,26 +2,27 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${level:-%5p}) [%8X{traceId:-}] [%thread] %clr(%-40.40logger{39}){cyan} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>
 
-    <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
-        <options>
-            <dsn>YOUR_DSN</dsn>
-        </options>
-        <minimumEventLevel>WARN</minimumEventLevel>
-        <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/app.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app.%d{yyyy-MM-dd}.log.zip</fileNamePattern>
+            <maxHistory>30</maxHistory> </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
     </appender>
 
-    <logger name="org.springframework" level="WARN"/>
-    <logger name="io.dodn.springboot" level="INFO"/>
+    <springProfile name="dev">
+        <root level="info">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
 
-    <root level="INFO">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="SENTRY"/>
-    </root>
 </configuration>

--- a/module/support/logging/src/main/resources/logback/logback-prod.xml
+++ b/module/support/logging/src/main/resources/logback/logback-prod.xml
@@ -2,26 +2,27 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
 
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%clr(%d{HH:mm:ss.SSS}){faint}|%clr(${level:-%5p})|%32X{traceId:-},%16X{spanId:-}|%clr(%-40.40logger{39}){cyan}%clr(|){faint}%m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
+            <pattern>%clr(%d{yyyy-MM-dd HH:mm:ss.SSS}){faint} %clr(${level:-%5p}) [%8X{traceId:-}] [%thread] %clr(%-40.40logger{39}){cyan} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}</pattern>
             <charset>utf8</charset>
         </encoder>
     </appender>
 
-    <appender name="SENTRY" class="io.sentry.logback.SentryAppender">
-        <options>
-            <dsn>YOUR_DSN</dsn>
-        </options>
-        <minimumEventLevel>WARN</minimumEventLevel>
-        <minimumBreadcrumbLevel>INFO</minimumBreadcrumbLevel>
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/app.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/app.%d{yyyy-MM-dd}.log.zip</fileNamePattern>
+            <maxHistory>30</maxHistory> </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
     </appender>
 
-    <logger name="org.springframework" level="WARN"/>
-    <logger name="io.dodn.springboot" level="INFO"/>
+    <springProfile name="prod">
+        <root level="info">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </springProfile>
 
-    <root level="INFO">
-        <appender-ref ref="STDOUT"/>
-        <appender-ref ref="SENTRY"/>
-    </root>
 </configuration>


### PR DESCRIPTION
## 배경

Linear: [MP-105](https://linear.app/metapick/issue/MP-105)
관련 PR: [lol-repository#67](https://github.com/padosol/lol-repository/pull/67)

환경 설정 yml 패턴이 모듈별로 들쭉날쭉했고, RabbitMQ exchange/routing key 는 운영/개발 모두 동일 값을 쓰므로 yml 보다 코드 레벨에서 관리하는 게 적절.

## 변경 사항

### RabbitMQ 키 코드 이관

`SummonerMessageAdapter` 의 `@Value("${rabbitmq.exchange.name}")` / `@Value("${rabbitmq.routing.key}")` → `private static final String EXCHANGE_NAME = "mmrtr.exchange"`, `ROUTING_KEY = "mmrtr.key"` 로 이관. 관련 yml 키 제거.

### api 모듈

| 파일 | 변경 |
|---|---|
| `api-local.yml` | 포트 `8085 → 8100`, OAuth Google/Riot `client-id`/`client-secret` 환경변수화 (`${GOOGLE_CLIENT_ID}`, `${RIOT_RSO_CLIENT_ID}` 등), `redirect-uri` `${OAUTH_REDIRECT_BASE_URL}` 사용 |
| `api-dev.yml` / `api-prod.yml` | tomcat accesslog 를 stdout 으로 보내는 directory/prefix/suffix/file-date-format 설정 추가 |

### persistence

`postgresql-local.yml`: datasource `url`/`username`/`password` 를 `${DB_HOST}` / `${DB_USERNAME}` / `${DB_PASSWORD}` 형태로 외부화.

### logging

`logback-dev.xml` / `logback-prod.xml`:
- `STDOUT` → `CONSOLE` 으로 이름 정리, 패턴 가독성 개선
- 의미 없던 `SENTRY` appender 제거 (DSN 미설정 상태였음)
- `RollingFileAppender` (`${LOG_PATH}/app.log`, 30일 보관) 추가
- `springProfile` 로 root 로거를 profile 별 분리

## Test plan

- [x] yml 에 `rabbitmq.queue.name`/`exchange.name`/`routing.key` 없음
- [x] `./gradlew :module:infra:message:rabbitmq:check` 통과
- [ ] (검토자) OAuth 환경변수 `GOOGLE_CLIENT_ID` / `RIOT_RSO_CLIENT_ID` / `OAUTH_REDIRECT_BASE_URL` 등이 로컬 `.env` 또는 외부 시크릿 매니저에 매핑되어 있는지 확인 필요
- [ ] (검토자) logback `${LOG_PATH}` 환경변수가 dev/prod 컨테이너에 주입되는지 확인 필요

Closes MP-105