### PR TITLE
fix: 챔피언 로테이션 빈 응답 캐시 오염 방지

### DIFF
--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionCacheAdapter.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionCacheAdapter.java
@@ -18,7 +18,11 @@ public class ChampionCacheAdapter implements ChampionPersistencePort {
     private final RedisTemplate<String, Object> redisTemplate;
 
     private static final String CACHE_KEY_PREFIX = "champion_rotation_";
-    private static final Duration CACHE_TTL = Duration.ofHours(1); // Cache for 1 hour
+    private static final Duration CACHE_TTL = Duration.ofHours(1); // 정상 로테이션 캐시 (1시간)
+    // 빈 로테이션(upstream/Riot 조회 실패)은 짧게만 캐싱한다. 아예 캐싱하지 않으면 매 요청이
+    // upstream→Riot 으로 관통해 rate limit 을 소모하고, 1시간을 캐싱하면 upstream 이 복구된 뒤에도
+    // 빈 값이 고착된다. 짧은 TTL 의 negative cache 로 두 문제를 동시에 방지한다.
+    private static final Duration EMPTY_CACHE_TTL = Duration.ofSeconds(60);
 
     @Override
     public Optional<ChampionRotate> getChampionRotate(String platformId) {
@@ -28,7 +32,9 @@ public class ChampionCacheAdapter implements ChampionPersistencePort {
 
     @Override
     public void saveChampionRotate(String platformId, ChampionRotate championRotate) {
-        log.info("Caching champion rotation for platformId: {}", platformId);
-        redisTemplate.opsForValue().set(CACHE_KEY_PREFIX + platformId, championRotate, CACHE_TTL);
+        Duration ttl = championRotate.isEmpty() ? EMPTY_CACHE_TTL : CACHE_TTL;
+        log.info("Caching champion rotation for platformId: {} (empty={}, ttl={})",
+                platformId, championRotate.isEmpty(), ttl);
+        redisTemplate.opsForValue().set(CACHE_KEY_PREFIX + platformId, championRotate, ttl);
     }
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/ChampionService.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/ChampionService.java
@@ -25,10 +25,18 @@ public class ChampionService implements ChampionRotateUseCase {
         Optional<ChampionRotate> championRotate = championPersistencePort.getChampionRotate(platformId);
         if (championRotate.isPresent()) {
             return championRotate.get();
-        } else {
-            ChampionRotate newChampionRotate = championClientPort.getChampionRotate(platformId);
-            championPersistencePort.saveChampionRotate(platformId, newChampionRotate);
+        }
+
+        ChampionRotate newChampionRotate = championClientPort.getChampionRotate(platformId);
+
+        // 빈 로테이션(upstream 조회 실패)은 캐싱하지 않는다.
+        // 캐싱하면 TTL 동안 빈 값이 고착되어, upstream 이 복구된 뒤에도 계속 빈 값을 서빙한다.
+        if (newChampionRotate.isEmpty()) {
+            log.warn("빈 챔피언 로테이션 응답 — 캐싱을 생략한다. platformId: {}", platformId);
             return newChampionRotate;
         }
+
+        championPersistencePort.saveChampionRotate(platformId, newChampionRotate);
+        return newChampionRotate;
     }
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/ChampionService.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/ChampionService.java
@@ -25,18 +25,12 @@ public class ChampionService implements ChampionRotateUseCase {
         Optional<ChampionRotate> championRotate = championPersistencePort.getChampionRotate(platformId);
         if (championRotate.isPresent()) {
             return championRotate.get();
-        }
-
-        ChampionRotate newChampionRotate = championClientPort.getChampionRotate(platformId);
-
-        // 빈 로테이션(upstream 조회 실패)은 캐싱하지 않는다.
-        // 캐싱하면 TTL 동안 빈 값이 고착되어, upstream 이 복구된 뒤에도 계속 빈 값을 서빙한다.
-        if (newChampionRotate.isEmpty()) {
-            log.warn("빈 챔피언 로테이션 응답 — 캐싱을 생략한다. platformId: {}", platformId);
+        } else {
+            ChampionRotate newChampionRotate = championClientPort.getChampionRotate(platformId);
+            // 빈 로테이션이어도 캐싱한다. 캐시 어댑터가 빈 값에는 짧은 TTL(negative cache)을 적용해
+            // Riot rate limit 소모를 막으면서 upstream 복구를 빠르게 반영한다.
+            championPersistencePort.saveChampionRotate(platformId, newChampionRotate);
             return newChampionRotate;
         }
-
-        championPersistencePort.saveChampionRotate(platformId, newChampionRotate);
-        return newChampionRotate;
     }
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/domain/ChampionRotate.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/domain/ChampionRotate.java
@@ -15,4 +15,13 @@ public class ChampionRotate {
     private int maxNewPlayerLevel;
     private List<Integer> freeChampionIdsForNewPlayers;
     private List<Integer> freeChampionIds;
+
+    /**
+     * 로테이션 데이터가 비어 있는지 여부.
+     * upstream(lol-repository)이 Riot 조회에 실패하면 {@code freeChampionIds} 가 null/빈 값인
+     * 응답을 내려주는데, 이런 값은 캐싱하면 안 되므로 이를 판별하는 guard.
+     */
+    public boolean isEmpty() {
+        return freeChampionIds == null || freeChampionIds.isEmpty();
+    }
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/domain/ChampionRotate.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/domain/ChampionRotate.java
@@ -19,7 +19,7 @@ public class ChampionRotate {
     /**
      * 로테이션 데이터가 비어 있는지 여부.
      * upstream(lol-repository)이 Riot 조회에 실패하면 {@code freeChampionIds} 가 null/빈 값인
-     * 응답을 내려주는데, 이런 값은 캐싱하면 안 되므로 이를 판별하는 guard.
+     * 응답을 내려주는데, 이런 값은 짧은 TTL(negative cache)로만 저장하기 위해 판별하는 guard.
      */
     public boolean isEmpty() {
         return freeChampionIds == null || freeChampionIds.isEmpty();

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionCacheAdapterTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionCacheAdapterTest.java
@@ -106,6 +106,46 @@ class ChampionCacheAdapterTest {
         );
     }
 
+    @DisplayName("빈 로테이션(freeChampionIds=null)은 짧은 TTL(60초)로 저장한다")
+    @Test
+    void saveChampionRotate_emptyNull_savesWithShortTtl() {
+        // given: upstream 조회 실패 시 내려오는 빈 응답
+        String platformId = "kr";
+        ChampionRotate emptyRotate = new ChampionRotate(0, null, null);
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        adapter.saveChampionRotate(platformId, emptyRotate);
+
+        // then: 1시간이 아니라 60초 negative cache 로 저장 → rate limit 보호 + 빠른 복구
+        then(valueOperations).should().set(
+                eq(CACHE_KEY_PREFIX + platformId),
+                eq(emptyRotate),
+                eq(Duration.ofSeconds(60))
+        );
+    }
+
+    @DisplayName("빈 로테이션(freeChampionIds=빈 리스트)도 짧은 TTL(60초)로 저장한다")
+    @Test
+    void saveChampionRotate_emptyList_savesWithShortTtl() {
+        // given
+        String platformId = "kr";
+        ChampionRotate emptyRotate = new ChampionRotate(0, List.of(), List.of());
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        adapter.saveChampionRotate(platformId, emptyRotate);
+
+        // then
+        then(valueOperations).should().set(
+                eq(CACHE_KEY_PREFIX + platformId),
+                eq(emptyRotate),
+                eq(Duration.ofSeconds(60))
+        );
+    }
+
     @DisplayName("다른 지역의 챔피언 로테이션을 각각 캐시에 저장하고 조회할 수 있다")
     @Test
     void getChampionRotate_differentPlatformIds_returnsCorrectData() {

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/ChampionServiceTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/ChampionServiceTest.java
@@ -97,9 +97,9 @@ class ChampionServiceTest {
         then(championPersistencePort).should().getChampionRotate(platformId);
     }
 
-    @DisplayName("클라이언트가 빈(freeChampionIds=null) 로테이션을 반환하면 캐싱하지 않는다")
+    @DisplayName("빈 로테이션 응답도 캐시에 저장한다 (짧은 TTL 은 캐시 어댑터가 적용)")
     @Test
-    void getChampionRotate_빈응답_null_캐싱생략() {
+    void getChampionRotate_빈응답_저장까지수행() {
         // given: upstream(lol-repository) 조회 실패 시 내려오는 빈 응답
         String platformId = "kr";
         ChampionRotate emptyRotate = new ChampionRotate(0, null, null);
@@ -109,26 +109,9 @@ class ChampionServiceTest {
         // when
         ChampionRotate result = championService.getChampionRotate(platformId);
 
-        // then: 빈 값은 그대로 반환하되, 캐시는 오염시키지 않는다
+        // then: 빈 값도 그대로 반환하고 저장한다 (rate limit 보호). TTL 차등은 어댑터 책임.
         assertThat(result).isEqualTo(emptyRotate);
         then(championClientPort).should().getChampionRotate(platformId);
-        then(championPersistencePort).should(never()).saveChampionRotate(platformId, emptyRotate);
-    }
-
-    @DisplayName("클라이언트가 빈(freeChampionIds=빈 리스트) 로테이션을 반환하면 캐싱하지 않는다")
-    @Test
-    void getChampionRotate_빈응답_emptyList_캐싱생략() {
-        // given
-        String platformId = "kr";
-        ChampionRotate emptyRotate = new ChampionRotate(0, List.of(), List.of());
-        given(championPersistencePort.getChampionRotate(platformId)).willReturn(Optional.empty());
-        given(championClientPort.getChampionRotate(platformId)).willReturn(emptyRotate);
-
-        // when
-        ChampionRotate result = championService.getChampionRotate(platformId);
-
-        // then
-        assertThat(result).isEqualTo(emptyRotate);
-        then(championPersistencePort).should(never()).saveChampionRotate(platformId, emptyRotate);
+        then(championPersistencePort).should().saveChampionRotate(platformId, emptyRotate);
     }
 }

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/ChampionServiceTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/ChampionServiceTest.java
@@ -96,4 +96,39 @@ class ChampionServiceTest {
         assertThat(result.getFreeChampionIds()).containsExactly(100, 101, 102, 103);
         then(championPersistencePort).should().getChampionRotate(platformId);
     }
+
+    @DisplayName("클라이언트가 빈(freeChampionIds=null) 로테이션을 반환하면 캐싱하지 않는다")
+    @Test
+    void getChampionRotate_빈응답_null_캐싱생략() {
+        // given: upstream(lol-repository) 조회 실패 시 내려오는 빈 응답
+        String platformId = "kr";
+        ChampionRotate emptyRotate = new ChampionRotate(0, null, null);
+        given(championPersistencePort.getChampionRotate(platformId)).willReturn(Optional.empty());
+        given(championClientPort.getChampionRotate(platformId)).willReturn(emptyRotate);
+
+        // when
+        ChampionRotate result = championService.getChampionRotate(platformId);
+
+        // then: 빈 값은 그대로 반환하되, 캐시는 오염시키지 않는다
+        assertThat(result).isEqualTo(emptyRotate);
+        then(championClientPort).should().getChampionRotate(platformId);
+        then(championPersistencePort).should(never()).saveChampionRotate(platformId, emptyRotate);
+    }
+
+    @DisplayName("클라이언트가 빈(freeChampionIds=빈 리스트) 로테이션을 반환하면 캐싱하지 않는다")
+    @Test
+    void getChampionRotate_빈응답_emptyList_캐싱생략() {
+        // given
+        String platformId = "kr";
+        ChampionRotate emptyRotate = new ChampionRotate(0, List.of(), List.of());
+        given(championPersistencePort.getChampionRotate(platformId)).willReturn(Optional.empty());
+        given(championClientPort.getChampionRotate(platformId)).willReturn(emptyRotate);
+
+        // when
+        ChampionRotate result = championService.getChampionRotate(platformId);
+
+        // then
+        assertThat(result).isEqualTo(emptyRotate);
+        then(championPersistencePort).should(never()).saveChampionRotate(platformId, emptyRotate);
+    }
 }


### PR DESCRIPTION
## 증상
`GET /api/v1/{platformId}/champion/rotation` 이 값을 전혀 반환하지 않음.
- `kr`: `200 SUCCESS` 지만 `{"maxNewPlayerLevel":0,"freeChampionIdsForNewPlayers":null,"freeChampionIds":null}` (빈 데이터)
- `na1` 등: upstream 500 이 그대로 `E500` 에러로 전파

## 원인 (2겹)
1. **1차 (lol-server 밖 · 근본 원인):** 데이터 소스인 lol-repository(`localhost:8111`)가 빈 로테이션을 반환한다. `localhost:8111/api/riot/kr/champion-rotate` 직접 호출로도 `{0, null, null}` 확인 — Riot 조회 실패(키 만료 등) 유력. **lol-server 코드로는 이 데이터를 만들어낼 수 없으며, 실제 값 복구는 lol-repository 측 수정이 필요하다.**
2. **2차 (본 PR):** `ChampionCacheAdapter` 가 빈 응답을 정상값과 동일하게 **1시간 TTL** 로 캐싱한다. 한번 오염되면 upstream 이 복구된 뒤에도 1시간 동안 빈 값을 서빙한다. 실제 Redis 에 `champion_rotation_kr → {0, null, null}` 오염 엔트리 확인.

## 변경 — negative caching
빈 값을 **아예 캐싱하지 않으면** 매 요청이 upstream→Riot 으로 관통해 rate limit 을 소모하므로, 빈 응답은 **짧은 TTL(60초)** 로만 캐싱한다.

- `ChampionRotate.isEmpty()` 도메인 guard 추가 — `freeChampionIds` null/빈 값이면 빈 로테이션으로 판별
- `ChampionCacheAdapter`: `isEmpty()` 면 `EMPTY_CACHE_TTL(60s)`, 아니면 기존 `CACHE_TTL(1h)`
- `ChampionService`: 빈 값도 항상 캐싱 (TTL 차등은 캐시 어댑터 책임)

효과: Riot rate limit 을 보호하면서(60초에 region당 최대 1회 upstream 조회), upstream 복구는 최대 60초 내 반영.

## 검증
- `:module:domain:gamedata:test` BUILD SUCCESSFUL (어댑터 negative-cache TTL 2건 + 서비스/도메인 케이스)
- `checkstyleMain`/`checkstyleTest` 통과

## 남은 조치 (이 PR 범위 밖)
- 실제 챔피언 로테이션 값이 나오려면 **lol-repository 의 Riot API 키/champion-rotate 데이터를 정상화**해야 한다. (근본 원인)
- 배포 후 오염된 Redis 키 flush 권장: `redis-cli DEL champion_rotation_kr` (안 해도 기존 엔트리는 TTL 로 최대 1시간 내 만료, 이후부터는 60초 negative cache 적용).
