### PR TITLE
chore: commit·PR 작성 규칙 스킬 추가

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: commit
+description: lol-server 저장소에서 git 커밋을 만들 때 사용한다. 커밋 메시지를 이 repo 컨벤션(`<type>: MP-<번호> <한글 설명>`)에 맞추고, Claude/AI 자동 서명(`Co-Authored-By: Claude`, `🤖 Generated with ...` 등)을 절대 넣지 않도록 보장한다. 사용자가 "커밋해줘", "commit", "변경사항 커밋" 등을 요청하거나 `git commit`을 실행하려 할 때 반드시 사용한다.
+---
+
+# Commit
+
+이 저장소의 커밋 메시지 규칙. 목적은 (1) 일관된 컨벤션, (2) AI 자동 서명이 이력에 새어 들어가지 않게 하는 것.
+
+## 메시지 형식
+
+`<type>: MP-<번호> <한글 설명>`
+
+- **type**: `feat` · `fix` · `refactor` · `docs` · `chore` 중 하나
+- **MP-<번호>**: 관련 Linear 이슈 키. 이슈가 있으면 포함하고, 없으면 사용자에게 확인하거나 생략한다(`<type>: <한글 설명>`).
+- **설명**: 한글로, 무엇을 왜 바꿨는지 간결하게.
+
+추가 맥락이 필요하면 제목 다음 빈 줄 뒤 본문에 한글로 적는다.
+
+## 절대 금지: AI 자동 서명
+
+커밋 메시지(제목·본문·트레일러 어디에도)에 다음을 **넣지 않는다**:
+
+- `Co-Authored-By: Claude ...`
+- `🤖 Generated with ...` 같은 AI 생성 표기
+
+이유: 한 번 push된 커밋 메시지는 force-push로만 바꿀 수 있고, 그래도 PR 타임라인의 force-push 기록과 dangling 커밋에 흔적이 남아 사실상 완전히 지울 수 없다. 처음부터 넣지 않는 것이 유일하게 깨끗한 방법이다.
+
+## 예시
+
+변경: Tomcat work 디렉토리를 `.gitignore`에 추가
+```
+chore: 내장 Tomcat work 디렉토리 .gitignore에 추가
+```
+
+변경: 소환사 검색 기능 추가 (Linear MP-7)
+```
+feat: MP-7 소환사 검색 API 추가
+```

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: pr
+description: lol-server 저장소에서 Pull Request를 만들 때 사용한다. PR 본문을 저장소의 `.github/PULL_REQUEST_TEMPLATE.md` 구조 그대로 채우고, 베이스 브랜치는 git-flow에 따라 `develop`으로 잡으며, Claude/AI 생성 표기(`🤖 Generated with ...`, `Co-Authored-By: Claude`)를 본문에 넣지 않도록 보장한다. 사용자가 "PR 만들어줘", "PR 올려줘", "pull request 생성" 등을 요청하거나 `gh pr create`를 실행하려 할 때 반드시 사용한다.
+---
+
+# Pull Request
+
+이 저장소에서 PR을 만들 때의 규칙.
+
+## 1. 베이스 브랜치
+
+git-flow를 따른다: 작업 브랜치 → `develop`. 기본은 `--base develop`. (긴급 `hotfix`만 `main`.)
+
+## 2. 본문은 템플릿을 따른다
+
+PR 본문은 **`.github/PULL_REQUEST_TEMPLATE.md`를 읽어** 그 섹션 구조를 그대로 채운다. 템플릿은 바뀔 수 있으니 매번 파일을 읽어 최신 섹션을 확인하고, 섹션 목록을 여기에 하드코딩하지 않는다.
+
+채울 때 주의:
+- **변경 유형**: 해당하는 체크박스를 `- [x]`로 표시한다.
+- **테스트**: 실제로 실행·검증한 항목만 체크한다. 안 했거나 해당 없으면 체크하지 말고 사유(예: `N/A — 코드 변경 없음`)를 적는다.
+- **관련 이슈**: Linear `MP-<번호>`가 있으면 링크하고, 없으면 사용자에게 확인하거나 `N/A`로 둔다.
+
+## 3. 절대 금지: AI 생성 표기
+
+PR 본문에 `🤖 Generated with Claude Code`, `Co-Authored-By: Claude` 등 AI 표기를 넣지 않는다. 한 번 만들어진 PR과 그 타임라인은 삭제할 수 없으므로 처음부터 넣지 않는다.
+
+## 만드는 법
+
+```bash
+gh pr create --base develop \
+  --title "<type>: <한글 제목>" \
+  --body "<템플릿을 읽어 채운 본문>"
+```


### PR DESCRIPTION
## 변경 유형
chore

## 변경 사항
- `.claude/skills/commit/SKILL.md` 추가 — 커밋 메시지 컨벤션(`<type>: MP-<번호> <한글 설명>`) + AI 자동 서명(`Co-Authored-By: Claude` 등) 금지
- `.claude/skills/pr/SKILL.md` 추가 — PR 본문을 `.github/PULL_REQUEST_TEMPLATE.md`로 채우기 + 베이스 `develop` + AI 표기 금지

## 변경 이유
- 최근 커밋/PR에 AI 자동 서명(`Co-Authored-By: ...`, `Generated with ...`)이 들어갔고, push 이후엔 PR 타임라인·dangling 커밋에 흔적이 남아 완전히 지우기 어려움 → 처음부터 안 들어가도록 규칙을 스킬로 고정
- 커밋/PR 작성 시 저장소 컨벤션(메시지 형식·PR 템플릿·베이스 브랜치)을 일관되게 따르도록 함

## 테스트
- [ ] 단위 테스트 통과 (`./gradlew test`) — N/A: 마크다운 스킬 문서만 추가
- [ ] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`) — N/A
- [ ] 로컬 빌드 확인 (`./gradlew build`) — N/A

## 리뷰 포인트
- 스킬 description의 트리거 문구가 커밋/PR 작성 상황에서 잘 발동되도록 적절한지
- `.claude/skills/`가 develop에 없던 상태라 신규 생성됨 (CLAUDE.md가 참조하는 build-validator 스킬은 현재 develop에 부재 — 별개 이슈)