### PR TITLE
refactor: core 모듈 정리 — enum을 :module:shared로 승격, lol-server-domain 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 |---|---|
 | [`module/app/application`](module/app/application/CLAUDE.md) | Spring Boot 진입점, 컴포지션 루트, bootJar |
 | `module/common` | 공유 커널 (web·error·support·security + persistence·redis·client config, testFixtures) — 도메인 아님 |
-| `module/core/enum` | `QueueType`, `Tier`, `Platform` 등 공유 enum |
+| `module/shared` | `QueueType`, `Tier`, `Platform` 등 공유 enum + `TierFilter` VO |
 | `module/support/logging` | `@LogExecutionTime` AOP 등 횡단 유틸 |
 | `module/domain/leaderboard` | 랭킹 리더보드 조회 |
 | `module/domain/match` | 전적/매치·타임라인 조회 + 2-tier Redis 캐시 |
@@ -18,6 +18,8 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 | `module/domain/member` | 회원·인증 (OAuth/RSO 연동) |
 | `module/domain/community` | 커뮤니티 게시글·댓글·투표 |
 | `module/domain/duo` | 듀오 모집글·신청 + Riot 계정 통계 집계 |
+
+> 모듈 단일 진실원천은 `settings.gradle`. `module/infra/`·`module/core/lol-server-domain/` 등은 레이어→수직 컨텍스트 재구성(77b945e5) 잔재 디렉터리로 빌드에 미포함. `docs/ARCHITECTURE.md`·일부 build 커맨드(`:module:infra:api:asciidoctor`)는 옛 구조 기준(stale).
 
 ## What to read first
 
@@ -35,6 +37,8 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 ```bash
 ./gradlew bootRun -Dspring.profiles.active=local   # Postgres/Redis/RabbitMQ Docker 필요
 ./gradlew test                                     # 전체 테스트
+./gradlew compileJava compileTestJava              # Docker 없이 전 모듈 컴파일 검증 (리팩토링용)
+./gradlew archTest                                 # Docker 없이 ArchUnit(*ArchitectureTest) 전 모듈 실행
 ./gradlew :module:infra:api:asciidoctor            # RestDocs HTML 재생성 (RestDocs 테스트 변경 시 필수)
 ./gradlew clean build                              # 클린 빌드
 ```
@@ -48,6 +52,7 @@ Spring Boot 3.3 + JDK 21, Riot API 기반 League of Legends 전적 검색 백엔
 - 도메인 규칙은 도메인 객체 `validate*` guard 가 직접 던진다 (서비스에서 boolean+throw 금지)
 - ReadModel 변환은 `*ReadModel.of(domain)` 정적 팩토리에서만
 - 매직 스트링 금지: `OAuthProvider.RIOT.name()`, `QueueType.RANKED_SOLO_5x5.name()` 등 enum 사용
+- Redis 값 직렬화는 `GenericJackson2JsonRedisSerializer`(`@class` FQN 포함) — 캐시되는 값 클래스 이동/리네임 시 기존 엔트리 역직렬화 실패, 배포 때 해당 키 flush
 - 커밋 메시지: `<type>: MP-<번호> <한글 설명>` (Linear 키 필수; 타입 `feat`, `fix`, `refactor`, `docs`, `chore`)
 - 브랜치: `<type>/MP-<번호>-*` 형식. 기본 흐름은 `develop` → `main`, `hotfix`만 `main` → `develop` 역반영. type 6종:
 

--- a/module/app/application/build.gradle
+++ b/module/app/application/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation project(":module:domain:duo")
 
     // 공유 모듈
-    implementation project(":module:core:enum")
+    implementation project(":module:shared")
     implementation project(":module:support:logging")
 
     implementation 'org.springframework.boot:spring-boot-starter'

--- a/module/domain/championstats/build.gradle
+++ b/module/domain/championstats/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation project(':module:common')
-    implementation project(':module:core:enum')
+    implementation project(':module:shared')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.redisson:redisson-spring-boot-starter:3.46.0'

--- a/module/domain/championstats/src/main/java/com/example/lolserver/championstats/adapter/in/web/ChampionStatsController.java
+++ b/module/domain/championstats/src/main/java/com/example/lolserver/championstats/adapter/in/web/ChampionStatsController.java
@@ -1,7 +1,7 @@
 package com.example.lolserver.championstats.adapter.in.web;
 
-import com.example.lolserver.Platform;
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.Platform;
+import com.example.lolserver.shared.TierFilter;
 import com.example.lolserver.common.web.response.ApiResponse;
 import com.example.lolserver.championstats.application.port.in.ChampionStatsQueryUseCase;
 import com.example.lolserver.championstats.application.model.ChampionStatsReadModel;

--- a/module/domain/championstats/src/main/java/com/example/lolserver/championstats/adapter/out/bigquery/ChampionStatsBigQueryAdapter.java
+++ b/module/domain/championstats/src/main/java/com/example/lolserver/championstats/adapter/out/bigquery/ChampionStatsBigQueryAdapter.java
@@ -1,7 +1,7 @@
 package com.example.lolserver.championstats.adapter.out.bigquery;
 
-import com.example.lolserver.Tier;
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.Tier;
+import com.example.lolserver.shared.TierFilter;
 import com.example.lolserver.championstats.application.model.ChampionAverageStatsReadModel;
 import com.example.lolserver.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.championstats.application.model.ChampionItemBuildReadModel;

--- a/module/domain/championstats/src/main/java/com/example/lolserver/championstats/application/ChampionStatsService.java
+++ b/module/domain/championstats/src/main/java/com/example/lolserver/championstats/application/ChampionStatsService.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.championstats.application;
 
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.TierFilter;
 import com.example.lolserver.championstats.application.model.ChampionAverageStatsReadModel;
 import com.example.lolserver.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.championstats.application.model.ChampionItemBuildReadModel;

--- a/module/domain/championstats/src/main/java/com/example/lolserver/championstats/application/port/in/ChampionStatsQueryUseCase.java
+++ b/module/domain/championstats/src/main/java/com/example/lolserver/championstats/application/port/in/ChampionStatsQueryUseCase.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.championstats.application.port.in;
 
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.TierFilter;
 import com.example.lolserver.championstats.application.model.ChampionStatsReadModel;
 import com.example.lolserver.championstats.application.model.PositionChampionStatsReadModel;
 

--- a/module/domain/championstats/src/main/java/com/example/lolserver/championstats/application/port/out/ChampionStatsQueryPort.java
+++ b/module/domain/championstats/src/main/java/com/example/lolserver/championstats/application/port/out/ChampionStatsQueryPort.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.championstats.application.port.out;
 
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.TierFilter;
 import com.example.lolserver.championstats.application.model.ChampionAverageStatsReadModel;
 import com.example.lolserver.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.championstats.application.model.ChampionItemBuildReadModel;

--- a/module/domain/championstats/src/test/java/com/example/lolserver/championstats/adapter/in/web/ChampionStatsControllerTest.java
+++ b/module/domain/championstats/src/test/java/com/example/lolserver/championstats/adapter/in/web/ChampionStatsControllerTest.java
@@ -25,7 +25,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 
 import java.util.List;
 
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.TierFilter;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;

--- a/module/domain/championstats/src/test/java/com/example/lolserver/championstats/adapter/out/bigquery/ChampionStatsBigQueryAdapterTest.java
+++ b/module/domain/championstats/src/test/java/com/example/lolserver/championstats/adapter/out/bigquery/ChampionStatsBigQueryAdapterTest.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.championstats.adapter.out.bigquery;
 
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.TierFilter;
 import com.example.lolserver.championstats.application.model.ChampionMatchupReadModel;
 import com.example.lolserver.championstats.application.model.ChampionRateReadModel;
 import com.example.lolserver.championstats.application.model.ChampionWinRateReadModel;

--- a/module/domain/championstats/src/test/java/com/example/lolserver/championstats/application/ChampionStatsServiceConcurrencyTest.java
+++ b/module/domain/championstats/src/test/java/com/example/lolserver/championstats/application/ChampionStatsServiceConcurrencyTest.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.championstats.application;
 
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.TierFilter;
 import com.example.lolserver.championstats.application.model.ChampionStatsReadModel;
 import com.example.lolserver.championstats.application.model.PositionChampionStatsReadModel;
 import com.example.lolserver.championstats.application.port.out.ChampionStatsCachePort;

--- a/module/domain/championstats/src/test/java/com/example/lolserver/championstats/application/ChampionStatsServiceTest.java
+++ b/module/domain/championstats/src/test/java/com/example/lolserver/championstats/application/ChampionStatsServiceTest.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.championstats.application;
 
-import com.example.lolserver.TierFilter;
+import com.example.lolserver.shared.TierFilter;
 import com.example.lolserver.championstats.application.model.ChampionBootBuildReadModel;
 import com.example.lolserver.championstats.application.model.ChampionItemBuildReadModel;
 import com.example.lolserver.championstats.application.model.ChampionMatchupReadModel;

--- a/module/domain/duo/build.gradle
+++ b/module/domain/duo/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation project(':module:common')
-    implementation project(':module:core:enum')
+    implementation project(':module:shared')
 
     // 상위 컨텍스트: published port.in(UseCase) + application.model(ReadModel)만 사용한다.
     // 경계는 ArchitectureTest 가 강제한다(각 컨텍스트의 domain/adapter/port.out 의존 금지).

--- a/module/domain/duo/src/main/java/com/example/lolserver/duo/application/RiotAccountResolver.java
+++ b/module/domain/duo/src/main/java/com/example/lolserver/duo/application/RiotAccountResolver.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.duo.application;
 
-import com.example.lolserver.QueueType;
+import com.example.lolserver.shared.QueueType;
 import com.example.lolserver.duo.domain.vo.MostChampion;
 import com.example.lolserver.duo.domain.vo.RecentGameSummary;
 import com.example.lolserver.duo.domain.vo.RiotAccountStats;

--- a/module/domain/gamedata/build.gradle
+++ b/module/domain/gamedata/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation project(':module:common')
-    implementation project(':module:core:enum')
+    implementation project(':module:shared')
     implementation project(':module:support:logging')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/TierCutoffService.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/TierCutoffService.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.gamedata.application;
 
-import com.example.lolserver.Platform;
+import com.example.lolserver.shared.Platform;
 import com.example.lolserver.gamedata.application.model.TierCutoffReadModel;
 import com.example.lolserver.gamedata.application.port.in.TierCutoffQueryUseCase;
 import com.example.lolserver.gamedata.application.port.out.TierCutoffPersistencePort;

--- a/module/domain/leaderboard/build.gradle
+++ b/module/domain/leaderboard/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation project(':module:common')
-    implementation project(':module:core:enum')
+    implementation project(':module:shared')
 
     testImplementation(testFixtures(project(':module:common')))
     testImplementation 'com.tngtech.archunit:archunit-junit5:1.3.0'

--- a/module/domain/leaderboard/src/main/java/com/example/lolserver/leaderboard/adapter/out/persistence/RankPersistenceAdapter.java
+++ b/module/domain/leaderboard/src/main/java/com/example/lolserver/leaderboard/adapter/out/persistence/RankPersistenceAdapter.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.leaderboard.adapter.out.persistence;
 
-import com.example.lolserver.QueueType;
+import com.example.lolserver.shared.QueueType;
 import com.example.lolserver.leaderboard.application.port.out.RankPersistencePort;
 import com.example.lolserver.leaderboard.domain.Rank;
 import com.example.lolserver.leaderboard.application.dto.RankSearchDto;

--- a/module/domain/match/build.gradle
+++ b/module/domain/match/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation project(':module:common')
-    implementation project(':module:core:enum')
+    implementation project(':module:shared')
     implementation project(':module:support:logging')
 
     // match 2-tier 캐시(ZSET ids + 단건 JSON) Redis 어댑터

--- a/module/domain/match/src/main/java/com/example/lolserver/match/adapter/out/persistence/adapter/MatchPersistenceAdapter.java
+++ b/module/domain/match/src/main/java/com/example/lolserver/match/adapter/out/persistence/adapter/MatchPersistenceAdapter.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.match.adapter.out.persistence.adapter;
 
-import com.example.lolserver.QueueType;
+import com.example.lolserver.shared.QueueType;
 import com.example.lolserver.match.application.port.out.MatchPersistencePort;
 import com.example.lolserver.match.application.model.DailyGameCountReadModel;
 import com.example.lolserver.match.application.model.GameInfoReadModel;

--- a/module/domain/match/src/main/java/com/example/lolserver/match/adapter/out/persistence/mapper/MatchMapper.java
+++ b/module/domain/match/src/main/java/com/example/lolserver/match/adapter/out/persistence/mapper/MatchMapper.java
@@ -1,7 +1,7 @@
 package com.example.lolserver.match.adapter.out.persistence.mapper;
 
-import com.example.lolserver.Division;
-import com.example.lolserver.Tier;
+import com.example.lolserver.shared.Division;
+import com.example.lolserver.shared.Tier;
 import com.example.lolserver.match.application.model.GameInfoReadModel;
 import com.example.lolserver.match.application.model.ItemValueReadModel;
 import com.example.lolserver.match.application.model.MSChampionDetailReadModel;

--- a/module/domain/match/src/main/java/com/example/lolserver/match/adapter/out/persistence/matchsummoner/dsl/impl/MatchSummonerRepositoryCustomImpl.java
+++ b/module/domain/match/src/main/java/com/example/lolserver/match/adapter/out/persistence/matchsummoner/dsl/impl/MatchSummonerRepositoryCustomImpl.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.match.adapter.out.persistence.matchsummoner.dsl.impl;
 
-import com.example.lolserver.QueueType;
+import com.example.lolserver.shared.QueueType;
 import com.example.lolserver.match.adapter.out.persistence.dto.DailyGameCountDTO;
 import com.example.lolserver.match.adapter.out.persistence.dto.LinePositionDTO;
 import com.example.lolserver.match.adapter.out.persistence.dto.MSChampionDTO;

--- a/module/domain/match/src/test/java/com/example/lolserver/match/adapter/out/persistence/adapter/MatchPersistenceAdapterTest.java
+++ b/module/domain/match/src/test/java/com/example/lolserver/match/adapter/out/persistence/adapter/MatchPersistenceAdapterTest.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.match.adapter.out.persistence.adapter;
 
-import com.example.lolserver.QueueType;
+import com.example.lolserver.shared.QueueType;
 import com.example.lolserver.match.application.model.GameReadModel;
 import com.example.lolserver.match.application.model.GameInfoReadModel;
 import com.example.lolserver.match.application.model.MSChampionByQueueReadModel;

--- a/module/domain/member/build.gradle
+++ b/module/domain/member/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation project(':module:common')
-    implementation project(':module:core:enum')
+    implementation project(':module:shared')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/module/domain/summoner/build.gradle
+++ b/module/domain/summoner/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     implementation project(':module:common')
-    implementation project(':module:core:enum')
+    implementation project(':module:shared')
     implementation project(':module:support:logging')
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/module/domain/summoner/src/main/java/com/example/lolserver/summoner/adapter/in/web/mapper/LeagueMapper.java
+++ b/module/domain/summoner/src/main/java/com/example/lolserver/summoner/adapter/in/web/mapper/LeagueMapper.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.summoner.adapter.in.web.mapper;
 
-import com.example.lolserver.QueueType;
+import com.example.lolserver.shared.QueueType;
 import com.example.lolserver.summoner.adapter.in.web.response.LeagueResponse;
 import com.example.lolserver.summoner.adapter.in.web.response.LeagueSummonerResponse;
 import com.example.lolserver.summoner.domain.League;

--- a/module/domain/summoner/src/main/java/com/example/lolserver/summoner/application/SummonerService.java
+++ b/module/domain/summoner/src/main/java/com/example/lolserver/summoner/application/SummonerService.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.summoner.application;
 
-import com.example.lolserver.RenewalStatus;
+import com.example.lolserver.shared.RenewalStatus;
 import com.example.lolserver.summoner.application.model.SummonerAutoReadModel;
 import com.example.lolserver.summoner.application.model.SummonerReadModel;
 import com.example.lolserver.summoner.application.model.SummonerRenewalInfoReadModel;

--- a/module/domain/summoner/src/main/java/com/example/lolserver/summoner/domain/SummonerRenewal.java
+++ b/module/domain/summoner/src/main/java/com/example/lolserver/summoner/domain/SummonerRenewal.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.summoner.domain;
 
-import com.example.lolserver.RenewalStatus;
+import com.example.lolserver.shared.RenewalStatus;
 import lombok.Getter;
 
 @Getter

--- a/module/domain/summoner/src/test/java/com/example/lolserver/summoner/adapter/in/web/SummonerControllerTest.java
+++ b/module/domain/summoner/src/test/java/com/example/lolserver/summoner/adapter/in/web/SummonerControllerTest.java
@@ -5,7 +5,7 @@ import com.example.lolserver.common.test.RestDocsSupport;
 import com.example.lolserver.summoner.application.port.in.SummonerQueryUseCase;
 import com.example.lolserver.summoner.application.port.in.SummonerUseCase;
 import com.example.lolserver.summoner.domain.SummonerRenewal;
-import com.example.lolserver.RenewalStatus;
+import com.example.lolserver.shared.RenewalStatus;
 
 import com.example.lolserver.summoner.application.model.SummonerAutoReadModel;
 import com.example.lolserver.summoner.domain.vo.GameName;

--- a/module/domain/summoner/src/test/java/com/example/lolserver/summoner/application/SummonerServiceTest.java
+++ b/module/domain/summoner/src/test/java/com/example/lolserver/summoner/application/SummonerServiceTest.java
@@ -1,6 +1,6 @@
 package com.example.lolserver.summoner.application;
 
-import com.example.lolserver.RenewalStatus;
+import com.example.lolserver.shared.RenewalStatus;
 import com.example.lolserver.summoner.application.model.SummonerAutoReadModel;
 import com.example.lolserver.summoner.application.model.SummonerReadModel;
 import com.example.lolserver.summoner.application.model.SummonerRenewalInfoReadModel;

--- a/module/shared/src/main/java/com/example/lolserver/shared/Division.java
+++ b/module/shared/src/main/java/com/example/lolserver/shared/Division.java
@@ -1,4 +1,4 @@
-package com.example.lolserver;
+package com.example.lolserver.shared;
 
 import lombok.Getter;
 

--- a/module/shared/src/main/java/com/example/lolserver/shared/Platform.java
+++ b/module/shared/src/main/java/com/example/lolserver/shared/Platform.java
@@ -1,4 +1,4 @@
-package com.example.lolserver;
+package com.example.lolserver.shared;
 
 import lombok.Getter;
 

--- a/module/shared/src/main/java/com/example/lolserver/shared/QueueType.java
+++ b/module/shared/src/main/java/com/example/lolserver/shared/QueueType.java
@@ -1,4 +1,4 @@
-package com.example.lolserver;
+package com.example.lolserver.shared;
 
 import lombok.Getter;
 

--- a/module/shared/src/main/java/com/example/lolserver/shared/RenewalStatus.java
+++ b/module/shared/src/main/java/com/example/lolserver/shared/RenewalStatus.java
@@ -1,4 +1,4 @@
-package com.example.lolserver;
+package com.example.lolserver.shared;
 
 public enum RenewalStatus {
     SUCCESS, FAILED, PROGRESS

--- a/module/shared/src/main/java/com/example/lolserver/shared/Tier.java
+++ b/module/shared/src/main/java/com/example/lolserver/shared/Tier.java
@@ -1,4 +1,4 @@
-package com.example.lolserver;
+package com.example.lolserver.shared;
 
 import lombok.Getter;
 

--- a/module/shared/src/main/java/com/example/lolserver/shared/TierFilter.java
+++ b/module/shared/src/main/java/com/example/lolserver/shared/TierFilter.java
@@ -1,4 +1,4 @@
-package com.example.lolserver;
+package com.example.lolserver.shared;
 
 import java.util.Arrays;
 import java.util.List;

--- a/module/shared/src/test/java/com/example/lolserver/shared/TierFilterTest.java
+++ b/module/shared/src/test/java/com/example/lolserver/shared/TierFilterTest.java
@@ -1,4 +1,4 @@
-package com.example.lolserver;
+package com.example.lolserver.shared;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,7 +4,7 @@ include(
         "module:app:application",
 
         // 공유 모듈
-        "module:core:enum",
+        "module:shared",
         "module:support:logging",
 
         // 공유 커널 (도메인 아님)


### PR DESCRIPTION
## 관련 이슈
<!-- Linear 키 필수: MP-<번호> -->
- N/A — 모듈 구조 정리(연결된 Linear 이슈 없음)

## 변경 유형
- [ ] feat
- [ ] fix
- [x] refactor
- [ ] docs
- [x] chore

## 변경 사항
- `module:core:enum` → `:module:shared` 승격 (단일 자식만 감싸던 `core` 래퍼 제거)
- 패키지 `com.example.lolserver` → `com.example.lolserver.shared` (app 진입점과 split-package 해소)
- enum 5종(Division/Platform/QueueType/RenewalStatus/Tier) + `TierFilter` VO + 테스트 이동; import 21파일 / build.gradle 8개 / settings.gradle 갱신
- 빈 잔재 모듈 `core:lol-server-domain` 제거 (수직 컨텍스트 재구성 후 미사용)
- 루트 `CLAUDE.md`: 모듈 표 갱신 + 세션 학습 3건(Docker 없는 검증 커맨드, settings.gradle 진실원천/stale 문서, Redis FQN 직렬화 gotcha)

## 변경 이유
- `lol-server-domain` 은 레이어→수직 컨텍스트 재구성(77b945e5) 이후 비워진 잔재였고, `core` 는 단일 자식(`enum`)만 감싸 불필요한 중첩이었음
- enum 이 base 패키지에 있어 app 진입점과 split-package 상태 → `shared` 서브패키지로 해소

## 테스트
- [ ] 단위 테스트 통과 (`./gradlew test`) — Docker(Postgres/Redis/RabbitMQ) 필요로 로컬 미실행, 아래로 대체 검증
- [x] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`) — 전 모듈
- [ ] 로컬 빌드 확인 (`./gradlew build`) — Docker 필요로 미실행
- [x] 추가 검증: `compileJava`/`compileTestJava` 전 모듈, `archTest`(ArchUnit) 8모듈, `:module:shared:test` 8건 통과

## 리뷰 포인트
- 순수 모듈/패키지 rename (로직 변경 0). `/code-review`(xhigh) 결과 correctness 버그 0건
- 머지 후: 작업 트리에 gitignore된 잔재 `module/core/` 디렉터리가 남으면 `rm -rf module/core` 로 정리(커밋 대상 아님)
- 참고: `docs/ARCHITECTURE.md`·`module/app/application/CLAUDE.md` 등은 옛 레이어 구조 기준 stale — 이 PR 범위 밖, 별도 정리 권장

🤖 Generated with [Claude Code](https://claude.com/claude-code)
