### PR TITLE
chore: 내장 Tomcat work 디렉토리 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ performance-tests/results/*.txt
 
 ### AI-Ready Audit ###
 .ai-ready-audit/
+
+### Embedded Tomcat ###
+work/


### PR DESCRIPTION
## 변경 유형
chore

## 변경 사항
- `.gitignore`에 `work/` 추가 (`### Embedded Tomcat ###` 섹션)

## 변경 이유
- `bootRun` 등 앱 실행 시 내장 Tomcat이 워킹 디렉토리에 `work/Tomcat/localhost/ROOT` 같은 런타임 작업 디렉토리를 생성함 — 컴파일된 JSP·세션 직렬화 등에 쓰이는 런타임 산출물로 버전 관리 대상이 아님
- 무시 규칙이 없어 워킹 카피에 남아 있었고(빈 디렉토리라 git status에는 안 잡혔지만), 실수로 커밋될 여지가 있었음

## 테스트
- [ ] 단위 테스트 통과 (`./gradlew test`) — N/A: 코드 변경 없음 (`.gitignore`만 수정)
- [ ] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`) — N/A: 코드 변경 없음
- [ ] 로컬 빌드 확인 (`./gradlew build`) — N/A: 코드 변경 없음

## 리뷰 포인트
- 로컬 워킹 카피의 `work/` 디렉토리는 별도로 삭제함 (빈 디렉토리, 앱 재실행 시 자동 재생성)
- `.gitignore` 한 줄 추가 외 코드/동작 변화 없음