### PR TITLE
feat: 애플리케이션 기본 타임존 KST(Asia/Seoul) 고정

### DIFF
--- a/module/app/application/src/main/java/com/example/lolserver/config/TimeZoneConfig.java
+++ b/module/app/application/src/main/java/com/example/lolserver/config/TimeZoneConfig.java
@@ -1,0 +1,25 @@
+package com.example.lolserver.config;
+
+import java.util.TimeZone;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 애플리케이션 기본 타임존을 KST(Asia/Seoul)로 고정한다.
+ *
+ * bootRun / IDE Run / 컨테이너 / 테스트 등 실행 방식과 무관하게 JVM 기본 타임존을
+ * 동일하게 맞춰, LocalDateTime.now()·new Date()·로그 타임스탬프·@Scheduled 등이
+ * 모든 환경에서 서울 시각을 따르도록 한다.
+ */
+@Configuration
+public class TimeZoneConfig {
+
+    private static final String DEFAULT_TIME_ZONE = "Asia/Seoul";
+
+    @PostConstruct
+    void setDefaultTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone(DEFAULT_TIME_ZONE));
+    }
+}


### PR DESCRIPTION
## 배경
로컬 `bootRun`·IDE Run 등에서는 배포 yaml(Helm)의 `TZ` env가 적용되지 않아, 개발자 머신 타임존을 따라가 시간 관련 로직 테스트가 환경마다 달라지는 문제가 있음. `application.yaml`에는 JVM 전체 기본 타임존을 바꾸는 프로퍼티가 없음(`spring.jackson.time-zone`은 JSON 직렬화 전용).

## 변경
- `TimeZoneConfig` 추가 — `@PostConstruct`에서 `TimeZone.setDefault("Asia/Seoul")` 호출.
- 실행 방식(bootRun/IDE/컨테이너/테스트)과 무관하게 JVM 기본 타임존을 KST로 고정.

## 영향
- `LocalDateTime.now()`, `new Date()`, 로그 타임스탬프, `@Scheduled` 등이 모든 환경에서 서울 시각을 따름.

## 검증
- `./gradlew :module:app:application:compileJava` 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JsX3vh4DTEhq8DU56ro1v