### PR TITLE
chore: PR 템플릿에 관련 이슈(MP-키) 섹션 추가 및 변경 유형 체크박스화

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,13 @@
+## 관련 이슈
+<!-- Linear 키 필수: MP-<번호> -->
+- MP-
+
 ## 변경 유형
-<!-- feat / fix / refactor / docs / chore 중 선택 -->
+- [ ] feat
+- [ ] fix
+- [ ] refactor
+- [ ] docs
+- [ ] chore
 
 ## 변경 사항
 -


### PR DESCRIPTION
## 관련 이슈
- N/A (MP 키 없이 진행)

## 변경 유형
- [ ] feat
- [ ] fix
- [ ] refactor
- [ ] docs
- [x] chore

## 변경 사항
- PR 템플릿(`.github/PULL_REQUEST_TEMPLATE.md`) 최상단에 `## 관련 이슈` 섹션 추가
- `## 변경 유형`을 자유 입력 주석에서 체크박스 형태로 전환

## 변경 이유
- 브랜치/커밋에 Linear `MP-<번호>` 키를 필수로 요구하는 컨벤션(CLAUDE.md)과 달리 PR 템플릿엔 이슈 링크 칸이 없어 추적성이 떨어졌음
- 변경 유형을 자유 입력하면 오타·누락 여지가 있어 체크박스로 강제

## 테스트
- [ ] 단위 테스트 통과 (`./gradlew test`) — N/A: 마크다운 템플릿만 변경
- [ ] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`) — N/A
- [ ] 로컬 빌드 확인 (`./gradlew build`) — N/A

## 리뷰 포인트
- `관련 이슈` 섹션 위치(최상단)와 문구가 적절한지
- 변경 유형 체크박스 항목(feat/fix/refactor/docs/chore)이 CLAUDE.md 커밋 타입과 일치하는지