### PR TITLE
chore: CI Gradle 캐시 시딩 + archTest job 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main, develop]
+  push:
+    branches: [main, develop]
 
 jobs:
   checkstyle:
@@ -16,20 +18,36 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
+      - uses: gradle/actions/setup-gradle@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
       - name: Run Checkstyle
         run: ./gradlew checkstyleMain checkstyleTest
+
+  archTest:
+    name: Architecture Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run Architecture Test
+        run: ./gradlew archTest
 
   build:
     name: Build & Test
@@ -42,14 +60,9 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
+      - uses: gradle/actions/setup-gradle@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
+          cache-read-only: ${{ github.event_name == 'pull_request' }}
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -77,8 +90,8 @@ jobs:
   notify:
     name: Slack Notification
     runs-on: ubuntu-latest
-    needs: [checkstyle, build]
-    if: always()
+    needs: [checkstyle, archTest, build]
+    if: always() && github.event_name == 'pull_request'
     steps:
       - name: Notify Slack
         uses: slackapi/slack-github-action@v2.1.1
@@ -92,4 +105,4 @@ jobs:
               - type: "section"
                 text:
                   type: "mrkdwn"
-                  text: "${{ contains(needs.*.result, 'failure') && '❌ *CI 실패*' || '✅ *CI 성공*' }}\n*Repo:* ${{ github.repository }}\n*Branch:* ${{ github.head_ref || github.ref_name }}\n*PR:* <${{ github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}|링크>\n*Author:* ${{ github.actor }}\n*Checkstyle:* ${{ needs.checkstyle.result }}\n*Build:* ${{ needs.build.result }}"
+                  text: "${{ contains(needs.*.result, 'failure') && '❌ *CI 실패*' || '✅ *CI 성공*' }}\n*Repo:* ${{ github.repository }}\n*Branch:* ${{ github.head_ref || github.ref_name }}\n*PR:* <${{ github.event.pull_request.html_url || format('{0}/{1}/commit/{2}', github.server_url, github.repository, github.sha) }}|링크>\n*Author:* ${{ github.actor }}\n*Checkstyle:* ${{ needs.checkstyle.result }}\n*Arch:* ${{ needs.archTest.result }}\n*Build:* ${{ needs.build.result }}"

--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,18 @@ subprojects {
         useJUnitPlatform()
     }
 
+    tasks.register('archTest', Test) {
+        description = 'ArchUnit 아키텍처 규칙 테스트(*ArchitectureTest)만 실행'
+        group = 'verification'
+        useJUnitPlatform()
+        testClassesDirs = sourceSets.test.output.classesDirs
+        classpath = sourceSets.test.runtimeClasspath
+        filter {
+            includeTestsMatching '*ArchitectureTest'
+            failOnNoMatchingTests = false
+        }
+    }
+
     bootRun {
         String activeProfile = System.properties['spring.profiles.active']
         systemProperty "spring.profiles.active", activeProfile


### PR DESCRIPTION
## 배경

CI(`checkstyle`, `Build & Test`)가 매 실행마다 Gradle 배포판과 의존성을 새로 내려받던 문제. 기존엔 `actions/cache`가 있었지만 트리거가 `pull_request` 뿐이라 **공유 브랜치(main/develop)에 캐시 시드가 생기지 않아** 새 PR 브랜치마다 콜드스타트가 났습니다 (GitHub Actions 캐시는 브랜치 스코프).

## 변경 내용

**Gradle 캐시**
- `push: [main, develop]` 트리거 추가 → 머지 시 공유 브랜치에 캐시 시드 생성, 이후 모든 PR이 상속
- `actions/cache@v4` → 공식 `gradle/actions/setup-gradle@v4` 교체
- `cache-read-only: ${{ github.event_name == 'pull_request' }}` → PR은 읽기 전용, push(공유 브랜치)에서만 캐시 갱신 (10GB 한도 오염 방지)

**Slack 알림**
- `notify` job을 `if: always() && github.event_name == 'pull_request'` 로 제한 → 머지(push) 시엔 알림 안 감

**archTest**
- `build.gradle`: `archTest` 태스크 신설 — `*ArchitectureTest`만 실행, arch 테스트 없는 모듈은 `failOnNoMatchingTests = false`로 통과. 로컬에서 `./gradlew archTest` 가능
- `ci.yml`: `Architecture Test` job 추가 (checkstyle/build와 병렬, 독립 체크). Slack 메시지에 `Arch` 라인 추가

## 검증

- `./gradlew archTest` BUILD SUCCESSFUL — 도메인 8개 모듈의 ArchUnit 테스트 총 41개 통과 (필터가 `*ArchitectureTest`만 정확히 선택)
- `ci.yml` YAML 파싱·트리거·게이팅 확인

## 참고 — 캐시 시드 부트스트랩

캐시는 다음 순서로 따뜻해집니다:
1. 이 PR 실행: 시드 없음 → 콜드(다운로드), read-only라 저장 안 함
2. develop 머지(push): 한 번 다운로드 후 **develop 스코프로 시드 저장**
3. 다음 PR부터: develop 시드 HIT → 다운로드 생략

확인: Actions run의 job Summary(setup-gradle 캐시 리포트), `actions/caches` 페이지, 또는 `gh cache list`.
