### PR TITLE
fix: ChampionRotate 파생 getter(empty) 캐시 직렬화 오염 수정

### DIFF
--- a/module/common/src/main/java/com/example/lolserver/common/config/RedisConfig.java
+++ b/module/common/src/main/java/com/example/lolserver/common/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.example.lolserver.common.config;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -50,11 +51,20 @@ public class RedisConfig {
      * InvalidDefinitionException 으로 실패한다. 모듈을 등록한 ObjectMapper 를 주입하되,
      * defaultTyping 은 켠 채로 둔다 — @class 타입 정보가 빠지면 역직렬화 결과가
      * LinkedHashMap 이 되어 호출부 캐스팅에서 깨진다.
+     *
+     * <p>{@code FAIL_ON_UNKNOWN_PROPERTIES} 는 끈다. 캐시는 버려도 되는 최적화이므로,
+     * 값 클래스에 필드가 추가/제거되거나(스키마 진화) 파생 getter 가 JSON 에 섞여도
+     * 역직렬화가 SerializationException 으로 500 을 던지는 대신 알 수 없는 필드를 무시하고
+     * 관대하게 복구되어야 한다. (실제 사례: {@code ChampionRotate.isEmpty()} 파생 getter 가
+     * {@code "empty"} 필드로 직렬화되어, 이후 읽기가 "Unrecognized field empty" 로 전량 실패.)
+     *
+     * <p>테스트에서 실제 직렬화기 동작을 검증할 수 있도록 public 으로 노출한다.
      */
-    private GenericJackson2JsonRedisSerializer jsonRedisSerializer() {
+    public GenericJackson2JsonRedisSerializer jsonRedisSerializer() {
         ObjectMapper objectMapper = JsonMapper.builder()
                 .addModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
                 .build();
 
         return GenericJackson2JsonRedisSerializer.builder()

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/domain/ChampionRotate.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/domain/ChampionRotate.java
@@ -1,5 +1,6 @@
 package com.example.lolserver.gamedata.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,7 +21,12 @@ public class ChampionRotate {
      * 로테이션 데이터가 비어 있는지 여부.
      * upstream(lol-repository)이 Riot 조회에 실패하면 {@code freeChampionIds} 가 null/빈 값인
      * 응답을 내려주는데, 이런 값은 짧은 TTL(negative cache)로만 저장하기 위해 판별하는 guard.
+     *
+     * <p>{@code @JsonIgnore} 필수: Jackson 은 {@code isEmpty()} 를 {@code "empty"} 프로퍼티로
+     * 인식해 Redis 캐시 JSON 에 직렬화하는데, 이 필드는 역직렬화 대상(필드/생성자 인자)이 아니라
+     * 읽을 때 "Unrecognized field empty" 로 캐시 조회가 전량 실패한다. 파생 값이므로 직렬화에서 제외한다.
      */
+    @JsonIgnore
     public boolean isEmpty() {
         return freeChampionIds == null || freeChampionIds.isEmpty();
     }

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionRotateCacheSerializationTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionRotateCacheSerializationTest.java
@@ -1,0 +1,79 @@
+package com.example.lolserver.gamedata.adapter.out.cache;
+
+import com.example.lolserver.common.config.RedisConfig;
+import com.example.lolserver.gamedata.domain.ChampionRotate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * {@link ChampionRotate} 가 Redis 캐시 직렬화기({@link RedisConfig#jsonRedisSerializer()})로
+ * 안전하게 왕복되는지 검증하는 회귀 테스트.
+ *
+ * <p>배경: 로테이션 negative-cache 도입 시 추가된 파생 getter {@code isEmpty()} 가 Jackson 에 의해
+ * {@code "empty"} 프로퍼티로 직렬화되어 Redis 에 저장됐고, 이후 조회에서
+ * {@code Unrecognized field "empty"} SerializationException 으로 캐시 읽기가 전량 500 으로 실패했다.
+ * 이 테스트는 (1) {@code @JsonIgnore} 로 {@code empty} 가 더 이상 직렬화되지 않고,
+ * (2) 이미 오염되어 {@code empty} 가 박혀 있는 엔트리도 관대하게 역직렬화되는지를 잠근다.
+ */
+class ChampionRotateCacheSerializationTest {
+
+    // 프로덕션과 동일한 직렬화기 설정을 그대로 사용한다 (설정 drift 방지).
+    private final GenericJackson2JsonRedisSerializer serializer = new RedisConfig().jsonRedisSerializer();
+
+    @DisplayName("직렬화된 JSON 에 파생 getter(empty) 가 포함되지 않는다")
+    @Test
+    void serialize_doesNotIncludeDerivedEmptyField() {
+        // given
+        ChampionRotate rotate = new ChampionRotate(10, List.of(18, 81), List.of(1, 2, 3));
+
+        // when
+        byte[] bytes = serializer.serialize(rotate);
+        String json = new String(bytes, StandardCharsets.UTF_8);
+
+        // then: isEmpty() 가 @JsonIgnore 로 제외되어 "empty" 키가 없어야 한다
+        assertThat(json).doesNotContain("\"empty\"");
+    }
+
+    @DisplayName("직렬화-역직렬화 왕복이 값을 보존한다")
+    @Test
+    void roundTrip_preservesValues() {
+        // given
+        ChampionRotate rotate = new ChampionRotate(10, List.of(18, 81), List.of(1, 2, 3));
+
+        // when
+        byte[] bytes = serializer.serialize(rotate);
+        ChampionRotate restored = (ChampionRotate) serializer.deserialize(bytes);
+
+        // then
+        assertThat(restored).isNotNull();
+        assertThat(restored.getMaxNewPlayerLevel()).isEqualTo(10);
+        assertThat(restored.getFreeChampionIdsForNewPlayers()).containsExactly(18, 81);
+        assertThat(restored.getFreeChampionIds()).containsExactly(1, 2, 3);
+    }
+
+    @DisplayName("empty 필드가 박힌 레거시(오염) 캐시 엔트리도 예외 없이 역직렬화된다")
+    @Test
+    void deserialize_legacyEntryWithEmptyField_doesNotThrow() {
+        // given: 기존 코드가 저장해 둔, "empty" 파생 필드가 섞인 오염 엔트리를 재현한다.
+        //        깨끗한 JSON 을 만든 뒤 루트에 "empty":false 를 주입한다.
+        ChampionRotate rotate = new ChampionRotate(10, List.of(18, 81), List.of(1, 2, 3));
+        String cleanJson = new String(serializer.serialize(rotate), StandardCharsets.UTF_8);
+        int lastBrace = cleanJson.lastIndexOf('}');
+        String poisonedJson = cleanJson.substring(0, lastBrace) + ",\"empty\":false}";
+
+        // when / then: FAIL_ON_UNKNOWN_PROPERTIES=false 로 알 수 없는 필드를 무시하고 복구되어야 한다
+        assertThatCode(() -> {
+            ChampionRotate restored = (ChampionRotate)
+                    serializer.deserialize(poisonedJson.getBytes(StandardCharsets.UTF_8));
+            assertThat(restored).isNotNull();
+            assertThat(restored.getFreeChampionIds()).containsExactly(1, 2, 3);
+        }).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Closes #139

## 문제

프로덕션 로그에서 챔피언 로테이션 조회 시 Redis 역직렬화가 500 으로 실패:

```
SerializationException: Could not read JSON: Unrecognized field "empty"
(class ...gamedata.domain.ChampionRotate), not marked as ignorable
(3 known properties: "freeChampionIdsForNewPlayers", "freeChampionIds", "maxNewPlayerLevel")
```

## 원인

로테이션 negative-cache 도입(#136)에서 추가된 파생 getter `ChampionRotate.isEmpty()` 를
Jackson 이 `"empty"` 프로퍼티로 인식해 캐시 JSON 에 **직렬화**한다. 그런데 `RedisConfig` 의
커스텀 ObjectMapper 는 `FAIL_ON_UNKNOWN_PROPERTIES` 가 켜진 기본값이라, `empty` 는 역직렬화
대상(필드/생성자 인자)이 아니므로 **읽을 때마다 예외**로 터진다. 즉 현재 코드가 자기가 저장한
값을 자기가 못 읽는 상태이며, TTL(정상 1시간) 동안 해당 지역 로테이션 조회가 전량 500.

## 수정

- **`ChampionRotate.isEmpty()` → `@JsonIgnore`**: 파생 getter 가 애초에 직렬화되지 않게 하여 오염 근절.
- **`RedisConfig`: `FAIL_ON_UNKNOWN_PROPERTIES` 비활성화**: 캐시는 버려도 되는 최적화이므로,
  이미 오염된 기존 엔트리 + 향후 값 클래스 스키마 진화에도 500 대신 알 수 없는 필드를 무시하고
  관대하게 복구. (CLAUDE.md 의 "값 클래스 이동/리네임 시 역직렬화 실패" 취약성 노트와 정합.)
  → 재배포 즉시 이미 캐시에 박힌 오염 엔트리도 정상 조회됨(flush 불필요).

전역 ObjectMapper visibility 변경 대신 위 2개로 **영향 범위를 최소화**했다(캐시되는 값 타입이
spectator·championstats·version·match 등 다수라 visibility 변경은 직렬화 shape 파급이 크고 검증 곤란).

## 검증

- 회귀 테스트 추가 `ChampionRotateCacheSerializationTest` (실제 `RedisConfig` 직렬화기 사용):
  1. 직렬화 JSON 에 `empty` 필드 미포함
  2. 직렬화-역직렬화 왕복 값 보존
  3. `empty` 가 박힌 레거시(오염) 엔트리도 **무예외** 역직렬화 (프로덕션 조건 재현)
- `./gradlew archTest` 전 모듈 통과 (도메인 `@JsonIgnore` 가 아키텍처 규칙 미위반)
- `./gradlew compileJava compileTestJava` 전 모듈 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)