### PR TITLE
refactor(match): GameReadModel 형태 캐시 JSON 직독 (read-side 변환 제거)

### DIFF
--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/MatchService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/MatchService.java
@@ -23,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -77,19 +76,16 @@ public class MatchService implements MatchQueryUseCase {
         }
 
         Optional<List<String>> cachedIds = matchIdsCachePort.findIds(puuid);
-        boolean fromCache = cachedIds.isPresent();
+        if (cachedIds.isEmpty()) {
+            return loadFromDbDirect(puuid, null, queueId, pageNo);
+        }
 
-        List<String> matchIds = fromCache
-                ? cachedIds.get()
-                : matchPersistencePort.findRecentMatchIds(puuid, DEFAULT_PAGE_SIZE);
+        List<String> matchIds = cachedIds.get();
         if (matchIds.isEmpty()) {
             return new SliceResult<>(Collections.emptyList(), false);
         }
 
-        Map<String, GameReadModel> matchesById = fromCache
-                ? resolveMatchesByIds(matchIds)
-                : loadAndCacheGames(puuid, matchIds);
-
+        Map<String, GameReadModel> matchesById = resolveMatchesByIds(matchIds);
         List<GameReadModel> ordered = filterAndOrder(matchIds, matchesById, queueId);
         return pageSlice(ordered, pageNo);
     }
@@ -115,26 +111,11 @@ public class MatchService implements MatchQueryUseCase {
         }
 
         Map<String, GameReadModel> matchesById = new HashMap<>(cached);
-        matchesById.putAll(fetchAndCacheFromDb(missingIds));
+        matchesById.putAll(fetchFromDb(missingIds));
         return matchesById;
     }
 
-    private Map<String, GameReadModel> loadAndCacheGames(String puuid, List<String> matchIds) {
-        Map<String, GameReadModel> matchesById = fetchAndCacheFromDb(matchIds);
-        List<Map.Entry<String, Long>> entries = new ArrayList<>(matchesById.size());
-        for (Map.Entry<String, GameReadModel> e : matchesById.entrySet()) {
-            Long score = gameCreationOf(e.getValue());
-            if (score != null) {
-                entries.add(new AbstractMap.SimpleEntry<>(e.getKey(), score));
-            }
-        }
-        if (!entries.isEmpty()) {
-            matchIdsCachePort.saveIds(puuid, entries);
-        }
-        return matchesById;
-    }
-
-    private Map<String, GameReadModel> fetchAndCacheFromDb(List<String> ids) {
+    private Map<String, GameReadModel> fetchFromDb(List<String> ids) {
         List<GameReadModel> games = matchPersistencePort.findMatchesByIds(ids);
         Map<String, GameReadModel> dbMap = new LinkedHashMap<>();
         for (GameReadModel game : games) {
@@ -142,9 +123,6 @@ public class MatchService implements MatchQueryUseCase {
             if (id != null) {
                 dbMap.put(id, game);
             }
-        }
-        if (!dbMap.isEmpty()) {
-            matchSingleCachePort.saveAll(dbMap);
         }
         return dbMap;
     }
@@ -182,10 +160,6 @@ public class MatchService implements MatchQueryUseCase {
 
     private String matchIdOf(GameReadModel game) {
         return game.getGameInfoData() == null ? null : game.getGameInfoData().getMatchId();
-    }
-
-    private Long gameCreationOf(GameReadModel game) {
-        return game.getGameInfoData() == null ? null : game.getGameInfoData().getGameCreation();
     }
 
     public SliceResult<String> findAllMatchIds(MatchCommand matchCommand) {

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/port/out/MatchIdsCachePort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/port/out/MatchIdsCachePort.java
@@ -1,7 +1,6 @@
 package com.example.lolserver.domain.match.application.port.out;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 public interface MatchIdsCachePort {
@@ -11,10 +10,4 @@ public interface MatchIdsCachePort {
      * 캐시 미스이면 {@code Optional.empty()} 를 반환한다.
      */
     Optional<List<String>> findIds(String puuid);
-
-    /**
-     * 매치 ID 와 정렬 기준 (gameCreation epoch ms) 쌍을 캐시에 저장한다.
-     * 캐시는 최신 N 개만 유지하며 일정 시간 후 만료된다.
-     */
-    void saveIds(String puuid, List<Map.Entry<String, Long>> matchIdToScore);
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/port/out/MatchSingleCachePort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/match/application/port/out/MatchSingleCachePort.java
@@ -12,9 +12,4 @@ public interface MatchSingleCachePort {
      * 누락된 matchId 는 결과 맵에 포함하지 않는다.
      */
     Map<String, GameReadModel> findByIds(Collection<String> matchIds);
-
-    /**
-     * 각 매치를 match:v1:{matchId} = JSON 으로 1시간 TTL 적용해 pipeline 으로 저장한다.
-     */
-    void saveAll(Map<String, GameReadModel> matches);
 }

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/match/application/MatchServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/match/application/MatchServiceTest.java
@@ -17,7 +17,6 @@ import com.example.lolserver.support.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,8 +31,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -195,49 +194,41 @@ class MatchServiceTest {
         // then
         assertThat(result.getContent()).hasSize(2);
         assertThat(result.isHasNext()).isFalse();
-        then(matchPersistencePort).should(never()).findRecentMatchIds(any(), anyInt());
         then(matchPersistencePort).should(never()).findMatchesByIds(anyCollection());
-        then(matchSingleCachePort).should(never()).saveAll(any());
-        then(matchIdsCachePort).should(never()).saveIds(any(), any());
+        then(matchPersistencePort).should(never())
+                .getMatchesBatch(any(), any(), any(), any(PaginationRequest.class));
     }
 
-    @DisplayName("getMatchesBatch ZSET 캐시 miss 시 DB 에서 matchIds 를 조회하고 ZSET 에 저장한다")
+    @DisplayName("getMatchesBatch ZSET 캐시 miss 시 DB 직조회로 떨어지고 캐시를 채우지 않는다")
     @Test
-    void getMatchesBatch_zsetMiss_loadsFromDbAndSavesZset() {
+    void getMatchesBatch_zsetMiss_loadsFromDbDirectAndDoesNotWriteCache() {
         // given
         MatchCommand command = MatchCommand.builder()
                 .puuid("test-puuid")
+                .queueId(420)
                 .pageNo(0)
                 .build();
 
         given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.empty());
-        List<String> dbIds = List.of("KR_A", "KR_B");
-        given(matchPersistencePort.findRecentMatchIds("test-puuid", 20)).willReturn(dbIds);
 
-        GameReadModel gameA = gameOf("KR_A", 420, 1000L);
-        GameReadModel gameB = gameOf("KR_B", 420, 2000L);
-        given(matchPersistencePort.findMatchesByIds(dbIds)).willReturn(List.of(gameA, gameB));
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(
+                List.of(gameOf("KR_A", 420, 1000L), gameOf("KR_B", 420, 2000L)), false);
+        given(matchPersistencePort.getMatchesBatch(
+                eq("test-puuid"), isNull(), eq(420), any(PaginationRequest.class)))
+                .willReturn(dbResult);
 
         // when
         SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
 
         // then
-        assertThat(result.getContent()).hasSize(2);
-        ArgumentCaptor<List<Map.Entry<String, Long>>> captor = ArgumentCaptor.forClass(List.class);
-        then(matchIdsCachePort).should().saveIds(eq("test-puuid"), captor.capture());
-        List<Map.Entry<String, Long>> saved = captor.getValue();
-        assertThat(saved).hasSize(2);
-        assertThat(saved).extracting(Map.Entry::getKey).containsExactly("KR_A", "KR_B");
-
-        ArgumentCaptor<Map<String, GameReadModel>> singleSaveCaptor = ArgumentCaptor.forClass(Map.class);
-        then(matchSingleCachePort).should().saveAll(singleSaveCaptor.capture());
-        assertThat(singleSaveCaptor.getValue()).containsKeys("KR_A", "KR_B");
+        assertThat(result).isSameAs(dbResult);
         then(matchSingleCachePort).should(never()).findByIds(anyCollection());
+        then(matchPersistencePort).should(never()).findMatchesByIds(anyCollection());
     }
 
-    @DisplayName("getMatchesBatch ZSET 캐시 hit + 단건 캐시 partial miss 시 DB IN 조회 후 saveAll 호출")
+    @DisplayName("getMatchesBatch ZSET hit + 단건 캐시 partial miss 시 누락분만 DB IN 조회로 보강하고 캐시는 채우지 않는다")
     @Test
-    void getMatchesBatch_zsetHitAndSinglePartialMiss_loadsMissingAndSaves() {
+    void getMatchesBatch_zsetHitAndSinglePartialMiss_loadsMissingNoCacheWrite() {
         // given
         MatchCommand command = MatchCommand.builder()
                 .puuid("test-puuid")
@@ -261,11 +252,7 @@ class MatchServiceTest {
 
         // then
         assertThat(result.getContent()).hasSize(3);
-        ArgumentCaptor<Map<String, GameReadModel>> captor = ArgumentCaptor.forClass(Map.class);
-        then(matchSingleCachePort).should().saveAll(captor.capture());
-        Map<String, GameReadModel> saved = captor.getValue();
-        assertThat(saved).containsKeys("KR_2", "KR_3");
-        assertThat(saved).doesNotContainKey("KR_1");
+        then(matchPersistencePort).should().findMatchesByIds(List.of("KR_2", "KR_3"));
     }
 
     @DisplayName("getMatchesBatch queueId 필터는 in-memory 로 동작한다")

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/match/MatchIdsCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/match/MatchIdsCacheAdapter.java
@@ -3,15 +3,11 @@ package com.example.lolserver.repository.match;
 import com.example.lolserver.domain.match.application.port.out.MatchIdsCachePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -21,9 +17,6 @@ import java.util.Set;
 public class MatchIdsCacheAdapter implements MatchIdsCachePort {
 
     static final String KEY_PREFIX = "match:ids:v1:";
-    static final int CAP = 20;
-    private static final Duration CACHE_TTL = Duration.ofHours(24);
-    private static final long CACHE_TTL_SECONDS = CACHE_TTL.toSeconds();
 
     private final RedisTemplate<String, Object> redisTemplate;
 
@@ -47,43 +40,6 @@ public class MatchIdsCacheAdapter implements MatchIdsCachePort {
         } catch (Exception e) {
             log.warn("매치 ID ZSET 조회 실패 - puuid: {}, message: {}", puuid, e.getMessage());
             return Optional.empty();
-        }
-    }
-
-    @Override
-    public void saveIds(String puuid, List<Map.Entry<String, Long>> matchIdToScore) {
-        if (matchIdToScore == null || matchIdToScore.isEmpty()) {
-            return;
-        }
-
-        String key = buildKey(puuid);
-        try {
-            RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
-            @SuppressWarnings("unchecked")
-            RedisSerializer<Object> valueSerializer = (RedisSerializer<Object>) redisTemplate.getValueSerializer();
-
-            byte[] rawKey = keySerializer.serialize(key);
-            if (rawKey == null) {
-                return;
-            }
-
-            redisTemplate.executePipelined((RedisConnection connection) -> {
-                for (Map.Entry<String, Long> entry : matchIdToScore) {
-                    if (entry.getKey() == null || entry.getValue() == null) {
-                        continue;
-                    }
-                    byte[] member = valueSerializer.serialize(entry.getKey());
-                    if (member == null) {
-                        continue;
-                    }
-                    connection.zSetCommands().zAdd(rawKey, entry.getValue(), member);
-                }
-                connection.zSetCommands().zRemRange(rawKey, 0, -(CAP + 1L));
-                connection.keyCommands().expire(rawKey, CACHE_TTL_SECONDS);
-                return null;
-            });
-        } catch (Exception e) {
-            log.warn("매치 ID ZSET 저장 실패 - puuid: {}, message: {}", puuid, e.getMessage());
         }
     }
 

--- a/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/match/MatchSingleCacheAdapter.java
+++ b/module/infra/persistence/redis/src/main/java/com/example/lolserver/repository/match/MatchSingleCacheAdapter.java
@@ -2,14 +2,15 @@ package com.example.lolserver.repository.match;
 
 import com.example.lolserver.domain.match.application.model.GameReadModel;
 import com.example.lolserver.domain.match.application.port.out.MatchSingleCachePort;
-import lombok.RequiredArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.connection.RedisConnection;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -17,16 +18,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * lol-repository 가 Redis `match:v1:{matchId}` 에 {@link GameReadModel} 형태로 직렬화해 둔 JSON 을 읽는다.
+ * 변환은 쓰기 측(lol-repository)에서 끝나므로 여기서는 raw JSON 을 그대로 역직렬화만 한다.
+ * <p>
+ * {@link GameReadModel} 트리의 값 객체 (ItemValue/StatValue/TeamData 등) 는 setter 가 없어
+ * 필드 직접 접근 가시성을 켠 전용 {@link ObjectMapper} 를 사용한다.
+ */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class MatchSingleCacheAdapter implements MatchSingleCachePort {
 
     static final String KEY_PREFIX = "match:v1:";
-    private static final Duration CACHE_TTL = Duration.ofHours(1);
-    private static final long CACHE_TTL_SECONDS = CACHE_TTL.toSeconds();
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public MatchSingleCacheAdapter(StringRedisTemplate stringRedisTemplate) {
+        this.stringRedisTemplate = stringRedisTemplate;
+        this.objectMapper = JsonMapper.builder()
+                .visibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .build();
+    }
 
     @Override
     public Map<String, GameReadModel> findByIds(Collection<String> matchIds) {
@@ -38,15 +52,19 @@ public class MatchSingleCacheAdapter implements MatchSingleCachePort {
         List<String> keys = ids.stream().map(this::buildKey).toList();
 
         try {
-            List<Object> values = redisTemplate.opsForValue().multiGet(keys);
+            List<String> values = stringRedisTemplate.opsForValue().multiGet(keys);
             if (values == null) {
                 return Collections.emptyMap();
             }
 
             Map<String, GameReadModel> result = new HashMap<>();
             for (int i = 0; i < ids.size(); i++) {
-                Object raw = i < values.size() ? values.get(i) : null;
-                if (raw instanceof GameReadModel game) {
+                String json = i < values.size() ? values.get(i) : null;
+                if (json == null) {
+                    continue;
+                }
+                GameReadModel game = deserialize(json);
+                if (game != null) {
                     result.put(ids.get(i), game);
                 }
             }
@@ -57,33 +75,12 @@ public class MatchSingleCacheAdapter implements MatchSingleCachePort {
         }
     }
 
-    @Override
-    public void saveAll(Map<String, GameReadModel> matches) {
-        if (matches == null || matches.isEmpty()) {
-            return;
-        }
-
+    private GameReadModel deserialize(String json) {
         try {
-            RedisSerializer<String> keySerializer = redisTemplate.getStringSerializer();
-            @SuppressWarnings("unchecked")
-            RedisSerializer<Object> valueSerializer = (RedisSerializer<Object>) redisTemplate.getValueSerializer();
-
-            redisTemplate.executePipelined((RedisConnection connection) -> {
-                for (Map.Entry<String, GameReadModel> entry : matches.entrySet()) {
-                    if (entry.getKey() == null || entry.getValue() == null) {
-                        continue;
-                    }
-                    byte[] rawKey = keySerializer.serialize(buildKey(entry.getKey()));
-                    byte[] rawValue = valueSerializer.serialize(entry.getValue());
-                    if (rawKey == null || rawValue == null) {
-                        continue;
-                    }
-                    connection.stringCommands().setEx(rawKey, CACHE_TTL_SECONDS, rawValue);
-                }
-                return null;
-            });
+            return objectMapper.readValue(json, GameReadModel.class);
         } catch (Exception e) {
-            log.warn("매치 단건 캐시 pipeline 저장 실패 - count: {}, message: {}", matches.size(), e.getMessage());
+            log.warn("매치 단건 캐시 역직렬화 실패 - message: {}", e.getMessage());
+            return null;
         }
     }
 

--- a/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/match/MatchIdsCacheAdapterTest.java
+++ b/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/match/MatchIdsCacheAdapterTest.java
@@ -61,10 +61,4 @@ class MatchIdsCacheAdapterTest {
         assertThat(result.get()).containsExactly("KR_3", "KR_2", "KR_1");
     }
 
-    @DisplayName("saveIds 빈 입력은 Redis 와 상호작용하지 않는다")
-    @Test
-    void saveIds_emptyInput_noInteraction() {
-        adapter.saveIds("test-puuid", List.of());
-        // RedisTemplate.executePipelined 호출 없음
-    }
 }

--- a/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/match/MatchSingleCacheAdapterTest.java
+++ b/module/infra/persistence/redis/src/test/java/com/example/lolserver/repository/match/MatchSingleCacheAdapterTest.java
@@ -1,14 +1,13 @@
 package com.example.lolserver.repository.match;
 
 import com.example.lolserver.domain.match.application.model.GameReadModel;
-import com.example.lolserver.domain.match.domain.gamedata.GameInfoData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
 import java.util.Arrays;
@@ -23,39 +22,63 @@ import static org.mockito.BDDMockito.given;
 class MatchSingleCacheAdapterTest {
 
     @Mock
-    private RedisTemplate<String, Object> redisTemplate;
+    private StringRedisTemplate stringRedisTemplate;
 
     @Mock
-    private ValueOperations<String, Object> valueOperations;
+    private ValueOperations<String, String> valueOperations;
 
     private MatchSingleCacheAdapter adapter;
 
     @BeforeEach
     void setUp() {
-        adapter = new MatchSingleCacheAdapter(redisTemplate);
+        adapter = new MatchSingleCacheAdapter(stringRedisTemplate);
     }
 
-    @DisplayName("findByIds 는 match:v1:{matchId} 키로 MGET 하여 hit 항목만 맵으로 반환한다")
+    @DisplayName("findByIds 는 match:v1:{matchId} 로 MGET 한 JSON 을 GameReadModel 로 역직렬화한다")
     @Test
-    void findByIds_returnsOnlyHitEntries() {
-        // given
+    void findByIds_deserializesJson() {
         List<String> ids = List.of("KR_1", "KR_2", "KR_3");
         List<String> expectedKeys = List.of("match:v1:KR_1", "match:v1:KR_2", "match:v1:KR_3");
 
-        GameReadModel g1 = gameOf("KR_1");
-        GameReadModel g3 = gameOf("KR_3");
+        String json1 = "{\"gameInfoData\":{\"matchId\":\"KR_1\",\"queueId\":420}}";
+        String json3 = """
+                {"gameInfoData":{"matchId":"KR_3"},
+                 "participantData":[{"puuid":"p0","championName":"Ahri",
+                   "item":{"item0":3006},"statValue":{"offense":5005}}],
+                 "teamInfoData":{"blueTeam":{"teamId":100,"baronKills":2},
+                   "redTeam":{"teamId":200}}}
+                """;
 
-        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.multiGet(expectedKeys))
-                .willReturn(Arrays.asList(g1, null, g3));
+                .willReturn(Arrays.asList(json1, null, json3));
 
-        // when
         Map<String, GameReadModel> result = adapter.findByIds(ids);
 
-        // then
         assertThat(result).containsOnlyKeys("KR_1", "KR_3");
-        assertThat(result.get("KR_1")).isSameAs(g1);
-        assertThat(result.get("KR_3")).isSameAs(g3);
+        assertThat(result.get("KR_1").getGameInfoData().getMatchId()).isEqualTo("KR_1");
+        assertThat(result.get("KR_1").getGameInfoData().getQueueId()).isEqualTo(420);
+
+        GameReadModel g3 = result.get("KR_3");
+        assertThat(g3.getParticipantData()).hasSize(1);
+        assertThat(g3.getParticipantData().get(0).getChampionName()).isEqualTo("Ahri");
+        // setter 없는 값 객체도 필드 가시성으로 역직렬화된다
+        assertThat(g3.getParticipantData().get(0).getItem().getItem0()).isEqualTo(3006);
+        assertThat(g3.getParticipantData().get(0).getStatValue().getOffense()).isEqualTo(5005);
+        assertThat(g3.getTeamInfoData().getBlueTeam().getBaronKills()).isEqualTo(2);
+        assertThat(g3.getTeamInfoData().getRedTeam().getTeamId()).isEqualTo(200);
+    }
+
+    @DisplayName("역직렬화 실패(malformed) 항목은 결과에서 제외된다")
+    @Test
+    void findByIds_skipsMalformed() {
+        given(stringRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.multiGet(List.of("match:v1:KR_1")))
+                .willReturn(List.of("{not-json"));
+
+        Map<String, GameReadModel> result = adapter.findByIds(List.of("KR_1"));
+
+        assertThat(result).isEmpty();
     }
 
     @DisplayName("findByIds 빈 입력은 곧바로 빈 맵을 반환한다")
@@ -68,24 +91,9 @@ class MatchSingleCacheAdapterTest {
     @DisplayName("findByIds Redis 장애 시 빈 맵을 반환한다")
     @Test
     void findByIds_redisFailure_returnsEmpty() {
-        given(redisTemplate.opsForValue()).willThrow(new RuntimeException("Redis down"));
+        given(stringRedisTemplate.opsForValue()).willThrow(new RuntimeException("Redis down"));
 
         Map<String, GameReadModel> result = adapter.findByIds(List.of("KR_1"));
         assertThat(result).isEmpty();
-    }
-
-    @DisplayName("saveAll 빈 입력은 Redis 와 상호작용하지 않는다")
-    @Test
-    void saveAll_emptyInput_noInteraction() {
-        adapter.saveAll(Collections.emptyMap());
-        // RedisTemplate 와의 어떤 상호작용도 없어야 한다 (executePipelined 호출되지 않음)
-    }
-
-    private GameReadModel gameOf(String matchId) {
-        GameReadModel game = new GameReadModel();
-        GameInfoData info = new GameInfoData();
-        info.setMatchId(matchId);
-        game.setGameInfoData(info);
-        return game;
     }
 }


### PR DESCRIPTION
## 배경
매치 캐시 JSON 변환을 **읽기 측(lol-server)** 에서 매 조회마다 수행하던 것을 **쓰기 측(lol-repository)** 으로 이관(1-C)하는 작업의 읽기 측 PR.

lol-repository 가 `GameReadModel` 과 동일한 형태로 캐시를 직렬화하므로, lol-server 는 per-read 변환 없이 raw JSON 을 한 번에 역직렬화한다. (이전엔 `RedisTemplate` 의 `GenericJackson2JsonRedisSerializer` 가 `@class` 를 기대해 lol-repository 가 쓴 raw JSON 을 읽지 못함 → 사실상 캐시 항상 miss)

## 변경
- **`MatchSingleCacheAdapter`** — `StringRedisTemplate` + 필드 가시성(`PropertyAccessor.FIELD`, `Visibility.ANY`) 전용 `ObjectMapper` 로 raw JSON 직독.
  - setter 없는 value object(`ItemValue`/`StatValue`/`TeamData` 등)도 필드 접근으로 역직렬화
  - `readValue(json, GameReadModel.class)` 한 줄, **per-read 변환 0**
- `MatchIdsCacheAdapter` / `MatchService` / 관련 포트 슬림화
- 테스트 재작성: JSON → GameReadModel (setter 없는 중첩 value 포함) 검증

## 검증
- `:module:infra:persistence:redis:check :module:core:lol-server-domain:check` → BUILD SUCCESSFUL

## 관련
- 쓰기 측: padosol/lol-repository#71
