### PR TITLE
chore: bootRun 시 루트 .env 자동 주입 + profiles.active 가드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,28 @@ subprojects {
 
     bootRun {
         String activeProfile = System.properties['spring.profiles.active']
-        systemProperty "spring.profiles.active", activeProfile
+        if (activeProfile != null) {
+            systemProperty "spring.profiles.active", activeProfile
+        }
+
+        // 루트 .env 를 읽어 bootRun 프로세스 환경변수로 주입
+        def envFile = rootProject.file('.env')
+        if (envFile.exists()) {
+            envFile.readLines('UTF-8').each { line ->
+                def t = line.trim()
+                if (t.isEmpty() || t.startsWith('#')) return
+                if (t.startsWith('export ')) t = t.substring(7).trim()
+                int i = t.indexOf('=')
+                if (i <= 0) return
+                def key = t.substring(0, i).trim()
+                def value = t.substring(i + 1).trim()
+                if ((value.startsWith('"') && value.endsWith('"')) ||
+                    (value.startsWith("'") && value.endsWith("'"))) {
+                    value = value.substring(1, value.length() - 1)
+                }
+                environment key, value
+            }
+        }
     }
 
 


### PR DESCRIPTION
## 배경

로컬 워킹트리에만 커밋되지 않은 채 남아 있던 변경입니다. 로컬 소스 정리 전에 유실을 막기 위해 PR 로 올립니다.

## 변경

- `bootRun` 실행 시 루트 `.env` 를 읽어 프로세스 환경변수로 주입
- `spring.profiles.active` 는 시스템 프로퍼티가 지정된 경우에만 설정 (미지정 시 `.env` 의 프로파일 설정이 `null` 로 덮이던 문제)

lol-repository 의 #76 / #77 과 동일한 구성입니다.

## 검증

- `./gradlew projects` 통과 (빌드 스크립트 평가 정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)