### PR TITLE
chore: DevTools 추가로 소스 변경 시 자동 재시작 지원

### DIFF
--- a/module/app/application/CLAUDE.md
+++ b/module/app/application/CLAUDE.md
@@ -56,7 +56,16 @@ Spring Boot 진입점 + 컴포지션 루트. **모든 인프라 모듈을 implem
 ./gradlew :module:app:application:bootRun -Dspring.profiles.active=local  # local 부트 (Docker 서비스 필요)
 ./gradlew :module:app:application:bootJar                                 # 실행 가능 fat jar
 ./gradlew :module:app:application:test                                    # 모듈 단위 테스트
+
+# DevTools 자동 재시작 — bootRun 은 컴파일된 build/classes 디렉터리를 감시하므로,
+# 소스 저장 시 자동 재컴파일이 있어야 재시작이 걸린다. 둘 중 하나:
+#  1) 별도 터미널에서 지속 컴파일 (전 모듈 소스 변경 감지)
+./gradlew classes -t
+#  2) IntelliJ: "Build project automatically" ON +
+#     Advanced Settings → "Allow auto-make to start even if developed application is currently running"
 ```
+
+> DevTools 는 `developmentOnly` 의존이라 `bootJar`(dev/prod) 에는 포함되지 않는다. 재시작/LiveReload 세부 설정은 `application-local.yml` 의 `spring.devtools.*` 에서.
 
 ## See Also
 

--- a/module/app/application/build.gradle
+++ b/module/app/application/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // DevTools — 소스 변경 시 클래스패스 감시 후 자동 재시작 (developmentOnly: bootJar/prod 미포함)
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
     // PostgreSQL 드라이버 (runtimeOnly는 모듈간 전이되지 않으므로 직접 추가)
     runtimeOnly 'org.postgresql:postgresql'
 }

--- a/module/app/application/src/main/resources/application-local.yml
+++ b/module/app/application/src/main/resources/application-local.yml
@@ -11,3 +11,10 @@ spring:
       - redis-local.yml
       - bigquery-local.yml
       - logging-local.yml
+  devtools:
+    restart:
+      enabled: true       # 클래스패스(도메인 모듈 포함) 변경 감지 시 자동 재시작
+      poll-interval: 2s    # 변경 폴링 주기
+      quiet-period: 1s     # 마지막 변경 후 안정화 대기 (poll-interval 보다 작아야 함)
+    livereload:
+      enabled: true       # 정적 리소스 변경 시 브라우저 LiveReload (포트 35729)


### PR DESCRIPTION
## 요약
로컬 개발 시 소스 코드 변경을 감지해 애플리케이션이 자동 재시작되도록 Spring Boot DevTools 를 추가합니다.

## 변경 내용
- `module/app/application/build.gradle`: `developmentOnly 'org.springframework.boot:spring-boot-devtools'` 추가
  - `developmentOnly` 구성이라 `bootJar`(dev/prod) 산출물에는 **포함되지 않음** — 로컬 `bootRun` 에서만 클래스패스 감시 활성화
- `application-local.yml`: `spring.devtools.restart`(재시작), `spring.devtools.livereload`(정적 리소스 브라우저 리로드) 설정 추가
- `module/app/application/CLAUDE.md`: 멀티모듈에서 자동 재컴파일을 걸어야 재시작이 동작한다는 사용법 문서화

## 사용법 (중요)
DevTools 는 컴파일된 `build/classes` 를 감시하므로, 소스 저장 시 **재컴파일**이 있어야 재시작이 걸립니다. 둘 중 하나:
1. 별도 터미널에서 지속 컴파일: `./gradlew classes -t`
2. IntelliJ: *Build project automatically* ON + Advanced Settings의 *Allow auto-make to start even if developed application is currently running*

## 검증
- `./gradlew :module:app:application:dependencies --configuration developmentOnly` — devtools 3.3.6 정상 해석 확인 (Spring Boot BOM 관리 버전)
- 빌드 스크립트 파싱 정상

## 참고
- 사용자 요청에 Linear(MP) 키가 없어 커밋/브랜치에 번호를 넣지 않았습니다. 필요 시 알려주시면 규칙(`chore/MP-<번호>-*`)에 맞춰 조정하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)