### PR TITLE
fix(redis): 캐시 직렬화에 JavaTimeModule 등록 — LocalDateTime 캐싱 시 500

### DIFF
--- a/module/common/src/main/java/com/example/lolserver/common/config/RedisConfig.java
+++ b/module/common/src/main/java/com/example/lolserver/common/config/RedisConfig.java
@@ -1,5 +1,9 @@
 package com.example.lolserver.common.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,15 +31,36 @@ public class RedisConfig {
 
         redisTemplate.setConnectionFactory(redisConnectionFactory);
 
+        GenericJackson2JsonRedisSerializer valueSerializer = jsonRedisSerializer();
+
         // Key-Value 형태로 직렬화를 수행합니다.
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(valueSerializer);
 
         // Hash Key-Value 형태로 직렬화를 수행합니다.
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashValueSerializer(valueSerializer);
 
         return redisTemplate;
+    }
+
+    /**
+     * GenericJackson2JsonRedisSerializer 의 기본 ObjectMapper 에는 JavaTimeModule 이 없어,
+     * LocalDateTime 을 담은 값(예: VersionReadModel)을 캐싱하는 순간
+     * InvalidDefinitionException 으로 실패한다. 모듈을 등록한 ObjectMapper 를 주입하되,
+     * defaultTyping 은 켠 채로 둔다 — @class 타입 정보가 빠지면 역직렬화 결과가
+     * LinkedHashMap 이 되어 호출부 캐스팅에서 깨진다.
+     */
+    private GenericJackson2JsonRedisSerializer jsonRedisSerializer() {
+        ObjectMapper objectMapper = JsonMapper.builder()
+                .addModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .build();
+
+        return GenericJackson2JsonRedisSerializer.builder()
+                .objectMapper(objectMapper)
+                .defaultTyping(true)
+                .build();
     }
 
 }


### PR DESCRIPTION
## 문제

`GET /api/v1/versions/latest` 가 **HTTP 500** 을 반환합니다.

```
InvalidDefinitionException: Java 8 date/time type `java.time.LocalDateTime`
not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
```

`RedisConfig` 가 `GenericJackson2JsonRedisSerializer` 를 **기본 생성자**로 만드는데, 이때 내부적으로 쓰이는 `ObjectMapper` 에는 `JavaTimeModule` 이 등록되어 있지 않습니다. 그래서 `java.time` 타입을 품은 값을 Redis 에 캐싱하는 순간 터집니다.

`VersionReadModel` 이 정확히 여기 걸립니다 — `LocalDateTime createdAt` 을 가진 record 입니다.

DB 를 직접 읽는 `GET /api/v1/versions` 는 **정상**이고, Redis 캐시를 경유하는 `/latest` 만 죽는 것이 근거입니다. 이 버그는 `versions/latest` 에 국한되지 않습니다 — **`RedisTemplate` 으로 캐싱되는 모든 `java.time` 타입**이 같은 문제를 겪습니다.

## 변경

`JavaTimeModule` 을 등록한 `ObjectMapper` 를 주입합니다. 다만 **`defaultTyping` 은 켠 채로 두어야 합니다.**

`GenericJackson2JsonRedisSerializer` 의 기본 생성자는 값에 `@class` 타입 정보를 심어 줍니다. `ObjectMapper` 를 그냥 주입하면 이 설정이 사라지고, 역직렬화 결과가 `LinkedHashMap` 이 되어 `VersionRedisAdapter` 의 `(VersionReadModel)` 캐스팅에서 **다시 깨집니다**. 즉 모듈만 추가하면 500 이 `ClassCastException` 으로 바뀔 뿐입니다.

이를 위해 deprecated 생성자 대신 `GenericJackson2JsonRedisSerializer.builder()` 를 써서 `objectMapper()` 와 `defaultTyping(true)` 를 함께 지정했습니다. (`new GenericJackson2JsonRedisSerializer(ObjectMapper)` + 수동 `activateDefaultTyping` 조합은 deprecation 경고가 발생합니다.)

## 검증

로컬 k3d 클러스터에 배포하고, `version:latest` 캐시를 삭제한 뒤 **두 번 호출**했습니다 (쓰기 경로와 읽기 경로를 모두 태우기 위함).

| | 결과 |
|---|---|
| 1회차 (캐시 miss → DB → Redis 쓰기) | **HTTP 200** |
| Redis 에 저장된 값 | `{"@class":"...VersionReadModel","versionId":1,"versionValue":"16.13","createdAt":"2026-07-14T15:28:53.835084"}` |
| 2회차 (캐시 hit → 역직렬화 → 캐스팅) | **HTTP 200** |

`@class` 타입 정보가 유지되고 `createdAt` 이 ISO-8601 로 직렬화된 것, 그리고 캐시에서 되읽어 캐스팅까지 성공하는 것을 확인했습니다.

> 참고: 이 버그는 `season` / `patch_version` 테이블에 초기 데이터를 넣고 나서야 드러났습니다. 그 전에는 조회 결과가 없어 캐시 쓰기 자체가 일어나지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Closes #130
