### PR TITLE
fix: Docker 빌드 스테이지에 buildSrc 복사 추가

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,8 @@ RUN chmod +x gradlew
 
 # 의존성 캐싱을 위해 빌드 파일 먼저 복사
 COPY build.gradle settings.gradle ./
+# convention plugins (lolserver.web-conventions 등) — module/*/build.gradle 에서 참조
+COPY buildSrc buildSrc
 COPY module module
 
 # 빌드 실행


### PR DESCRIPTION
## 관련 이슈
<!-- Linear 키 필수: MP-<번호> — 해당 시 채워주세요 -->
- MP-

## 변경 유형
- [x] fix

## 변경 사항
- Dockerfile 빌드 스테이지에 `COPY buildSrc buildSrc` 추가 (`module` 복사 직전)

## 변경 이유
- `module/common/build.gradle` 이 `buildSrc` 의 convention plugin(`lolserver.web-conventions`, `lolserver.persistence-conventions`)을 참조함
- Dockerfile 빌드 스테이지가 `buildSrc` 를 복사하지 않아, `./gradlew :module:app:application:bootJar` 실행 시 convention plugin 해석 실패로 **Docker 이미지 빌드가 깨짐**
- 로컬/CI gradle 빌드는 `buildSrc` 가 있어 통과하지만 Docker 빌드만 실패하던 차이를 제거

## 테스트
- [ ] 단위 테스트 통과 (`./gradlew test`)
- [ ] Checkstyle 통과
- [ ] 로컬 빌드 확인
- [x] Docker 이미지 빌드 시 buildSrc 누락으로 인한 플러그인 해석 실패 해소 (변경 근거)

## 리뷰 포인트
- `buildSrc` 복사 위치(의존성 캐싱 레이어와 `module` 복사 사이)가 캐시 효율상 적절한지
