### PR TITLE
feat: local 시즌 기본 데이터 시드 추가

### DIFF
--- a/module/app/application/src/main/resources/db/seed/season-local.sql
+++ b/module/app/application/src/main/resources/db/seed/season-local.sql
@@ -1,0 +1,22 @@
+-- local 개발용 season 기본 데이터 시드
+-- postgresql-local.yml 의 spring.sql.init 로 매 부팅마다 실행되므로 ON CONFLICT 로 멱등 보장.
+-- 스키마(테이블)는 Flyway(V1__init.sql)가 생성하며, 이 스크립트는 데이터만 채운다.
+
+-- 시즌 16
+INSERT INTO season (season_value, season_name, start_date, end_date, created_at)
+VALUES (16, '2025 Season 2', '2025-05-01', NULL, now())
+ON CONFLICT (season_value) DO NOTHING;
+
+-- 패치 버전 16.10 ~ 16.14 (시즌 16 소속)
+INSERT INTO patch_version (version_value, season_id, created_at)
+SELECT v.version_value, s.season_id, now()
+FROM season s
+CROSS JOIN (VALUES
+    ('16.10'),
+    ('16.11'),
+    ('16.12'),
+    ('16.13'),
+    ('16.14')
+) AS v(version_value)
+WHERE s.season_value = 16
+ON CONFLICT (version_value) DO NOTHING;

--- a/module/app/application/src/main/resources/postgresql-local.yml
+++ b/module/app/application/src/main/resources/postgresql-local.yml
@@ -4,6 +4,13 @@ spring:
     baseline-on-migrate: true
     baseline-version: 2
 
+  # local 개발용 기본 데이터 시드 (스키마는 Flyway 담당, 여기선 데이터만).
+  # Flyway 마이그레이션 이후 실행되며, 스크립트는 ON CONFLICT 로 멱등 처리됨.
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:db/seed/season-local.sql
+
   jpa:
     open-in-view: false
     hibernate:


### PR DESCRIPTION
## 배경
local 프로파일로 부팅하면 `season` 테이블이 Flyway(`V1__init.sql`)로 **생성만** 되고 비어 있어, `GET /api/v1/seasons` 가 빈 배열을 반환했습니다. 개발용 기본 데이터를 자동 세팅합니다.

## 변경
- `postgresql-local.yml` 에 `spring.sql.init`(`mode: always`, `data-locations: classpath:db/seed/season-local.sql`) 추가
  - Flyway 마이그레이션 **이후** 실행되며 (스키마는 Flyway, 데이터만 이 스크립트)
- `db/seed/season-local.sql` 신규
  - `season` value=16 (`2025 Season 2`) 1건
  - `patch_version` 16.10 ~ 16.14 (season 16 소속) 5건
  - `ON CONFLICT DO NOTHING` 으로 매 부팅 멱등

## 검증
임시 Postgres 16 컨테이너에서 스키마 생성 후 seed 를 **2회 실행** → `season=1`, `patch_version=5` 로 멱등성/문법/FK 조인 확인.

## 참고
- **local 전용**(dev/prod 무영향). 전 환경 반영이 필요하면 `lol-db-schema` submodule 에 Flyway seed 마이그레이션으로 옮기는 편이 정석입니다.
- `season_name` `2025 Season 2` 는 테스트 코드 명명 패턴(14=`2024 Season 3`, 15=`2025 Season 1`) 추정값 — 실제 값이 다르면 SQL 한 줄만 수정하면 됩니다.
- Linear MP 이슈 번호가 있으면 커밋 메시지/브랜치명(`feature/MP-<번호>-*`) 에 반영해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNgb6H8Ggja6fqAykKn3fQ