### PR TITLE
feat: 솔로/자유랭크 LP 시계열 API 추가

### DIFF
--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/league/application/LeagueService.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/league/application/LeagueService.java
@@ -36,4 +36,18 @@ public class LeagueService implements LeagueQueryUseCase {
             return league;
         }).toList();
     }
+
+    @Override
+    public List<League> getLpTimeline(String puuid) {
+        List<League> leagues = leaguePersistencePort.findAllLeaguesByPuuid(puuid);
+
+        for (League league : leagues) {
+            List<LeagueHistory> recentHistories = leaguePersistencePort
+                    .findRecentHistoryByLeagueSummonerId(league.getId());
+
+            league.addAllHistoryDomain(recentHistories);
+        }
+
+        return leagues;
+    }
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/league/application/port/LeaguePersistencePort.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/league/application/port/LeaguePersistencePort.java
@@ -8,4 +8,7 @@ import java.util.List;
 public interface LeaguePersistencePort {
     List<League> findAllLeaguesByPuuid(String puuid);
     List<LeagueHistory> findAllHistoryByLeagueSummonerIds(List<Long> ids);
+
+    // LP 시계열용: 한 리그(큐)의 최신 history 만 제한적으로 조회한다.
+    List<LeagueHistory> findRecentHistoryByLeagueSummonerId(Long leagueSummonerId);
 }

--- a/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/league/application/port/in/LeagueQueryUseCase.java
+++ b/module/core/lol-server-domain/src/main/java/com/example/lolserver/domain/league/application/port/in/LeagueQueryUseCase.java
@@ -7,4 +7,7 @@ import java.util.List;
 public interface LeagueQueryUseCase {
 
     List<League> getLeaguesBypuuid(String puuid);
+
+    // LP 시계열 그래프용: 큐별 최신 history 만 포함한 리그 리스트를 반환한다.
+    List<League> getLpTimeline(String puuid);
 }

--- a/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/league/application/LeagueServiceTest.java
+++ b/module/core/lol-server-domain/src/test/java/com/example/lolserver/domain/league/application/LeagueServiceTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class LeagueServiceTest {
@@ -149,5 +150,57 @@ class LeagueServiceTest {
 
         then(leaguePersistencePort).should().findAllLeaguesByPuuid(puuid);
         then(leaguePersistencePort).should().findAllHistoryByLeagueSummonerIds(List.of(1L, 2L));
+    }
+
+    @DisplayName("LP 시계열 조회 시 리그별 최신 history 만 포함하고 무제한 배치 쿼리를 쓰지 않는다")
+    @Test
+    void getLpTimeline_리그별제한조회_무제한쿼리미사용() {
+        // given
+        String puuid = "timeline-puuid";
+
+        League soloLeague = League.builder()
+                .id(1L).puuid(puuid).queue("RANKED_SOLO_5x5").tier("DIAMOND").rank("II").build();
+        League flexLeague = League.builder()
+                .id(2L).puuid(puuid).queue("RANKED_FLEX_SR").tier("PLATINUM").rank("I").build();
+
+        LeagueHistory soloHistory = new LeagueHistory(
+                1L, puuid, "RANKED_SOLO_5x5", "solo-league-id",
+                50, 30, "DIAMOND", "II", 60, 2260L,
+                false, false, false, false, LocalDateTime.now()
+        );
+        LeagueHistory flexHistory = new LeagueHistory(
+                2L, puuid, "RANKED_FLEX_SR", "flex-league-id",
+                20, 15, "PLATINUM", "I", 40, 2040L,
+                false, false, false, false, LocalDateTime.now()
+        );
+
+        given(leaguePersistencePort.findAllLeaguesByPuuid(puuid))
+                .willReturn(List.of(soloLeague, flexLeague));
+        given(leaguePersistencePort.findRecentHistoryByLeagueSummonerId(1L))
+                .willReturn(List.of(soloHistory));
+        given(leaguePersistencePort.findRecentHistoryByLeagueSummonerId(2L))
+                .willReturn(List.of(flexHistory));
+
+        // when
+        List<League> result = leagueService.getLpTimeline(puuid);
+
+        // then
+        assertThat(result).hasSize(2);
+
+        League resultSolo = result.stream()
+                .filter(l -> l.getQueue().equals("RANKED_SOLO_5x5"))
+                .findFirst().orElseThrow();
+        assertThat(resultSolo.getLeagueHistory()).hasSize(1);
+        assertThat(resultSolo.getLeagueHistory().get(0).leagueSummonerId()).isEqualTo(1L);
+
+        League resultFlex = result.stream()
+                .filter(l -> l.getQueue().equals("RANKED_FLEX_SR"))
+                .findFirst().orElseThrow();
+        assertThat(resultFlex.getLeagueHistory()).hasSize(1);
+
+        // 리그(큐)별 제한 쿼리가 각각 호출되고, 무제한 배치 쿼리는 호출되지 않아야 한다
+        then(leaguePersistencePort).should().findRecentHistoryByLeagueSummonerId(1L);
+        then(leaguePersistencePort).should().findRecentHistoryByLeagueSummonerId(2L);
+        then(leaguePersistencePort).should(never()).findAllHistoryByLeagueSummonerIds(anyList());
     }
 }

--- a/module/infra/api/src/docs/asciidoc/api/league/lp-timeline.adoc
+++ b/module/infra/api/src/docs/asciidoc/api/league/lp-timeline.adoc
@@ -1,0 +1,10 @@
+[[league-lp-timeline]]
+=== 유저 LP 변화 시계열 (솔로/자유랭크 그래프)
+
+==== HTTP Request
+include::{snippets}/league-lp-timeline/http-request.adoc[]
+include::{snippets}/league-lp-timeline/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/league-lp-timeline/http-response.adoc[]
+include::{snippets}/league-lp-timeline/response-fields.adoc[]

--- a/module/infra/api/src/docs/asciidoc/index.adoc
+++ b/module/infra/api/src/docs/asciidoc/index.adoc
@@ -54,6 +54,8 @@ include::api/match/match-daily-count.adoc[]
 
 include::api/league/league-detail.adoc[]
 
+include::api/league/lp-timeline.adoc[]
+
 
 [[Champion-API]]
 == Champion API

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/league/LeagueController.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/league/LeagueController.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.controller.league;
 
 import com.example.lolserver.controller.league.response.LeagueResponse;
+import com.example.lolserver.controller.league.response.LpTimelineResponse;
 import com.example.lolserver.controller.league.mapper.LeagueMapper;
 import com.example.lolserver.domain.league.domain.League;
 import com.example.lolserver.domain.league.application.port.in.LeagueQueryUseCase;
@@ -35,5 +36,20 @@ public class LeagueController {
 
         return new ResponseEntity<>(ApiResponse.success(
                 LeagueMapper.domainToResponse(leagues)), HttpStatus.OK);
+    }
+
+    /**
+     * 소환사 LP 변화 시계열 조회 API (솔로랭크/자유랭크 그래프 데이터)
+     * @param puuid 소환사 puuid
+     * @return 큐별 LP 시계열 (시간 오름차순)
+     */
+    @GetMapping("/v1/leagues/by-puuid/{puuid}/lp-timeline")
+    public ResponseEntity<ApiResponse<LpTimelineResponse>> fetchLpTimeline(
+            @PathVariable("puuid") String puuid
+    ) {
+        List<League> leagues = leagueService.getLpTimeline(puuid);
+
+        return new ResponseEntity<>(ApiResponse.success(
+                LeagueMapper.domainToLpTimeline(leagues)), HttpStatus.OK);
     }
 }

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/league/mapper/LeagueMapper.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/league/mapper/LeagueMapper.java
@@ -3,12 +3,15 @@ package com.example.lolserver.controller.league.mapper;
 import com.example.lolserver.QueueType;
 import com.example.lolserver.controller.league.response.LeagueResponse;
 import com.example.lolserver.controller.league.response.LeagueSummonerResponse;
+import com.example.lolserver.controller.league.response.LpTimelinePoint;
+import com.example.lolserver.controller.league.response.LpTimelineResponse;
 import com.example.lolserver.domain.league.domain.League;
 import com.example.lolserver.domain.league.domain.vo.LeagueHistory;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 public final class LeagueMapper {
@@ -63,6 +66,42 @@ public final class LeagueMapper {
         return new LeagueResponse(
                 soloLeague, flexLeague, soloLeagueHistory, flexLeagueHistory
         );
+    }
+
+    /**
+     * 솔로/자유 랭크 history 스냅샷을 LP 시계열 그래프 데이터로 변환한다.
+     * 각 시계열은 시간 오름차순(과거 → 현재)으로 정렬한다.
+     */
+    public static LpTimelineResponse domainToLpTimeline(List<League> leagues) {
+        List<LpTimelinePoint> soloRankTimeline = new ArrayList<>();
+        List<LpTimelinePoint> flexRankTimeline = new ArrayList<>();
+
+        for (League league : leagues) {
+            for (LeagueHistory history : league.getLeagueHistory()) {
+                LpTimelinePoint point = new LpTimelinePoint(
+                        history.createdAt(),
+                        history.leaguePoints(),
+                        history.absolutePoints(),
+                        history.tier(),
+                        history.rank()
+                );
+
+                if (history.queue().equals(QueueType.RANKED_SOLO_5x5.name())) {
+                    soloRankTimeline.add(point);
+                } else {
+                    flexRankTimeline.add(point);
+                }
+            }
+        }
+
+        Comparator<LpTimelinePoint> byTimestamp = Comparator.comparing(
+                LpTimelinePoint::timestamp,
+                Comparator.nullsLast(Comparator.naturalOrder())
+        );
+        soloRankTimeline.sort(byTimestamp);
+        flexRankTimeline.sort(byTimestamp);
+
+        return new LpTimelineResponse(soloRankTimeline, flexRankTimeline);
     }
 
     private static BigDecimal calculateWinRate(int wins, int losses) {

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/league/response/LpTimelinePoint.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/league/response/LpTimelinePoint.java
@@ -1,0 +1,17 @@
+package com.example.lolserver.controller.league.response;
+
+import java.time.LocalDateTime;
+
+/**
+ * LP 시계열 그래프의 한 데이터 포인트.
+ * x축은 {@code timestamp}, y축은 {@code leaguePoints}(티어마다 0~100 으로 리셋) 또는
+ * {@code absolutePoints}(티어를 가로질러 연속 증가하는 누적값) 중 하나를 사용한다.
+ */
+public record LpTimelinePoint(
+        LocalDateTime timestamp,
+        int leaguePoints,
+        long absolutePoints,
+        String tier,
+        String rank
+) {
+}

--- a/module/infra/api/src/main/java/com/example/lolserver/controller/league/response/LpTimelineResponse.java
+++ b/module/infra/api/src/main/java/com/example/lolserver/controller/league/response/LpTimelineResponse.java
@@ -1,0 +1,14 @@
+package com.example.lolserver.controller.league.response;
+
+import java.util.List;
+
+/**
+ * 소환사의 솔로랭크/자유랭크 LP 변화 시계열 응답.
+ * 각 리스트는 시간 오름차순(과거 → 현재)으로 정렬된 LP 데이터 포인트이며,
+ * 프런트엔드 그래프 라이브러리에 그대로 전달할 수 있다.
+ */
+public record LpTimelineResponse(
+        List<LpTimelinePoint> soloRankTimeline,
+        List<LpTimelinePoint> flexRankTimeline
+) {
+}

--- a/module/infra/api/src/test/java/com/example/lolserver/docs/controller/LeagueControllerTest.java
+++ b/module/infra/api/src/test/java/com/example/lolserver/docs/controller/LeagueControllerTest.java
@@ -14,6 +14,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,6 +28,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -138,6 +140,99 @@ class LeagueControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.flexLeagueHistory[].oow").type(JsonFieldType.STRING).description("승률"),
                                 fieldWithPath("data.flexLeagueHistory[].tier").type(JsonFieldType.STRING).description("티어 (e.g., CHALLENGER)"),
                                 fieldWithPath("data.flexLeagueHistory[].rank").type(JsonFieldType.STRING).description("랭크 (e.g., I)"),
+                                fieldWithPath("errorMessage").type(JsonFieldType.OBJECT).description("에러 정보 (정상 응답 시 null)").optional(),
+                                fieldWithPath("errorMessage.errorCode").type(JsonFieldType.STRING).description("에러 코드").optional(),
+                                fieldWithPath("errorMessage.message").type(JsonFieldType.STRING).description("에러 메시지").optional(),
+                                fieldWithPath("errorMessage.timestamp").type(JsonFieldType.STRING).description("에러 발생 시각").optional()
+                        )
+                ));
+    }
+
+    @DisplayName("소환사 LP 변화 시계열 조회 API")
+    @Test
+    void fetchLpTimeline() throws Exception {
+        // given
+        String puuid = "puuid-1234";
+
+        // 솔로랭크 history 스냅샷 2건 (의도적으로 시간 역순으로 넣어 정렬 동작을 확인)
+        LeagueHistory soloLater = mock(LeagueHistory.class);
+        given(soloLater.queue()).willReturn("RANKED_SOLO_5x5");
+        given(soloLater.createdAt()).willReturn(LocalDateTime.of(2026, 5, 24, 21, 30, 0));
+        given(soloLater.leaguePoints()).willReturn(20);
+        given(soloLater.absolutePoints()).willReturn(1420L);
+        given(soloLater.tier()).willReturn("PLATINUM");
+        given(soloLater.rank()).willReturn("IV");
+
+        LeagueHistory soloEarlier = mock(LeagueHistory.class);
+        given(soloEarlier.queue()).willReturn("RANKED_SOLO_5x5");
+        given(soloEarlier.createdAt()).willReturn(LocalDateTime.of(2026, 5, 20, 9, 0, 0));
+        given(soloEarlier.leaguePoints()).willReturn(75);
+        given(soloEarlier.absolutePoints()).willReturn(1275L);
+        given(soloEarlier.tier()).willReturn("GOLD");
+        given(soloEarlier.rank()).willReturn("I");
+
+        LeagueHistory flexHistory = mock(LeagueHistory.class);
+        given(flexHistory.queue()).willReturn("RANKED_FLEX_SR");
+        given(flexHistory.createdAt()).willReturn(LocalDateTime.of(2026, 5, 22, 18, 0, 0));
+        given(flexHistory.leaguePoints()).willReturn(40);
+        given(flexHistory.absolutePoints()).willReturn(840L);
+        given(flexHistory.tier()).willReturn("SILVER");
+        given(flexHistory.rank()).willReturn("II");
+
+        League soloLeagueDomain = mock(League.class);
+        given(soloLeagueDomain.getLeagueHistory()).willReturn(List.of(soloLater, soloEarlier));
+
+        League flexLeagueDomain = mock(League.class);
+        given(flexLeagueDomain.getLeagueHistory()).willReturn(List.of(flexHistory));
+
+        given(leagueService.getLpTimeline(anyString()))
+                .willReturn(List.of(soloLeagueDomain, flexLeagueDomain));
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/leagues/by-puuid/{puuid}/lp-timeline", puuid)
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result").value("SUCCESS"))
+                // 시간 오름차순 정렬 검증: history 를 역순으로 넣었어도 더 이른 스냅샷이 [0] 에 온다
+                .andExpect(jsonPath("$.data.soloRankTimeline.length()").value(2))
+                .andExpect(jsonPath("$.data.soloRankTimeline[0].timestamp").value("2026-05-20T09:00:00"))
+                .andExpect(jsonPath("$.data.soloRankTimeline[0].leaguePoints").value(75))
+                .andExpect(jsonPath("$.data.soloRankTimeline[0].absolutePoints").value(1275))
+                .andExpect(jsonPath("$.data.soloRankTimeline[0].tier").value("GOLD"))
+                .andExpect(jsonPath("$.data.soloRankTimeline[0].rank").value("I"))
+                .andExpect(jsonPath("$.data.soloRankTimeline[1].timestamp").value("2026-05-24T21:30:00"))
+                .andExpect(jsonPath("$.data.soloRankTimeline[1].leaguePoints").value(20))
+                .andExpect(jsonPath("$.data.soloRankTimeline[1].absolutePoints").value(1420))
+                .andExpect(jsonPath("$.data.flexRankTimeline.length()").value(1))
+                .andExpect(jsonPath("$.data.flexRankTimeline[0].timestamp").value("2026-05-22T18:00:00"))
+                .andExpect(jsonPath("$.data.flexRankTimeline[0].leaguePoints").value(40))
+                .andExpect(jsonPath("$.data.flexRankTimeline[0].absolutePoints").value(840))
+                .andExpect(jsonPath("$.data.flexRankTimeline[0].tier").value("SILVER"))
+                .andExpect(jsonPath("$.data.flexRankTimeline[0].rank").value("II"))
+                .andDo(print())
+                .andDo(document("league-lp-timeline",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        pathParameters(
+                                parameterWithName("puuid").description("조회할 소환사의 PUUID")
+                        ),
+                        responseFields(
+                                fieldWithPath("result").type(JsonFieldType.STRING).description("API 성공 여부"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT).description("응답 데이터"),
+                                fieldWithPath("data.soloRankTimeline[]").type(JsonFieldType.ARRAY).description("솔로랭크 LP 시계열 (시간 오름차순)"),
+                                fieldWithPath("data.soloRankTimeline[].timestamp").type(JsonFieldType.STRING).description("스냅샷 시각 (ISO-8601)"),
+                                fieldWithPath("data.soloRankTimeline[].leaguePoints").type(JsonFieldType.NUMBER).description("리그 포인트 (티어마다 0~100 리셋)"),
+                                fieldWithPath("data.soloRankTimeline[].absolutePoints").type(JsonFieldType.NUMBER).description("티어를 가로질러 연속 증가하는 누적 LP (그래프 y축 권장)"),
+                                fieldWithPath("data.soloRankTimeline[].tier").type(JsonFieldType.STRING).description("티어 (e.g., GOLD)"),
+                                fieldWithPath("data.soloRankTimeline[].rank").type(JsonFieldType.STRING).description("랭크 (e.g., I)"),
+                                fieldWithPath("data.flexRankTimeline[]").type(JsonFieldType.ARRAY).description("자유랭크 LP 시계열 (시간 오름차순)"),
+                                fieldWithPath("data.flexRankTimeline[].timestamp").type(JsonFieldType.STRING).description("스냅샷 시각 (ISO-8601)"),
+                                fieldWithPath("data.flexRankTimeline[].leaguePoints").type(JsonFieldType.NUMBER).description("리그 포인트 (티어마다 0~100 리셋)"),
+                                fieldWithPath("data.flexRankTimeline[].absolutePoints").type(JsonFieldType.NUMBER).description("티어를 가로질러 연속 증가하는 누적 LP (그래프 y축 권장)"),
+                                fieldWithPath("data.flexRankTimeline[].tier").type(JsonFieldType.STRING).description("티어 (e.g., SILVER)"),
+                                fieldWithPath("data.flexRankTimeline[].rank").type(JsonFieldType.STRING).description("랭크 (e.g., II)"),
                                 fieldWithPath("errorMessage").type(JsonFieldType.OBJECT).description("에러 정보 (정상 응답 시 null)").optional(),
                                 fieldWithPath("errorMessage.errorCode").type(JsonFieldType.STRING).description("에러 코드").optional(),
                                 fieldWithPath("errorMessage.message").type(JsonFieldType.STRING).description("에러 메시지").optional(),

--- a/module/infra/persistence/postgresql/src/main/java/com/example/lolserver/repository/league/LeagueSummonerHistoryRepository.java
+++ b/module/infra/persistence/postgresql/src/main/java/com/example/lolserver/repository/league/LeagueSummonerHistoryRepository.java
@@ -7,4 +7,7 @@ import java.util.List;
 
 public interface LeagueSummonerHistoryRepository extends JpaRepository<LeagueSummonerHistoryEntity, Long> {
     List<LeagueSummonerHistoryEntity> findAllByLeagueSummonerIdInOrderByCreatedAtDesc(List<Long> leagueSummonerIds);
+
+    // LP 시계열 그래프용: 리그(큐)별 최신 20건만 조회해 무제한 적재를 방지한다.
+    List<LeagueSummonerHistoryEntity> findTop20ByLeagueSummonerIdOrderByCreatedAtDesc(Long leagueSummonerId);
 }

--- a/module/infra/persistence/postgresql/src/main/java/com/example/lolserver/repository/league/adapter/LeaguePersistenceAdapter.java
+++ b/module/infra/persistence/postgresql/src/main/java/com/example/lolserver/repository/league/adapter/LeaguePersistenceAdapter.java
@@ -37,4 +37,12 @@ public class LeaguePersistenceAdapter implements LeaguePersistencePort {
         return leagueDomainMapper.toDomainHistoryList(leagueSummonerHistoryEntities);
     }
 
+    @Override
+    public List<LeagueHistory> findRecentHistoryByLeagueSummonerId(Long leagueSummonerId) {
+        List<LeagueSummonerHistoryEntity> leagueSummonerHistoryEntities =
+                leagueSummonerHistoryRepository
+                        .findTop20ByLeagueSummonerIdOrderByCreatedAtDesc(leagueSummonerId);
+        return leagueDomainMapper.toDomainHistoryList(leagueSummonerHistoryEntities);
+    }
+
 }

--- a/module/infra/persistence/postgresql/src/test/java/com/example/lolserver/repository/league/adapter/LeaguePersistenceAdapterTest.java
+++ b/module/infra/persistence/postgresql/src/test/java/com/example/lolserver/repository/league/adapter/LeaguePersistenceAdapterTest.java
@@ -15,6 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -130,6 +133,110 @@ class LeaguePersistenceAdapterTest extends RepositoryTestBase {
         assertThat(result).hasSize(2);
         assertThat(result).extracting(LeagueHistory::tier)
                 .containsExactlyInAnyOrder("GOLD", "GOLD");
+    }
+
+    @DisplayName("리그별 최신 history 조회는 25건 중 createdAt 내림차순 최신 20건만 반환하고 오래된 5건은 제외한다")
+    @Test
+    void findRecentHistoryByLeagueSummonerId_returnsLatest20ByCreatedAtDesc() {
+        // given
+        LeagueSummonerEntity savedSummoner = leagueSummonerRepository.save(
+                buildLeagueSummoner("recent-history-puuid", "RANKED_SOLO_5x5"));
+        entityManager.flush();
+
+        // leaguePoints = i, createdAt = base + i분  → i 가 클수록 최신 (총 25건, i: 0~24)
+        LocalDateTime base = LocalDateTime.of(2026, 1, 1, 0, 0, 0);
+        List<LeagueSummonerHistoryEntity> histories = new ArrayList<>();
+        for (int i = 0; i < 25; i++) {
+            histories.add(createHistoryEntityAt(savedSummoner.getId(), i, base.plusMinutes(i)));
+        }
+        leagueSummonerHistoryRepository.saveAll(histories);
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<LeagueHistory> result = adapter.findRecentHistoryByLeagueSummonerId(savedSummoner.getId());
+
+        // then
+        assertThat(result).hasSize(20);
+        // 최신순(createdAt DESC): leaguePoints 24, 23, ... , 5
+        assertThat(result).extracting(LeagueHistory::leaguePoints)
+                .containsExactly(24, 23, 22, 21, 20, 19, 18, 17, 16, 15,
+                        14, 13, 12, 11, 10, 9, 8, 7, 6, 5);
+        // 가장 오래된 5건(leaguePoints 0~4)은 제외된다
+        assertThat(result).extracting(LeagueHistory::leaguePoints)
+                .doesNotContain(0, 1, 2, 3, 4);
+        // 정렬 키는 createdAt 이며 내림차순이다
+        assertThat(result).extracting(LeagueHistory::createdAt)
+                .isSortedAccordingTo(Comparator.reverseOrder());
+    }
+
+    @DisplayName("리그별 최신 history 조회는 대상 leagueSummonerId 의 history 만 반환하고 다른 리그 데이터는 섞이지 않는다")
+    @Test
+    void findRecentHistoryByLeagueSummonerId_filtersByLeagueSummonerId() {
+        // given
+        LeagueSummonerEntity target = leagueSummonerRepository.save(
+                buildLeagueSummoner("filter-target-puuid", "RANKED_SOLO_5x5"));
+        LeagueSummonerEntity other = leagueSummonerRepository.save(
+                buildLeagueSummoner("filter-other-puuid", "RANKED_FLEX_SR"));
+        entityManager.flush();
+
+        LocalDateTime base = LocalDateTime.of(2026, 1, 1, 0, 0, 0);
+        leagueSummonerHistoryRepository.saveAll(List.of(
+                createHistoryEntityAt(target.getId(), 10, base),
+                createHistoryEntityAt(target.getId(), 11, base.plusMinutes(1)),
+                createHistoryEntityAt(other.getId(), 99, base.plusMinutes(2))
+        ));
+        entityManager.flush();
+        entityManager.clear();
+
+        // when
+        List<LeagueHistory> result = adapter.findRecentHistoryByLeagueSummonerId(target.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(LeagueHistory::leagueSummonerId)
+                .containsOnly(target.getId());
+        // 다른 리그(other)의 history(leaguePoints 99)는 누수되지 않는다
+        assertThat(result).extracting(LeagueHistory::leaguePoints)
+                .doesNotContain(99);
+    }
+
+    private LeagueSummonerEntity buildLeagueSummoner(String puuid, String queue) {
+        return LeagueSummonerEntity.builder()
+                .puuid(puuid)
+                .queue(queue)
+                .leagueId("league-recent")
+                .wins(50)
+                .losses(30)
+                .tier("GOLD")
+                .rank("I")
+                .leaguePoints(25)
+                .absolutePoints(4125)
+                .veteran(false)
+                .inactive(false)
+                .freshBlood(false)
+                .hotStreak(false)
+                .build();
+    }
+
+    private LeagueSummonerHistoryEntity createHistoryEntityAt(Long leagueSummonerId, int leaguePoints, LocalDateTime createdAt) {
+        LeagueSummonerHistoryEntity entity = new LeagueSummonerHistoryEntity();
+        ReflectionTestUtils.setField(entity, "leagueSummonerId", leagueSummonerId);
+        ReflectionTestUtils.setField(entity, "puuid", "history-test-puuid");
+        ReflectionTestUtils.setField(entity, "queue", "RANKED_SOLO_5x5");
+        ReflectionTestUtils.setField(entity, "leagueId", "league-history");
+        ReflectionTestUtils.setField(entity, "tier", "GOLD");
+        ReflectionTestUtils.setField(entity, "rank", "I");
+        ReflectionTestUtils.setField(entity, "wins", 40);
+        ReflectionTestUtils.setField(entity, "losses", 30);
+        ReflectionTestUtils.setField(entity, "leaguePoints", leaguePoints);
+        ReflectionTestUtils.setField(entity, "absolutePoints", 4125L);
+        ReflectionTestUtils.setField(entity, "veteran", false);
+        ReflectionTestUtils.setField(entity, "inactive", false);
+        ReflectionTestUtils.setField(entity, "freshBlood", false);
+        ReflectionTestUtils.setField(entity, "hotStreak", false);
+        ReflectionTestUtils.setField(entity, "createdAt", createdAt);
+        return entity;
     }
 
     private LeagueSummonerHistoryEntity createHistoryEntity(Long leagueSummonerId, String tier, String rank, int wins, int losses) {


### PR DESCRIPTION
## 개요

유저의 **솔로랭크/자유랭크 LP 변화를 시계열 그래프 데이터**로 반환하는 API를 추가합니다.

## 엔드포인트

```
GET /api/v1/leagues/by-puuid/{puuid}/lp-timeline
```

큐별로 **최신 20건**의 history 스냅샷을 **시간 오름차순(과거 → 현재)** 으로 반환합니다.

### 응답 예시

```json
{
  "result": "SUCCESS",
  "data": {
    "soloRankTimeline": [
      { "timestamp": "2026-05-20T09:00:00", "leaguePoints": 75, "absolutePoints": 1275, "tier": "GOLD", "rank": "I" },
      { "timestamp": "2026-05-24T21:30:00", "leaguePoints": 20, "absolutePoints": 1420, "tier": "PLATINUM", "rank": "IV" }
    ],
    "flexRankTimeline": [
      { "timestamp": "2026-05-22T18:00:00", "leaguePoints": 40, "absolutePoints": 840, "tier": "SILVER", "rank": "II" }
    ]
  },
  "errorMessage": null
}
```

## 설계

- **기존 데이터/도메인 재사용**: `league_summoner_history` 테이블에 이미 타임스탬프 스냅샷이 쌓입니다. 시계열 전용 read 경로(`getLpTimeline`)만 추가했고 도메인 모델/스키마 변경은 없습니다.
- **Y축 두 값 모두 제공**: `leaguePoints`(티어마다 0~100 리셋)와 `absolutePoints`(티어 간 연속 누적값)를 함께 반환해 프런트가 그래프 Y축을 선택합니다.
- **기존 `/by-puuid/{puuid}` 계약 비파괴**: 그 응답은 타임스탬프가 없어 그래프에 못 쓰므로 전용 엔드포인트를 신설했습니다.
- 헥사고날 레이어 흐름: `LeagueController → LeagueQueryUseCase.getLpTimeline → LeaguePersistencePort.findRecentHistoryByLeagueSummonerId → Adapter → Repository`.

## 코드 리뷰 반영

- **무제한 조회 차단**: 시계열 조회를 **큐별 최신 20건**으로 DB 레벨에서 제한(`findTop20ByLeagueSummonerIdOrderByCreatedAtDesc`). 입력과 무관하게 메모리 적재가 바운딩됩니다. 기존 공유 쿼리/엔드포인트는 손대지 않았습니다.
- **테스트 보강**:
  - 컨트롤러 테스트에 jsonPath 단언 추가 — 역순 입력 history가 시간 오름차순으로 정렬되는지 + 모든 필드 값 검증.
  - 어댑터 테스트에서 `createdAt`를 명시 세팅해 "createdAt DESC 최신 20건·오래된 5건 제외"를 `containsExactly`로 검증, 두 summoner 데이터로 `leagueSummonerId` 필터 누수까지 검증.

## 테스트

```
core:lol-server-domain  : 188 tests, 0 failures
infra:persistence:postgresql : 136 tests, 0 failures
infra:api               :  87 tests, 0 failures
```

RestDocs 스니펫(`league-lp-timeline`) 생성 및 `index.adoc` include 추가 완료.

## 참고 (후속)

시계열은 `league_summoner_history` 스냅샷을 사용하므로, 정상 동작하려면 `league_summoner → league_summoner_history`로 주기적 스냅샷을 적재하는 스케줄러가 필요합니다. (현재 Airflow에 해당 일배치 job은 확인되지 않음 — 별도 점검 권장.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
