### PR TITLE
feat: 커뮤니티 북마크 API

### DIFF
--- a/module/common/src/main/java/com/example/lolserver/common/error/ErrorType.java
+++ b/module/common/src/main/java/com/example/lolserver/common/error/ErrorType.java
@@ -38,6 +38,8 @@ public enum ErrorType {
     INVALID_CATEGORY(400, ErrorCode.E400, "유효하지 않은 카테고리입니다."),
     COMMENT_DEPTH_EXCEEDED(400, ErrorCode.E400, "댓글 최대 깊이를 초과했습니다."),
     VOTE_TARGET_NOT_FOUND(404, ErrorCode.E404, "투표 대상을 찾을 수 없습니다."),
+    BOOKMARK_ALREADY_EXISTS(409, ErrorCode.E409, "이미 북마크한 게시글입니다."),
+    BOOKMARK_NOT_FOUND(404, ErrorCode.E404, "북마크를 찾을 수 없습니다."),
 
     MEMBER_ALREADY_WITHDRAWN(400, ErrorCode.E400,
             "이미 탈퇴한 회원입니다."),

--- a/module/common/src/testFixtures/java/com/example/lolserver/common/test/TestJpaConfig.java
+++ b/module/common/src/testFixtures/java/com/example/lolserver/common/test/TestJpaConfig.java
@@ -14,6 +14,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 // 영속성 어댑터(*.adapter.out.persistence.*: 어댑터 + MapStruct 매퍼)만 남기고
 // 나머지 레이어(application 서비스, adapter.in 컨트롤러, client/messaging/cache driven 어댑터, *.config)는
 // 제외한다 — 이들은 RestClient/RabbitTemplate/타 포트 등 JPA 슬라이스에 없는 빈을 요구하기 때문.
+// (oauth 어댑터도 RestClient 를 요구하므로 같은 이유로 제외한다. 빠져 있으면
+//  member 를 의존하는 컨텍스트에서 리포지토리 테스트 컨텍스트가 아예 뜨지 않는다.)
 // 엔티티/리포지토리는 @EntityScan/@EnableJpaRepositories, JPA 보조 빈은 @Import 로 주입.
 @SpringBootApplication
 @EntityScan(basePackages = "com.example.lolserver")
@@ -26,7 +28,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
             @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*\\.adapter\\.in\\..*"),
             @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*\\.adapter\\.out\\.client\\..*"),
             @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*\\.adapter\\.out\\.messaging\\..*"),
-            @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*\\.adapter\\.out\\.cache\\..*")
+            @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*\\.adapter\\.out\\.cache\\..*"),
+            @ComponentScan.Filter(type = FilterType.REGEX, pattern = ".*\\.adapter\\.out\\.oauth\\..*")
         })
 @Import(AsyncQueryConfig.class)
 public class TestJpaConfig {

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/CommunityBookmarkController.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/CommunityBookmarkController.java
@@ -1,0 +1,46 @@
+package com.example.lolserver.community.adapter.in.web;
+
+import com.example.lolserver.common.web.response.ApiResponse;
+import com.example.lolserver.common.web.security.AuthenticatedMember;
+import com.example.lolserver.community.adapter.in.web.request.BookmarkRequest;
+import com.example.lolserver.community.application.port.in.BookmarkUseCase;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 북마크 경로는 반드시 /api/community/bookmarks 최상위에 둔다.
+ * /api/community/posts/{id}/bookmark 로 중첩하면 SecurityConfig 의
+ * `GET /api/community/posts/**` permitAll 규칙에 걸려 인증 없이 뚫린다.
+ */
+@RestController
+@RequestMapping("/api/community")
+@RequiredArgsConstructor
+public class CommunityBookmarkController {
+
+    private final BookmarkUseCase bookmarkUseCase;
+
+    @PostMapping("/bookmarks")
+    public ResponseEntity<ApiResponse<?>> addBookmark(
+            @AuthenticationPrincipal AuthenticatedMember member,
+            @Valid @RequestBody BookmarkRequest request) {
+        bookmarkUseCase.addBookmark(member.memberId(), request.postId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
+    }
+
+    @DeleteMapping("/bookmarks/{postId}")
+    public ResponseEntity<Void> removeBookmark(
+            @AuthenticationPrincipal AuthenticatedMember member,
+            @PathVariable Long postId) {
+        bookmarkUseCase.removeBookmark(member.memberId(), postId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/CommunityBookmarkController.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/CommunityBookmarkController.java
@@ -1,8 +1,13 @@
 package com.example.lolserver.community.adapter.in.web;
 
+import com.example.lolserver.common.support.SliceResult;
 import com.example.lolserver.common.web.response.ApiResponse;
+import com.example.lolserver.common.web.response.SliceResponse;
 import com.example.lolserver.common.web.security.AuthenticatedMember;
 import com.example.lolserver.community.adapter.in.web.request.BookmarkRequest;
+import com.example.lolserver.community.adapter.in.web.response.PostListResponse;
+import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
+import com.example.lolserver.community.application.port.in.BookmarkQueryUseCase;
 import com.example.lolserver.community.application.port.in.BookmarkUseCase;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,10 +15,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -27,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class CommunityBookmarkController {
 
     private final BookmarkUseCase bookmarkUseCase;
+    private final BookmarkQueryUseCase bookmarkQueryUseCase;
 
     @PostMapping("/bookmarks")
     public ResponseEntity<ApiResponse<?>> addBookmark(
@@ -42,5 +50,19 @@ public class CommunityBookmarkController {
             @PathVariable Long postId) {
         bookmarkUseCase.removeBookmark(member.memberId(), postId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me/bookmarks")
+    public ResponseEntity<ApiResponse<SliceResponse<PostListResponse>>> getMyBookmarks(
+            @AuthenticationPrincipal AuthenticatedMember member,
+            @RequestParam(defaultValue = "0") int page) {
+        return ResponseEntity.ok(ApiResponse.success(
+                toSlice(bookmarkQueryUseCase.getMyBookmarks(member.memberId(), page))));
+    }
+
+    private SliceResponse<PostListResponse> toSlice(SliceResult<PostListReadModel> result) {
+        return new SliceResponse<>(
+                result.getContent().stream().map(PostListResponse::from).toList(),
+                result.isHasNext());
     }
 }

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/CommunityBookmarkController.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/CommunityBookmarkController.java
@@ -24,9 +24,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 북마크 경로는 반드시 /api/community/bookmarks 최상위에 둔다.
- * /api/community/posts/{id}/bookmark 로 중첩하면 SecurityConfig 의
- * `GET /api/community/posts/**` permitAll 규칙에 걸려 인증 없이 뚫린다.
+ * 북마크 경로는 /api/community/bookmarks 최상위에 둔다.
+ *
+ * <p>SecurityConfig 의 permitAll 은 <b>GET</b> /api/community/posts/** 한정이므로
+ * 여기의 POST/DELETE 는 중첩했더라도 /api/community/** .authenticated() 에 걸린다.
+ * 다만 앞으로 "GET /posts/{id}/bookmark 로 북마크 여부 조회" 같은 것을 posts 하위에
+ * 추가하면 그건 <b>실제로 permitAll 에 걸려 인증 없이 뚫린다.</b> 그래서 북마크 리소스는
+ * 처음부터 posts 바깥에 둔다.
  */
 @RestController
 @RequestMapping("/api/community")
@@ -37,11 +41,12 @@ public class CommunityBookmarkController {
     private final BookmarkQueryUseCase bookmarkQueryUseCase;
 
     @PostMapping("/bookmarks")
-    public ResponseEntity<ApiResponse<?>> addBookmark(
+    public ResponseEntity<ApiResponse<Void>> addBookmark(
             @AuthenticationPrincipal AuthenticatedMember member,
             @Valid @RequestBody BookmarkRequest request) {
         bookmarkUseCase.addBookmark(member.memberId(), request.postId());
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(null));
     }
 
     @DeleteMapping("/bookmarks/{postId}")

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/request/BookmarkRequest.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/request/BookmarkRequest.java
@@ -1,0 +1,8 @@
+package com.example.lolserver.community.adapter.in.web.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record BookmarkRequest(
+        @NotNull Long postId
+) {
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/response/PostResponse.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/in/web/response/PostResponse.java
@@ -16,6 +16,7 @@ public record PostResponse(
         int commentCount,
         AuthorResponse author,
         String currentUserVote,
+        boolean currentUserBookmarked,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -31,6 +32,7 @@ public record PostResponse(
                 readModel.getCommentCount(),
                 AuthorResponse.from(readModel.getAuthor()),
                 readModel.getCurrentUserVote() != null ? readModel.getCurrentUserVote().name() : null,
+                readModel.isCurrentUserBookmarked(),
                 readModel.getCreatedAt(),
                 readModel.getUpdatedAt()
         );
@@ -48,6 +50,7 @@ public record PostResponse(
                 resultModel.getCommentCount(),
                 AuthorResponse.from(resultModel.getAuthor()),
                 resultModel.getCurrentUserVote() != null ? resultModel.getCurrentUserVote().name() : null,
+                resultModel.isCurrentUserBookmarked(),
                 resultModel.getCreatedAt(),
                 resultModel.getUpdatedAt()
         );

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/adapter/BookmarkPersistenceAdapter.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/adapter/BookmarkPersistenceAdapter.java
@@ -4,7 +4,7 @@ import com.example.lolserver.common.error.CoreException;
 import com.example.lolserver.common.error.ErrorType;
 import com.example.lolserver.common.support.SliceResult;
 import com.example.lolserver.community.adapter.out.persistence.entity.CommunityBookmarkEntity;
-import com.example.lolserver.community.adapter.out.persistence.entity.CommunityPostEntity;
+import com.example.lolserver.community.adapter.out.persistence.dto.PostListDTO;
 import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
 import com.example.lolserver.community.adapter.out.persistence.mapper.CommunityBookmarkMapper;
 import com.example.lolserver.community.adapter.out.persistence.repository.CommunityBookmarkJpaRepository;
@@ -43,6 +43,11 @@ public class BookmarkPersistenceAdapter implements BookmarkPersistencePort {
     }
 
     @Override
+    public boolean existsByMemberIdAndPostId(Long memberId, Long postId) {
+        return bookmarkJpaRepository.existsByMemberIdAndPostId(memberId, postId);
+    }
+
+    @Override
     public Optional<Bookmark> findByMemberIdAndPostId(Long memberId, Long postId) {
         return bookmarkJpaRepository.findByMemberIdAndPostId(memberId, postId)
                 .map(bookmarkMapper::toDomain);
@@ -56,22 +61,22 @@ public class BookmarkPersistenceAdapter implements BookmarkPersistencePort {
     @Override
     public SliceResult<PostListReadModel> findBookmarkedPosts(Long memberId, int page) {
         Pageable pageable = PageRequest.of(page, PAGE_SIZE);
-        Slice<CommunityPostEntity> slice =
+        Slice<PostListDTO> slice =
                 bookmarkJpaRepository.findBookmarkedPosts(memberId, pageable);
 
         return new SliceResult<>(
                 slice.getContent().stream()
-                        .map(entity -> PostListReadModel.builder()
-                                .id(entity.getId())
-                                .title(entity.getTitle())
-                                .category(entity.getCategory())
-                                .viewCount(entity.getViewCount())
-                                .upvoteCount(entity.getUpvoteCount())
-                                .downvoteCount(entity.getDownvoteCount())
-                                .commentCount(entity.getCommentCount())
-                                .hotScore(entity.getHotScore())
-                                .authorId(entity.getMemberId())
-                                .createdAt(entity.getCreatedAt())
+                        .map(dto -> PostListReadModel.builder()
+                                .id(dto.getId())
+                                .title(dto.getTitle())
+                                .category(dto.getCategory())
+                                .viewCount(dto.getViewCount())
+                                .upvoteCount(dto.getUpvoteCount())
+                                .downvoteCount(dto.getDownvoteCount())
+                                .commentCount(dto.getCommentCount())
+                                .hotScore(dto.getHotScore())
+                                .authorId(dto.getMemberId())
+                                .createdAt(dto.getCreatedAt())
                                 .build())
                         .toList(),
                 slice.hasNext()

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/adapter/BookmarkPersistenceAdapter.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/adapter/BookmarkPersistenceAdapter.java
@@ -1,11 +1,17 @@
 package com.example.lolserver.community.adapter.out.persistence.adapter;
 
+import com.example.lolserver.common.support.SliceResult;
 import com.example.lolserver.community.adapter.out.persistence.entity.CommunityBookmarkEntity;
+import com.example.lolserver.community.adapter.out.persistence.entity.CommunityPostEntity;
+import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
 import com.example.lolserver.community.adapter.out.persistence.mapper.CommunityBookmarkMapper;
 import com.example.lolserver.community.adapter.out.persistence.repository.CommunityBookmarkJpaRepository;
 import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
 import com.example.lolserver.community.domain.Bookmark;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -13,6 +19,8 @@ import java.util.Optional;
 @Component
 @RequiredArgsConstructor
 public class BookmarkPersistenceAdapter implements BookmarkPersistencePort {
+
+    private static final int PAGE_SIZE = 20;
 
     private final CommunityBookmarkJpaRepository bookmarkJpaRepository;
     private final CommunityBookmarkMapper bookmarkMapper;
@@ -33,5 +41,30 @@ public class BookmarkPersistenceAdapter implements BookmarkPersistencePort {
     @Override
     public void delete(Bookmark bookmark) {
         bookmarkJpaRepository.deleteById(bookmark.getId());
+    }
+
+    @Override
+    public SliceResult<PostListReadModel> findBookmarkedPosts(Long memberId, int page) {
+        Pageable pageable = PageRequest.of(page, PAGE_SIZE);
+        Slice<CommunityPostEntity> slice =
+                bookmarkJpaRepository.findBookmarkedPosts(memberId, pageable);
+
+        return new SliceResult<>(
+                slice.getContent().stream()
+                        .map(entity -> PostListReadModel.builder()
+                                .id(entity.getId())
+                                .title(entity.getTitle())
+                                .category(entity.getCategory())
+                                .viewCount(entity.getViewCount())
+                                .upvoteCount(entity.getUpvoteCount())
+                                .downvoteCount(entity.getDownvoteCount())
+                                .commentCount(entity.getCommentCount())
+                                .hotScore(entity.getHotScore())
+                                .authorId(entity.getMemberId())
+                                .createdAt(entity.getCreatedAt())
+                                .build())
+                        .toList(),
+                slice.hasNext()
+        );
     }
 }

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/adapter/BookmarkPersistenceAdapter.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/adapter/BookmarkPersistenceAdapter.java
@@ -1,0 +1,37 @@
+package com.example.lolserver.community.adapter.out.persistence.adapter;
+
+import com.example.lolserver.community.adapter.out.persistence.entity.CommunityBookmarkEntity;
+import com.example.lolserver.community.adapter.out.persistence.mapper.CommunityBookmarkMapper;
+import com.example.lolserver.community.adapter.out.persistence.repository.CommunityBookmarkJpaRepository;
+import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
+import com.example.lolserver.community.domain.Bookmark;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class BookmarkPersistenceAdapter implements BookmarkPersistencePort {
+
+    private final CommunityBookmarkJpaRepository bookmarkJpaRepository;
+    private final CommunityBookmarkMapper bookmarkMapper;
+
+    @Override
+    public Bookmark save(Bookmark bookmark) {
+        CommunityBookmarkEntity entity = bookmarkMapper.toEntity(bookmark);
+        CommunityBookmarkEntity saved = bookmarkJpaRepository.save(entity);
+        return bookmarkMapper.toDomain(saved);
+    }
+
+    @Override
+    public Optional<Bookmark> findByMemberIdAndPostId(Long memberId, Long postId) {
+        return bookmarkJpaRepository.findByMemberIdAndPostId(memberId, postId)
+                .map(bookmarkMapper::toDomain);
+    }
+
+    @Override
+    public void delete(Bookmark bookmark) {
+        bookmarkJpaRepository.deleteById(bookmark.getId());
+    }
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/adapter/BookmarkPersistenceAdapter.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/adapter/BookmarkPersistenceAdapter.java
@@ -1,5 +1,7 @@
 package com.example.lolserver.community.adapter.out.persistence.adapter;
 
+import com.example.lolserver.common.error.CoreException;
+import com.example.lolserver.common.error.ErrorType;
 import com.example.lolserver.common.support.SliceResult;
 import com.example.lolserver.community.adapter.out.persistence.entity.CommunityBookmarkEntity;
 import com.example.lolserver.community.adapter.out.persistence.entity.CommunityPostEntity;
@@ -9,6 +11,7 @@ import com.example.lolserver.community.adapter.out.persistence.repository.Commun
 import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
 import com.example.lolserver.community.domain.Bookmark;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -28,8 +31,15 @@ public class BookmarkPersistenceAdapter implements BookmarkPersistencePort {
     @Override
     public Bookmark save(Bookmark bookmark) {
         CommunityBookmarkEntity entity = bookmarkMapper.toEntity(bookmark);
-        CommunityBookmarkEntity saved = bookmarkJpaRepository.save(entity);
-        return bookmarkMapper.toDomain(saved);
+        try {
+            CommunityBookmarkEntity saved = bookmarkJpaRepository.save(entity);
+            return bookmarkMapper.toDomain(saved);
+        } catch (DataIntegrityViolationException e) {
+            // 서비스의 사전 조회를 동시 요청 두 건이 모두 통과하면 여기서 uq_cb_member_post 가
+            // 걸린다. 그대로 두면 처리되지 않은 예외로 500 이 나가므로, 사전 조회가 잡았을
+            // 때와 같은 도메인 에러로 수렴시킨다.
+            throw new CoreException(ErrorType.BOOKMARK_ALREADY_EXISTS);
+        }
     }
 
     @Override

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/entity/CommunityBookmarkEntity.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/entity/CommunityBookmarkEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,13 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "community_bookmark")
+@Table(
+        name = "community_bookmark",
+        // V31 의 uq_cb_member_post 와 같은 제약. 선언하지 않으면 엔티티로 스키마를
+        // 만드는 환경(H2 create-drop 등)에서 중복 북마크가 그냥 들어간다.
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_cb_member_post",
+                columnNames = {"member_id", "post_id"}))
 @Getter
 @Setter
 @Builder

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/entity/CommunityBookmarkEntity.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/entity/CommunityBookmarkEntity.java
@@ -1,0 +1,40 @@
+package com.example.lolserver.community.adapter.out.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "community_bookmark")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityBookmarkEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
+    // createdAt 은 JPA Auditing 이 아니라 도메인 Bookmark.create() 가 채운다
+    // (community 컨텍스트 전체가 같은 방식).
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/mapper/CommunityBookmarkMapper.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/mapper/CommunityBookmarkMapper.java
@@ -1,0 +1,13 @@
+package com.example.lolserver.community.adapter.out.persistence.mapper;
+
+import com.example.lolserver.community.adapter.out.persistence.entity.CommunityBookmarkEntity;
+import com.example.lolserver.community.domain.Bookmark;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface CommunityBookmarkMapper {
+
+    Bookmark toDomain(CommunityBookmarkEntity entity);
+
+    CommunityBookmarkEntity toEntity(Bookmark bookmark);
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/repository/CommunityBookmarkJpaRepository.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/repository/CommunityBookmarkJpaRepository.java
@@ -1,0 +1,12 @@
+package com.example.lolserver.community.adapter.out.persistence.repository;
+
+import com.example.lolserver.community.adapter.out.persistence.entity.CommunityBookmarkEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CommunityBookmarkJpaRepository
+        extends JpaRepository<CommunityBookmarkEntity, Long> {
+
+    Optional<CommunityBookmarkEntity> findByMemberIdAndPostId(Long memberId, Long postId);
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/repository/CommunityBookmarkJpaRepository.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/repository/CommunityBookmarkJpaRepository.java
@@ -1,7 +1,7 @@
 package com.example.lolserver.community.adapter.out.persistence.repository;
 
+import com.example.lolserver.community.adapter.out.persistence.dto.PostListDTO;
 import com.example.lolserver.community.adapter.out.persistence.entity.CommunityBookmarkEntity;
-import com.example.lolserver.community.adapter.out.persistence.entity.CommunityPostEntity;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,18 +15,28 @@ public interface CommunityBookmarkJpaRepository
 
     Optional<CommunityBookmarkEntity> findByMemberIdAndPostId(Long memberId, Long postId);
 
+    boolean existsByMemberIdAndPostId(Long memberId, Long postId);
+
     /**
      * 북마크한 게시글 목록.
-     * 정렬 기준은 글 작성 시각이 아니라 <b>북마크한 시각</b>이다 — 사용자가 기대하는 순서는
-     * "내가 최근에 담은 순"이다. 그래서 idx_cb_member_created 가 필요하다.
-     * 삭제된 글은 목록에서 제외한다 (북마크 레코드 자체는 남는다).
+     *
+     * <p>정렬 기준은 글 작성 시각이 아니라 <b>북마크한 시각</b>이다 — 사용자가 기대하는 순서는
+     * "내가 최근에 담은 순"이고, 이를 위해 V31 의 idx_cb_member_created 가 있다.
+     * 같은 시각의 북마크가 있을 때 페이지 경계에서 행이 중복/누락되지 않도록 b.id 를 타이브레이커로 둔다.
+     *
+     * <p>엔티티가 아니라 DTO 로 프로젝션하는 이유: 목록 응답은 본문(content, TEXT)을 쓰지 않는다.
+     * 엔티티를 가져오면 페이지당 20건의 본문을 통째로 읽어 영속성 컨텍스트에 적재한다.
+     *
+     * <p>삭제된 글은 목록에서 제외하되 북마크 레코드 자체는 남긴다.
      */
     @Query("""
-            SELECT p FROM CommunityPostEntity p
+            SELECT new com.example.lolserver.community.adapter.out.persistence.dto.PostListDTO(
+                p.id, p.title, p.category, p.viewCount, p.upvoteCount, p.downvoteCount,
+                p.commentCount, p.hotScore, p.createdAt, p.memberId)
+            FROM CommunityPostEntity p
             JOIN CommunityBookmarkEntity b ON b.postId = p.id
             WHERE b.memberId = :memberId AND p.deleted = false
-            ORDER BY b.createdAt DESC
+            ORDER BY b.createdAt DESC, b.id DESC
             """)
-    Slice<CommunityPostEntity> findBookmarkedPosts(@Param("memberId") Long memberId,
-                                                   Pageable pageable);
+    Slice<PostListDTO> findBookmarkedPosts(@Param("memberId") Long memberId, Pageable pageable);
 }

--- a/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/repository/CommunityBookmarkJpaRepository.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/adapter/out/persistence/repository/CommunityBookmarkJpaRepository.java
@@ -1,7 +1,12 @@
 package com.example.lolserver.community.adapter.out.persistence.repository;
 
 import com.example.lolserver.community.adapter.out.persistence.entity.CommunityBookmarkEntity;
+import com.example.lolserver.community.adapter.out.persistence.entity.CommunityPostEntity;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -9,4 +14,19 @@ public interface CommunityBookmarkJpaRepository
         extends JpaRepository<CommunityBookmarkEntity, Long> {
 
     Optional<CommunityBookmarkEntity> findByMemberIdAndPostId(Long memberId, Long postId);
+
+    /**
+     * 북마크한 게시글 목록.
+     * 정렬 기준은 글 작성 시각이 아니라 <b>북마크한 시각</b>이다 — 사용자가 기대하는 순서는
+     * "내가 최근에 담은 순"이다. 그래서 idx_cb_member_created 가 필요하다.
+     * 삭제된 글은 목록에서 제외한다 (북마크 레코드 자체는 남는다).
+     */
+    @Query("""
+            SELECT p FROM CommunityPostEntity p
+            JOIN CommunityBookmarkEntity b ON b.postId = p.id
+            WHERE b.memberId = :memberId AND p.deleted = false
+            ORDER BY b.createdAt DESC
+            """)
+    Slice<CommunityPostEntity> findBookmarkedPosts(@Param("memberId") Long memberId,
+                                                   Pageable pageable);
 }

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/BookmarkService.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/BookmarkService.java
@@ -2,24 +2,37 @@ package com.example.lolserver.community.application;
 
 import com.example.lolserver.common.error.CoreException;
 import com.example.lolserver.common.error.ErrorType;
+import com.example.lolserver.common.support.SliceResult;
+import com.example.lolserver.community.application.model.readmodel.AuthorReadModel;
+import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
+import com.example.lolserver.community.application.port.in.BookmarkQueryUseCase;
 import com.example.lolserver.community.application.port.in.BookmarkUseCase;
 import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
 import com.example.lolserver.community.application.port.out.PostPersistencePort;
 import com.example.lolserver.community.domain.Bookmark;
 import com.example.lolserver.community.domain.Post;
+import com.example.lolserver.member.application.model.readmodel.MemberProfileReadModel;
+import com.example.lolserver.member.application.port.in.MemberQueryUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class BookmarkService implements BookmarkUseCase {
+public class BookmarkService implements BookmarkUseCase, BookmarkQueryUseCase {
 
     private final BookmarkPersistencePort bookmarkPersistencePort;
     private final PostPersistencePort postPersistencePort;
+    private final MemberQueryUseCase memberQueryUseCase;
 
     @Override
     @Transactional
@@ -48,5 +61,47 @@ public class BookmarkService implements BookmarkUseCase {
                 .orElseThrow(() -> new CoreException(ErrorType.BOOKMARK_NOT_FOUND));
 
         bookmarkPersistencePort.delete(bookmark);
+    }
+
+    @Override
+    public SliceResult<PostListReadModel> getMyBookmarks(Long memberId, int page) {
+        return enrichAuthors(bookmarkPersistencePort.findBookmarkedPosts(memberId, page));
+    }
+
+    /**
+     * 목록의 작성자 정보를 member port.in 으로 배치 보강한다.
+     * 보강하지 않으면 북마크 목록에서만 작성자가 비어 보인다.
+     *
+     * <p>PostService 에 같은 로직이 있다. 호출부가 4곳(목록·검색·내글·북마크)이 되었으므로
+     * 공용 컴포넌트로 추출할 만하지만, PostService 의 기존 테스트가 이 동작을 직접
+     * 검증하고 있어 이번 기능과 분리해 별도로 다룬다.
+     */
+    private SliceResult<PostListReadModel> enrichAuthors(SliceResult<PostListReadModel> slice) {
+        List<Long> authorIds = slice.getContent().stream()
+                .map(PostListReadModel::getAuthorId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        // 빈 목록에 회원 조회를 날리지 않는다.
+        if (authorIds.isEmpty()) {
+            return slice;
+        }
+
+        Map<Long, MemberProfileReadModel> profiles =
+                memberQueryUseCase.getMemberProfiles(authorIds).stream()
+                        .collect(Collectors.toMap(MemberProfileReadModel::getId, Function.identity()));
+
+        List<PostListReadModel> content = slice.getContent().stream()
+                .map(rm -> rm.toBuilder()
+                        .author(toAuthor(profiles.get(rm.getAuthorId())))
+                        .build())
+                .toList();
+
+        return new SliceResult<>(content, slice.isHasNext());
+    }
+
+    private AuthorReadModel toAuthor(MemberProfileReadModel profile) {
+        return profile != null ? AuthorReadModel.of(profile) : null;
     }
 }

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/BookmarkService.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/BookmarkService.java
@@ -1,0 +1,52 @@
+package com.example.lolserver.community.application;
+
+import com.example.lolserver.common.error.CoreException;
+import com.example.lolserver.common.error.ErrorType;
+import com.example.lolserver.community.application.port.in.BookmarkUseCase;
+import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
+import com.example.lolserver.community.application.port.out.PostPersistencePort;
+import com.example.lolserver.community.domain.Bookmark;
+import com.example.lolserver.community.domain.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BookmarkService implements BookmarkUseCase {
+
+    private final BookmarkPersistencePort bookmarkPersistencePort;
+    private final PostPersistencePort postPersistencePort;
+
+    @Override
+    @Transactional
+    public void addBookmark(Long memberId, Long postId) {
+        Post post = postPersistencePort.findById(postId)
+                .orElseThrow(() -> new CoreException(ErrorType.POST_NOT_FOUND));
+        post.validateNotDeleted();
+
+        // 사전 조회로 막지만 최종 방어선은 uq_cb_member_post 다.
+        // 동시 요청 두 건은 둘 다 이 조회를 통과할 수 있다.
+        bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId)
+                .ifPresent(bookmark -> {
+                    throw new CoreException(ErrorType.BOOKMARK_ALREADY_EXISTS);
+                });
+
+        bookmarkPersistencePort.save(Bookmark.create(memberId, postId));
+    }
+
+    @Override
+    @Transactional
+    public void removeBookmark(Long memberId, Long postId) {
+        // 게시글 존재 여부는 확인하지 않는다. 글이 지워졌다고 내 북마크가
+        // 남아있으면 목록에서 영영 못 지운다.
+        Bookmark bookmark = bookmarkPersistencePort
+                .findByMemberIdAndPostId(memberId, postId)
+                .orElseThrow(() -> new CoreException(ErrorType.BOOKMARK_NOT_FOUND));
+
+        bookmarkPersistencePort.delete(bookmark);
+    }
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/BookmarkService.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/BookmarkService.java
@@ -41,12 +41,11 @@ public class BookmarkService implements BookmarkUseCase, BookmarkQueryUseCase {
                 .orElseThrow(() -> new CoreException(ErrorType.POST_NOT_FOUND));
         post.validateNotDeleted();
 
-        // 사전 조회로 막지만 최종 방어선은 uq_cb_member_post 다.
-        // 동시 요청 두 건은 둘 다 이 조회를 통과할 수 있다.
-        bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId)
-                .ifPresent(bookmark -> {
-                    throw new CoreException(ErrorType.BOOKMARK_ALREADY_EXISTS);
-                });
+        // 동시 요청 두 건은 둘 다 이 조회를 통과할 수 있다. 그때는 uq_cb_member_post 가
+        // 걸리고, 어댑터가 같은 BOOKMARK_ALREADY_EXISTS 로 변환한다.
+        if (bookmarkPersistencePort.existsByMemberIdAndPostId(memberId, postId)) {
+            throw new CoreException(ErrorType.BOOKMARK_ALREADY_EXISTS);
+        }
 
         bookmarkPersistencePort.save(Bookmark.create(memberId, postId));
     }
@@ -65,6 +64,11 @@ public class BookmarkService implements BookmarkUseCase, BookmarkQueryUseCase {
 
     @Override
     public SliceResult<PostListReadModel> getMyBookmarks(Long memberId, int page) {
+        // PageRequest.of 는 음수에 IllegalArgumentException 을 던지고, 그건 처리되지 않아
+        // 500 이 된다. 잘못된 입력이므로 400 으로 돌려준다.
+        if (page < 0) {
+            throw new CoreException(ErrorType.INVALID_INPUT);
+        }
         return enrichAuthors(bookmarkPersistencePort.findBookmarkedPosts(memberId, page));
     }
 

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/PostService.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/PostService.java
@@ -77,7 +77,7 @@ public class PostService implements PostUseCase, PostQueryUseCase {
         // false 로 고정하면 자기 글을 북마크한 뒤 수정했을 때 응답이 해제 상태로
         // 돌아와 클라이언트 캐시가 뒤집힌다. 실제 상태를 조회한다.
         boolean bookmarked = bookmarkPersistencePort
-                .findByMemberIdAndPostId(memberId, postId).isPresent();
+                .existsByMemberIdAndPostId(memberId, postId);
 
         return PostDetailResultModel.of(saved, author, null, bookmarked);
     }
@@ -117,7 +117,7 @@ public class PostService implements PostUseCase, PostQueryUseCase {
         // 비로그인은 조회 없이 false. null 이 아니라 false 여야 응답에서 모호해지지 않는다.
         boolean currentUserBookmarked = currentMemberId != null
                 && bookmarkPersistencePort
-                        .findByMemberIdAndPostId(currentMemberId, postId).isPresent();
+                        .existsByMemberIdAndPostId(currentMemberId, postId);
 
         return PostDetailReadModel.of(post, author, currentUserVote, currentUserBookmarked);
     }
@@ -147,6 +147,11 @@ public class PostService implements PostUseCase, PostQueryUseCase {
                 .filter(Objects::nonNull)
                 .distinct()
                 .toList();
+
+        // 빈 목록에 회원 조회를 날리지 않는다.
+        if (authorIds.isEmpty()) {
+            return slice;
+        }
 
         Map<Long, MemberProfileReadModel> profiles = memberQueryUseCase.getMemberProfiles(authorIds).stream()
                 .collect(Collectors.toMap(MemberProfileReadModel::getId, Function.identity()));

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/PostService.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/PostService.java
@@ -9,6 +9,7 @@ import com.example.lolserver.community.application.model.readmodel.PostListReadM
 import com.example.lolserver.community.application.model.resultmodel.PostDetailResultModel;
 import com.example.lolserver.community.application.port.in.PostQueryUseCase;
 import com.example.lolserver.community.application.port.in.PostUseCase;
+import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
 import com.example.lolserver.community.application.port.out.PostPersistencePort;
 import com.example.lolserver.community.application.port.out.VotePersistencePort;
 import com.example.lolserver.community.domain.Post;
@@ -39,6 +40,7 @@ public class PostService implements PostUseCase, PostQueryUseCase {
 
     private final PostPersistencePort postPersistencePort;
     private final MemberQueryUseCase memberQueryUseCase;
+    private final BookmarkPersistencePort bookmarkPersistencePort;
     private final VotePersistencePort votePersistencePort;
 
     @Override
@@ -53,7 +55,8 @@ public class PostService implements PostUseCase, PostQueryUseCase {
 
         Post saved = postPersistencePort.save(post);
 
-        return PostDetailResultModel.of(saved, author, null);
+        // 방금 만든 글이므로 북마크되어 있을 수 없다.
+        return PostDetailResultModel.of(saved, author, null, false);
     }
 
     @Override
@@ -71,7 +74,12 @@ public class PostService implements PostUseCase, PostQueryUseCase {
 
         MemberProfileReadModel author = memberQueryUseCase.getMemberProfile(memberId);
 
-        return PostDetailResultModel.of(saved, author, null);
+        // false 로 고정하면 자기 글을 북마크한 뒤 수정했을 때 응답이 해제 상태로
+        // 돌아와 클라이언트 캐시가 뒤집힌다. 실제 상태를 조회한다.
+        boolean bookmarked = bookmarkPersistencePort
+                .findByMemberIdAndPostId(memberId, postId).isPresent();
+
+        return PostDetailResultModel.of(saved, author, null, bookmarked);
     }
 
     @Override
@@ -106,7 +114,12 @@ public class PostService implements PostUseCase, PostQueryUseCase {
                     .orElse(null);
         }
 
-        return PostDetailReadModel.of(post, author, currentUserVote);
+        // 비로그인은 조회 없이 false. null 이 아니라 false 여야 응답에서 모호해지지 않는다.
+        boolean currentUserBookmarked = currentMemberId != null
+                && bookmarkPersistencePort
+                        .findByMemberIdAndPostId(currentMemberId, postId).isPresent();
+
+        return PostDetailReadModel.of(post, author, currentUserVote, currentUserBookmarked);
     }
 
     @Override

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/model/readmodel/PostDetailReadModel.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/model/readmodel/PostDetailReadModel.java
@@ -25,10 +25,12 @@ public class PostDetailReadModel {
     private final int commentCount;
     private final AuthorReadModel author;
     private final VoteType currentUserVote;
+    private final boolean currentUserBookmarked;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public static PostDetailReadModel of(Post post, MemberProfileReadModel author, Vote currentUserVote) {
+    public static PostDetailReadModel of(Post post, MemberProfileReadModel author, Vote currentUserVote,
+                                         boolean currentUserBookmarked) {
         return PostDetailReadModel.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -42,6 +44,7 @@ public class PostDetailReadModel {
                 .currentUserVote(
                         currentUserVote != null
                                 ? currentUserVote.getVoteType() : null)
+                .currentUserBookmarked(currentUserBookmarked)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/model/resultmodel/PostDetailResultModel.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/model/resultmodel/PostDetailResultModel.java
@@ -26,10 +26,12 @@ public class PostDetailResultModel {
     private final int commentCount;
     private final AuthorReadModel author;
     private final VoteType currentUserVote;
+    private final boolean currentUserBookmarked;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
 
-    public static PostDetailResultModel of(Post post, MemberProfileReadModel author, Vote currentUserVote) {
+    public static PostDetailResultModel of(Post post, MemberProfileReadModel author, Vote currentUserVote,
+                                           boolean currentUserBookmarked) {
         return PostDetailResultModel.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -43,6 +45,7 @@ public class PostDetailResultModel {
                 .currentUserVote(
                         currentUserVote != null
                                 ? currentUserVote.getVoteType() : null)
+                .currentUserBookmarked(currentUserBookmarked)
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
                 .build();

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/port/in/BookmarkQueryUseCase.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/port/in/BookmarkQueryUseCase.java
@@ -1,0 +1,9 @@
+package com.example.lolserver.community.application.port.in;
+
+import com.example.lolserver.common.support.SliceResult;
+import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
+
+public interface BookmarkQueryUseCase {
+
+    SliceResult<PostListReadModel> getMyBookmarks(Long memberId, int page);
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/port/in/BookmarkUseCase.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/port/in/BookmarkUseCase.java
@@ -1,0 +1,8 @@
+package com.example.lolserver.community.application.port.in;
+
+public interface BookmarkUseCase {
+
+    void addBookmark(Long memberId, Long postId);
+
+    void removeBookmark(Long memberId, Long postId);
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/port/out/BookmarkPersistencePort.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/port/out/BookmarkPersistencePort.java
@@ -1,5 +1,7 @@
 package com.example.lolserver.community.application.port.out;
 
+import com.example.lolserver.common.support.SliceResult;
+import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
 import com.example.lolserver.community.domain.Bookmark;
 
 import java.util.Optional;
@@ -15,4 +17,9 @@ public interface BookmarkPersistencePort {
     Optional<Bookmark> findByMemberIdAndPostId(Long memberId, Long postId);
 
     void delete(Bookmark bookmark);
+
+    /**
+     * 북마크한 게시글 목록. 북마크 시각 기준 최신순이며 삭제된 글은 제외한다.
+     */
+    SliceResult<PostListReadModel> findBookmarkedPosts(Long memberId, int page);
 }

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/port/out/BookmarkPersistencePort.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/port/out/BookmarkPersistencePort.java
@@ -1,0 +1,18 @@
+package com.example.lolserver.community.application.port.out;
+
+import com.example.lolserver.community.domain.Bookmark;
+
+import java.util.Optional;
+
+public interface BookmarkPersistencePort {
+
+    Bookmark save(Bookmark bookmark);
+
+    /**
+     * 중복 북마크(409)와 미존재 북마크 해제(404)를 모두 이 한 번의 조회로 판정한다.
+     * VotePersistencePort 의 findByMemberIdAndTargetTypeAndTargetId 와 같은 역할.
+     */
+    Optional<Bookmark> findByMemberIdAndPostId(Long memberId, Long postId);
+
+    void delete(Bookmark bookmark);
+}

--- a/module/domain/community/src/main/java/com/example/lolserver/community/application/port/out/BookmarkPersistencePort.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/application/port/out/BookmarkPersistencePort.java
@@ -16,6 +16,12 @@ public interface BookmarkPersistencePort {
      */
     Optional<Bookmark> findByMemberIdAndPostId(Long memberId, Long postId);
 
+    /**
+     * 존재 여부만 필요할 때 쓴다. 엔티티를 통째로 읽어 즉시 버리지 않기 위함이며,
+     * 특히 게시글 상세 조회는 최다 호출 읽기 경로다.
+     */
+    boolean existsByMemberIdAndPostId(Long memberId, Long postId);
+
     void delete(Bookmark bookmark);
 
     /**

--- a/module/domain/community/src/main/java/com/example/lolserver/community/domain/Bookmark.java
+++ b/module/domain/community/src/main/java/com/example/lolserver/community/domain/Bookmark.java
@@ -1,0 +1,27 @@
+package com.example.lolserver.community.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Bookmark {
+
+    private Long id;
+    private Long memberId;
+    private Long postId;
+    private LocalDateTime createdAt;
+
+    public static Bookmark create(Long memberId, Long postId) {
+        return Bookmark.builder()
+                .memberId(memberId)
+                .postId(postId)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/module/domain/community/src/test/java/com/example/lolserver/community/adapter/out/persistence/BookmarkPersistenceAdapterTest.java
+++ b/module/domain/community/src/test/java/com/example/lolserver/community/adapter/out/persistence/BookmarkPersistenceAdapterTest.java
@@ -1,0 +1,161 @@
+package com.example.lolserver.community.adapter.out.persistence;
+
+import com.example.lolserver.common.error.CoreException;
+import com.example.lolserver.common.error.ErrorType;
+import com.example.lolserver.common.support.SliceResult;
+import com.example.lolserver.common.test.RepositoryTestBase;
+import com.example.lolserver.community.adapter.out.persistence.adapter.BookmarkPersistenceAdapter;
+import com.example.lolserver.community.adapter.out.persistence.entity.CommunityPostEntity;
+import com.example.lolserver.community.adapter.out.persistence.repository.CommunityPostJpaRepository;
+import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
+import com.example.lolserver.community.domain.Bookmark;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * JPQL 조인 쿼리와 UNIQUE 제약은 단위 테스트로 검증할 수 없다.
+ * @Query 는 컴파일이 아니라 리포지토리 부트스트랩 시점에 파싱되므로,
+ * 이 테스트가 없으면 쿼리가 깨져도 CI 는 green 이고 운영 기동에서 처음 터진다.
+ */
+class BookmarkPersistenceAdapterTest extends RepositoryTestBase {
+
+    @Autowired
+    private BookmarkPersistenceAdapter bookmarkPersistenceAdapter;
+
+    @Autowired
+    private CommunityPostJpaRepository postJpaRepository;
+
+    @DisplayName("북마크한 글 목록은 글 작성 시각이 아니라 북마크한 시각의 최신순으로 나온다")
+    @Test
+    void findBookmarkedPosts_orderedByBookmarkedAt() {
+        // given — 글은 오래된 순으로 만들고, 북마크는 그 반대 순으로 담는다
+        Long memberId = 1L;
+        Long oldPostId = savePost("오래된 글", false);
+        Long newPostId = savePost("새 글", false);
+
+        bookmarkAt(memberId, newPostId, LocalDateTime.now().minusDays(2));
+        bookmarkAt(memberId, oldPostId, LocalDateTime.now().minusHours(1));
+
+        // when
+        SliceResult<PostListReadModel> result =
+                bookmarkPersistenceAdapter.findBookmarkedPosts(memberId, 0);
+
+        // then — 최근에 담은 "오래된 글" 이 먼저 나와야 한다
+        assertThat(result.getContent()).extracting(PostListReadModel::getTitle)
+                .containsExactly("오래된 글", "새 글");
+    }
+
+    @DisplayName("삭제된 글은 북마크 목록에서 제외된다")
+    @Test
+    void findBookmarkedPosts_excludesDeletedPost() {
+        // given
+        Long memberId = 1L;
+        Long alive = savePost("살아있는 글", false);
+        Long deleted = savePost("삭제된 글", true);
+        bookmarkAt(memberId, alive, LocalDateTime.now());
+        bookmarkAt(memberId, deleted, LocalDateTime.now());
+
+        // when
+        SliceResult<PostListReadModel> result =
+                bookmarkPersistenceAdapter.findBookmarkedPosts(memberId, 0);
+
+        // then
+        assertThat(result.getContent()).extracting(PostListReadModel::getTitle)
+                .containsExactly("살아있는 글");
+    }
+
+    @DisplayName("다른 회원의 북마크는 섞이지 않는다")
+    @Test
+    void findBookmarkedPosts_isolatedPerMember() {
+        // given
+        Long postId = savePost("공용 글", false);
+        bookmarkAt(1L, postId, LocalDateTime.now());
+
+        // when
+        SliceResult<PostListReadModel> result =
+                bookmarkPersistenceAdapter.findBookmarkedPosts(2L, 0);
+
+        // then
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @DisplayName("페이지 크기(20)를 넘으면 hasNext 가 true 이고 초과분은 잘린다")
+    @Test
+    void findBookmarkedPosts_hasNext() {
+        // given — 21건
+        Long memberId = 1L;
+        for (int i = 0; i < 21; i++) {
+            bookmarkAt(memberId, savePost("글 " + i, false),
+                    LocalDateTime.now().minusMinutes(i));
+        }
+
+        // when
+        SliceResult<PostListReadModel> first =
+                bookmarkPersistenceAdapter.findBookmarkedPosts(memberId, 0);
+        SliceResult<PostListReadModel> second =
+                bookmarkPersistenceAdapter.findBookmarkedPosts(memberId, 1);
+
+        // then
+        assertThat(first.getContent()).hasSize(20);
+        assertThat(first.isHasNext()).isTrue();
+        assertThat(second.getContent()).hasSize(1);
+        assertThat(second.isHasNext()).isFalse();
+    }
+
+    @DisplayName("같은 회원이 같은 글을 두 번 북마크하면 BOOKMARK_ALREADY_EXISTS 로 변환된다")
+    @Test
+    void save_duplicate_translatesToDomainError() {
+        // given — 서비스의 사전 조회를 통과한 동시 요청 두 건과 같은 상황
+        Long memberId = 1L;
+        Long postId = savePost("글", false);
+        bookmarkPersistenceAdapter.save(Bookmark.create(memberId, postId));
+
+        // when & then — DataIntegrityViolationException 이 그대로 새어나가면 500 이 된다
+        assertThatThrownBy(() ->
+                bookmarkPersistenceAdapter.save(Bookmark.create(memberId, postId)))
+                .isInstanceOf(CoreException.class)
+                .extracting(e -> ((CoreException) e).getErrorType())
+                .isEqualTo(ErrorType.BOOKMARK_ALREADY_EXISTS);
+    }
+
+    @DisplayName("다른 회원이 같은 글을 북마크하는 것은 허용된다")
+    @Test
+    void save_differentMemberSamePost_allowed() {
+        // given
+        Long postId = savePost("글", false);
+        bookmarkPersistenceAdapter.save(Bookmark.create(1L, postId));
+
+        // when
+        Bookmark saved = bookmarkPersistenceAdapter.save(Bookmark.create(2L, postId));
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+    }
+
+    private Long savePost(String title, boolean deleted) {
+        LocalDateTime now = LocalDateTime.now();
+        return postJpaRepository.save(CommunityPostEntity.builder()
+                .memberId(99L)
+                .title(title)
+                .content("내용")
+                .category("GENERAL")
+                .deleted(deleted)
+                .createdAt(now)
+                .updatedAt(now)
+                .build()).getId();
+    }
+
+    private void bookmarkAt(Long memberId, Long postId, LocalDateTime bookmarkedAt) {
+        bookmarkPersistenceAdapter.save(Bookmark.builder()
+                .memberId(memberId)
+                .postId(postId)
+                .createdAt(bookmarkedAt)
+                .build());
+    }
+}

--- a/module/domain/community/src/test/java/com/example/lolserver/community/application/BookmarkServiceTest.java
+++ b/module/domain/community/src/test/java/com/example/lolserver/community/application/BookmarkServiceTest.java
@@ -2,10 +2,14 @@ package com.example.lolserver.community.application;
 
 import com.example.lolserver.common.error.CoreException;
 import com.example.lolserver.common.error.ErrorType;
+import com.example.lolserver.common.support.SliceResult;
+import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
 import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
 import com.example.lolserver.community.application.port.out.PostPersistencePort;
 import com.example.lolserver.community.domain.Bookmark;
 import com.example.lolserver.community.domain.Post;
+import com.example.lolserver.member.application.model.readmodel.MemberProfileReadModel;
+import com.example.lolserver.member.application.port.in.MemberQueryUseCase;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,8 +18,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -30,6 +36,9 @@ class BookmarkServiceTest {
 
     @Mock
     private PostPersistencePort postPersistencePort;
+
+    @Mock
+    private MemberQueryUseCase memberQueryUseCase;
 
     @InjectMocks
     private BookmarkService bookmarkService;
@@ -153,6 +162,52 @@ class BookmarkServiceTest {
         // then
         then(bookmarkPersistencePort).should().delete(bookmark);
         then(postPersistencePort).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("내 북마크 목록을 조회하면 작성자가 보강된 페이지 결과를 반환한다")
+    @Test
+    void getMyBookmarks_enrichesAuthor() {
+        // given — 영속성은 authorId 만 채워주고 author 는 비어 있다
+        Long memberId = 1L;
+        int page = 2;
+        PostListReadModel item = PostListReadModel.builder()
+                .id(10L).title("제목").category("GENERAL")
+                .authorId(7L)
+                .createdAt(LocalDateTime.now())
+                .build();
+        given(bookmarkPersistencePort.findBookmarkedPosts(memberId, page))
+                .willReturn(new SliceResult<>(List.of(item), true));
+        given(memberQueryUseCase.getMemberProfiles(List.of(7L)))
+                .willReturn(List.of(MemberProfileReadModel.builder()
+                        .id(7L).nickname("테스터")
+                        .profileImageUrl("http://img/7").build()));
+
+        // when
+        SliceResult<PostListReadModel> result =
+                bookmarkService.getMyBookmarks(memberId, page);
+
+        // then — 게시글 목록과 동일하게 author 가 채워져야 한다.
+        // 안 채우면 북마크 목록에서만 작성자가 비어 보인다.
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getAuthor()).isNotNull();
+        assertThat(result.getContent().get(0).getAuthor().id()).isEqualTo(7L);
+        assertThat(result.getContent().get(0).getAuthor().nickname()).isEqualTo("테스터");
+        assertThat(result.isHasNext()).isTrue();
+    }
+
+    @DisplayName("북마크 목록이 비어 있으면 회원 조회를 하지 않는다")
+    @Test
+    void getMyBookmarks_empty_skipsMemberLookup() {
+        // given
+        given(bookmarkPersistencePort.findBookmarkedPosts(1L, 0))
+                .willReturn(new SliceResult<>(List.of(), false));
+
+        // when
+        SliceResult<PostListReadModel> result = bookmarkService.getMyBookmarks(1L, 0);
+
+        // then — 빈 목록에 회원 조회를 날리면 불필요한 쿼리가 된다
+        assertThat(result.getContent()).isEmpty();
+        then(memberQueryUseCase).shouldHaveNoInteractions();
     }
 
     private Post createPost(Long postId, boolean deleted) {

--- a/module/domain/community/src/test/java/com/example/lolserver/community/application/BookmarkServiceTest.java
+++ b/module/domain/community/src/test/java/com/example/lolserver/community/application/BookmarkServiceTest.java
@@ -1,0 +1,170 @@
+package com.example.lolserver.community.application;
+
+import com.example.lolserver.common.error.CoreException;
+import com.example.lolserver.common.error.ErrorType;
+import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
+import com.example.lolserver.community.application.port.out.PostPersistencePort;
+import com.example.lolserver.community.domain.Bookmark;
+import com.example.lolserver.community.domain.Post;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class BookmarkServiceTest {
+
+    @Mock
+    private BookmarkPersistencePort bookmarkPersistencePort;
+
+    @Mock
+    private PostPersistencePort postPersistencePort;
+
+    @InjectMocks
+    private BookmarkService bookmarkService;
+
+    @DisplayName("북마크하지 않은 게시글을 북마크하면 저장된다")
+    @Test
+    void addBookmark_success() {
+        // given
+        Long memberId = 1L;
+        Long postId = 10L;
+        given(postPersistencePort.findById(postId))
+                .willReturn(Optional.of(createPost(postId, false)));
+        given(bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId))
+                .willReturn(Optional.empty());
+
+        // when
+        bookmarkService.addBookmark(memberId, postId);
+
+        // then
+        then(bookmarkPersistencePort).should().save(any(Bookmark.class));
+    }
+
+    @DisplayName("이미 북마크한 게시글을 다시 북마크하면 예외가 발생한다")
+    @Test
+    void addBookmark_alreadyExists() {
+        // given
+        Long memberId = 1L;
+        Long postId = 10L;
+        given(postPersistencePort.findById(postId))
+                .willReturn(Optional.of(createPost(postId, false)));
+        given(bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId))
+                .willReturn(Optional.of(Bookmark.create(memberId, postId)));
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.addBookmark(memberId, postId))
+                .isInstanceOf(CoreException.class)
+                .extracting(e -> ((CoreException) e).getErrorType())
+                .isEqualTo(ErrorType.BOOKMARK_ALREADY_EXISTS);
+        then(bookmarkPersistencePort).should(never()).save(any());
+    }
+
+    @DisplayName("존재하지 않는 게시글을 북마크하면 예외가 발생한다")
+    @Test
+    void addBookmark_postNotFound() {
+        // given
+        Long memberId = 1L;
+        Long postId = 999L;
+        given(postPersistencePort.findById(postId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.addBookmark(memberId, postId))
+                .isInstanceOf(CoreException.class)
+                .extracting(e -> ((CoreException) e).getErrorType())
+                .isEqualTo(ErrorType.POST_NOT_FOUND);
+        then(bookmarkPersistencePort).should(never()).save(any());
+    }
+
+    @DisplayName("삭제된 게시글을 북마크하면 예외가 발생한다")
+    @Test
+    void addBookmark_deletedPost() {
+        // given
+        Long memberId = 1L;
+        Long postId = 10L;
+        given(postPersistencePort.findById(postId))
+                .willReturn(Optional.of(createPost(postId, true)));
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.addBookmark(memberId, postId))
+                .isInstanceOf(CoreException.class)
+                .extracting(e -> ((CoreException) e).getErrorType())
+                .isEqualTo(ErrorType.POST_NOT_FOUND);
+        then(bookmarkPersistencePort).should(never()).save(any());
+    }
+
+    @DisplayName("북마크한 게시글을 해제하면 삭제된다")
+    @Test
+    void removeBookmark_success() {
+        // given
+        Long memberId = 1L;
+        Long postId = 10L;
+        Bookmark bookmark = Bookmark.create(memberId, postId);
+        given(bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId))
+                .willReturn(Optional.of(bookmark));
+
+        // when
+        bookmarkService.removeBookmark(memberId, postId);
+
+        // then
+        then(bookmarkPersistencePort).should().delete(bookmark);
+    }
+
+    @DisplayName("북마크하지 않은 게시글을 해제하면 예외가 발생한다")
+    @Test
+    void removeBookmark_notFound() {
+        // given
+        Long memberId = 1L;
+        Long postId = 10L;
+        given(bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> bookmarkService.removeBookmark(memberId, postId))
+                .isInstanceOf(CoreException.class)
+                .extracting(e -> ((CoreException) e).getErrorType())
+                .isEqualTo(ErrorType.BOOKMARK_NOT_FOUND);
+    }
+
+    @DisplayName("삭제된 게시글의 북마크는 해제할 수 있다")
+    @Test
+    void removeBookmark_deletedPost_allowed() {
+        // given — 글이 지워졌다고 내 북마크가 남아있으면 안 되므로 해제는 막지 않는다
+        Long memberId = 1L;
+        Long postId = 10L;
+        Bookmark bookmark = Bookmark.create(memberId, postId);
+        given(bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId))
+                .willReturn(Optional.of(bookmark));
+
+        // when
+        bookmarkService.removeBookmark(memberId, postId);
+
+        // then
+        then(bookmarkPersistencePort).should().delete(bookmark);
+        then(postPersistencePort).shouldHaveNoInteractions();
+    }
+
+    private Post createPost(Long postId, boolean deleted) {
+        return Post.builder()
+                .id(postId)
+                .memberId(2L)
+                .title("제목")
+                .content("내용")
+                .category("GENERAL")
+                .deleted(deleted)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/module/domain/community/src/test/java/com/example/lolserver/community/application/BookmarkServiceTest.java
+++ b/module/domain/community/src/test/java/com/example/lolserver/community/application/BookmarkServiceTest.java
@@ -51,8 +51,8 @@ class BookmarkServiceTest {
         Long postId = 10L;
         given(postPersistencePort.findById(postId))
                 .willReturn(Optional.of(createPost(postId, false)));
-        given(bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId))
-                .willReturn(Optional.empty());
+        given(bookmarkPersistencePort.existsByMemberIdAndPostId(memberId, postId))
+                .willReturn(false);
 
         // when
         bookmarkService.addBookmark(memberId, postId);
@@ -69,8 +69,8 @@ class BookmarkServiceTest {
         Long postId = 10L;
         given(postPersistencePort.findById(postId))
                 .willReturn(Optional.of(createPost(postId, false)));
-        given(bookmarkPersistencePort.findByMemberIdAndPostId(memberId, postId))
-                .willReturn(Optional.of(Bookmark.create(memberId, postId)));
+        given(bookmarkPersistencePort.existsByMemberIdAndPostId(memberId, postId))
+                .willReturn(true);
 
         // when & then
         assertThatThrownBy(() -> bookmarkService.addBookmark(memberId, postId))
@@ -208,6 +208,17 @@ class BookmarkServiceTest {
         // then — 빈 목록에 회원 조회를 날리면 불필요한 쿼리가 된다
         assertThat(result.getContent()).isEmpty();
         then(memberQueryUseCase).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("page 가 음수면 500 이 아니라 INVALID_INPUT 으로 막는다")
+    @Test
+    void getMyBookmarks_negativePage() {
+        // when & then — PageRequest.of 까지 내려가면 IllegalArgumentException 으로 500 이 된다
+        assertThatThrownBy(() -> bookmarkService.getMyBookmarks(1L, -1))
+                .isInstanceOf(CoreException.class)
+                .extracting(e -> ((CoreException) e).getErrorType())
+                .isEqualTo(ErrorType.INVALID_INPUT);
+        then(bookmarkPersistencePort).shouldHaveNoInteractions();
     }
 
     private Post createPost(Long postId, boolean deleted) {

--- a/module/domain/community/src/test/java/com/example/lolserver/community/application/PostServiceTest.java
+++ b/module/domain/community/src/test/java/com/example/lolserver/community/application/PostServiceTest.java
@@ -6,8 +6,10 @@ import com.example.lolserver.community.application.command.UpdatePostCommand;
 import com.example.lolserver.community.application.model.readmodel.PostDetailReadModel;
 import com.example.lolserver.community.application.model.readmodel.PostListReadModel;
 import com.example.lolserver.community.application.model.resultmodel.PostDetailResultModel;
+import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
 import com.example.lolserver.community.application.port.out.PostPersistencePort;
 import com.example.lolserver.community.application.port.out.VotePersistencePort;
+import com.example.lolserver.community.domain.Bookmark;
 import com.example.lolserver.community.domain.Post;
 import com.example.lolserver.community.domain.vo.SortType;
 import com.example.lolserver.member.application.model.readmodel.MemberProfileReadModel;
@@ -40,6 +42,9 @@ class PostServiceTest {
 
     @Mock
     private MemberQueryUseCase memberQueryUseCase;
+
+    @Mock
+    private BookmarkPersistencePort bookmarkPersistencePort;
 
     @Mock
     private VotePersistencePort votePersistencePort;
@@ -200,6 +205,67 @@ class PostServiceTest {
         // then
         assertThat(result.getId()).isEqualTo(postId);
         then(postPersistencePort).should().incrementViewCount(postId);
+    }
+
+    @DisplayName("비로그인 상세 조회 시 북마크 여부는 false 이고 북마크를 조회하지 않는다")
+    @Test
+    void getPost_anonymous_bookmarkFalse() {
+        // given
+        Long postId = 1L;
+        Long authorId = 1L;
+        given(postPersistencePort.findById(postId))
+                .willReturn(Optional.of(createPost(postId, authorId)));
+        given(memberQueryUseCase.getMemberProfile(authorId))
+                .willReturn(createProfile(authorId));
+
+        // when
+        PostDetailReadModel result = postService.getPost(postId, null);
+
+        // then — null 이 아니라 false 여야 한다 (응답에서 구분 불가한 값이 되면 안 된다)
+        assertThat(result.isCurrentUserBookmarked()).isFalse();
+        then(bookmarkPersistencePort).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("북마크한 게시글을 상세 조회하면 북마크 여부가 true 이다")
+    @Test
+    void getPost_bookmarked_returnsTrue() {
+        // given
+        Long postId = 1L;
+        Long authorId = 1L;
+        Long viewerId = 99L;
+        given(postPersistencePort.findById(postId))
+                .willReturn(Optional.of(createPost(postId, authorId)));
+        given(memberQueryUseCase.getMemberProfile(authorId))
+                .willReturn(createProfile(authorId));
+        given(bookmarkPersistencePort.findByMemberIdAndPostId(viewerId, postId))
+                .willReturn(Optional.of(Bookmark.create(viewerId, postId)));
+
+        // when
+        PostDetailReadModel result = postService.getPost(postId, viewerId);
+
+        // then
+        assertThat(result.isCurrentUserBookmarked()).isTrue();
+    }
+
+    @DisplayName("북마크하지 않은 게시글을 상세 조회하면 북마크 여부가 false 이다")
+    @Test
+    void getPost_notBookmarked_returnsFalse() {
+        // given
+        Long postId = 1L;
+        Long authorId = 1L;
+        Long viewerId = 99L;
+        given(postPersistencePort.findById(postId))
+                .willReturn(Optional.of(createPost(postId, authorId)));
+        given(memberQueryUseCase.getMemberProfile(authorId))
+                .willReturn(createProfile(authorId));
+        given(bookmarkPersistencePort.findByMemberIdAndPostId(viewerId, postId))
+                .willReturn(Optional.empty());
+
+        // when
+        PostDetailReadModel result = postService.getPost(postId, viewerId);
+
+        // then
+        assertThat(result.isCurrentUserBookmarked()).isFalse();
     }
 
     @DisplayName("게시글 목록을 조회하면 작성자가 보강된 페이지 결과를 반환한다")

--- a/module/domain/community/src/test/java/com/example/lolserver/community/application/PostServiceTest.java
+++ b/module/domain/community/src/test/java/com/example/lolserver/community/application/PostServiceTest.java
@@ -9,7 +9,6 @@ import com.example.lolserver.community.application.model.resultmodel.PostDetailR
 import com.example.lolserver.community.application.port.out.BookmarkPersistencePort;
 import com.example.lolserver.community.application.port.out.PostPersistencePort;
 import com.example.lolserver.community.application.port.out.VotePersistencePort;
-import com.example.lolserver.community.domain.Bookmark;
 import com.example.lolserver.community.domain.Post;
 import com.example.lolserver.community.domain.vo.SortType;
 import com.example.lolserver.member.application.model.readmodel.MemberProfileReadModel;
@@ -126,6 +125,52 @@ class PostServiceTest {
         assertThat(result).isNotNull();
     }
 
+    @DisplayName("북마크한 자기 글을 수정해도 응답의 북마크 여부는 true 로 유지된다")
+    @Test
+    void updatePost_keepsBookmarkedState() {
+        // given — false 로 고정하면 클라이언트 캐시가 해제 상태로 뒤집힌다
+        Long memberId = 1L;
+        Long postId = 1L;
+        UpdatePostCommand command = UpdatePostCommand.builder()
+                .title("수정된 제목").content("수정된 내용").category("GENERAL")
+                .build();
+        Post post = createPost(postId, memberId);
+
+        given(postPersistencePort.findById(postId)).willReturn(Optional.of(post));
+        given(postPersistencePort.save(any(Post.class))).willReturn(post);
+        given(memberQueryUseCase.getMemberProfile(memberId))
+                .willReturn(createProfile(memberId));
+        given(bookmarkPersistencePort.existsByMemberIdAndPostId(memberId, postId))
+                .willReturn(true);
+
+        // when
+        PostDetailResultModel result = postService.updatePost(memberId, postId, command);
+
+        // then
+        assertThat(result.isCurrentUserBookmarked()).isTrue();
+    }
+
+    @DisplayName("게시글을 새로 작성하면 북마크 여부는 항상 false 이고 조회하지 않는다")
+    @Test
+    void createPost_neverBookmarked() {
+        // given
+        Long memberId = 1L;
+        CreatePostCommand command = CreatePostCommand.builder()
+                .title("제목").content("내용").category("GENERAL")
+                .build();
+        given(memberQueryUseCase.getMemberProfile(memberId))
+                .willReturn(createProfile(memberId));
+        given(postPersistencePort.save(any(Post.class)))
+                .willReturn(createPost(1L, memberId));
+
+        // when
+        PostDetailResultModel result = postService.createPost(memberId, command);
+
+        // then — 방금 만든 글이므로 조회 없이 false 여야 한다
+        assertThat(result.isCurrentUserBookmarked()).isFalse();
+        then(bookmarkPersistencePort).shouldHaveNoInteractions();
+    }
+
     @DisplayName("다른 사람의 게시글을 수정하면 FORBIDDEN 예외가 발생한다")
     @Test
     void updatePost_forbidden() {
@@ -237,8 +282,8 @@ class PostServiceTest {
                 .willReturn(Optional.of(createPost(postId, authorId)));
         given(memberQueryUseCase.getMemberProfile(authorId))
                 .willReturn(createProfile(authorId));
-        given(bookmarkPersistencePort.findByMemberIdAndPostId(viewerId, postId))
-                .willReturn(Optional.of(Bookmark.create(viewerId, postId)));
+        given(bookmarkPersistencePort.existsByMemberIdAndPostId(viewerId, postId))
+                .willReturn(true);
 
         // when
         PostDetailReadModel result = postService.getPost(postId, viewerId);
@@ -258,8 +303,8 @@ class PostServiceTest {
                 .willReturn(Optional.of(createPost(postId, authorId)));
         given(memberQueryUseCase.getMemberProfile(authorId))
                 .willReturn(createProfile(authorId));
-        given(bookmarkPersistencePort.findByMemberIdAndPostId(viewerId, postId))
-                .willReturn(Optional.empty());
+        given(bookmarkPersistencePort.existsByMemberIdAndPostId(viewerId, postId))
+                .willReturn(false);
 
         // when
         PostDetailReadModel result = postService.getPost(postId, viewerId);

--- a/module/domain/community/src/test/java/com/example/lolserver/community/domain/BookmarkTest.java
+++ b/module/domain/community/src/test/java/com/example/lolserver/community/domain/BookmarkTest.java
@@ -1,0 +1,37 @@
+package com.example.lolserver.community.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BookmarkTest {
+
+    @DisplayName("create 는 회원/게시글을 담고 생성 시각을 찍는다")
+    @Test
+    void create_success() {
+        // given
+        LocalDateTime before = LocalDateTime.now();
+
+        // when
+        Bookmark bookmark = Bookmark.create(1L, 10L);
+
+        // then
+        assertThat(bookmark.getMemberId()).isEqualTo(1L);
+        assertThat(bookmark.getPostId()).isEqualTo(10L);
+        assertThat(bookmark.getCreatedAt()).isNotNull();
+        assertThat(bookmark.getCreatedAt()).isAfterOrEqualTo(before);
+    }
+
+    @DisplayName("create 로 만든 북마크는 아직 저장 전이므로 id 가 없다")
+    @Test
+    void create_hasNoId() {
+        // when
+        Bookmark bookmark = Bookmark.create(1L, 10L);
+
+        // then
+        assertThat(bookmark.getId()).isNull();
+    }
+}

--- a/module/domain/community/src/test/resources/application-test.yml
+++ b/module/domain/community/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  flyway:
+    enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+    show-sql: true
+
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:


### PR DESCRIPTION
커뮤니티 북마크(스크랩) 서버 구현입니다. 커밋 8개.

## 🔴 머지 순서 — 이 PR 만 먼저 배포하면 안 됩니다

4단계 릴리스의 **3단계**입니다.

```
① lol-db-schema V31          padosol/lol-db-schema#5  ← 선행
② lol-repository (Flyway 적용·배포)                   ← 선행
③ lol-server                 이 PR
④ lol-ui
```

`ddl-auto: validate` 라 **`community_bookmark` 테이블이 없는 상태로 뜨면 CrashLoopBackOff** 됩니다.
`deploy-service.yml` 은 `main` 의 CI 완료에만 반응하므로 **develop 머지 자체는 배포되지 않습니다.** 위험한 시점은 `develop → main` 입니다.

## API

| 메서드 | 경로 | 응답 |
|---|---|---|
| POST | `/api/community/bookmarks` | 201 / 중복 시 **409** |
| DELETE | `/api/community/bookmarks/{postId}` | 204 / 없으면 404 |
| GET | `/api/community/me/bookmarks?page=` | 200 `SliceResponse<PostListResponse>` |

`PostResponse` 에 `currentUserBookmarked` 추가 (`currentUserVote` 와 대칭).

## 설계 판단

**경로를 `/api/community/posts/` 아래에 중첩하지 않았습니다.** permitAll 은 `GET /api/community/posts/**` 한정이라 POST/DELETE 는 중첩해도 뚫리지 않지만, 앞으로 "GET 으로 북마크 여부 조회"를 posts 하위에 추가하면 **그건 실제로 인증 없이 뚫립니다.** 그래서 처음부터 posts 바깥에 뒀습니다.

**해제할 때 게시글 존재를 확인하지 않습니다.** 글이 지워졌다고 북마크가 남으면 목록에서 영영 못 지웁니다.

**수정 응답의 북마크 상태를 실제로 조회합니다.** `false` 로 고정하면 자기 글을 북마크한 뒤 수정했을 때 응답이 해제 상태로 돌아와 클라이언트 캐시가 뒤집힙니다. 생성은 방금 만든 글이라 항상 `false` 가 맞습니다.

**목록 정렬은 글 작성 시각이 아니라 북마크한 시각 기준**입니다(V31 의 `idx_cb_member_created`). 같은 시각 북마크에서 페이지 경계가 어긋나지 않도록 `b.id` 를 타이브레이커로 뒀습니다.

## 적대적 리뷰에서 고친 것

**동시 요청이 500 을 내고 있었습니다.** 서비스의 사전 조회를 두 요청이 모두 통과하면 `uq_cb_member_post` 위반이 `DataIntegrityViolationException` 으로 올라오는데, `CoreExceptionAdvice` 에 이 핸들러가 없어 그대로 500 이 나갔습니다. "최종 방어선은 UNIQUE 제약"이라던 제 주석은 사실과 반대였습니다 — **방어선이 아니라 처리되지 않은 탈출구**였습니다. 어댑터에서 409 로 수렴시켰습니다.

그 밖에: 목록 쿼리가 쓰지도 않는 `content`(TEXT)를 20건씩 읽던 것 → DTO 프로젝션, 존재 여부만 필요한 3곳이 엔티티를 통째로 읽던 것 → `exists`, `page` 음수가 500 이던 것 → 400, `enrichAuthors` 복사본과 원본의 분기 제거.

## 테스트 인프라 수정 (별도 커밋)

`TestJpaConfig` 가 driven 어댑터를 client/messaging/cache 까지만 제외하고 **`adapter.out.oauth` 를 빠뜨려**, member 를 의존하는 컨텍스트에서 리포지토리 테스트 컨텍스트가 아예 뜨지 않았습니다. `@Query` 는 컴파일이 아니라 **부트스트랩 시점에 파싱**되므로, 이 상태에서는 JPQL 이 깨져도 CI 는 green 이고 운영 기동에서 처음 터집니다.

이 한 줄을 고쳐 `BookmarkPersistenceAdapterTest` 를 붙였고, 그 덕에 위 500 버그를 **테스트로 재현한 뒤 고쳤습니다.**

## 검증

- [x] `./gradlew test` — 전체 모듈 통과. 커뮤니티 **55개** (기존 27 → 55)
- [x] `./gradlew archTest` — 6개 규칙 통과
- [x] `./gradlew compileJava compileTestJava`
- [x] JPQL 조인·정렬·삭제글 제외·회원 격리·페이징(20/21건 경계)·UNIQUE 변환을 **실제 DB(H2)로 검증**
- [x] TDD — 각 단계에서 실패를 확인한 뒤 구현했습니다. 500 버그도 red 를 먼저 봤습니다

**미검증**
- [ ] 실제 Postgres 기동 검증 — H2 로만 확인했습니다. ①② 배포 후 `validate` 통과 여부는 그때 확인이 필요합니다
- [ ] 비로그인 401 / 인증 동작 — SecurityConfig 규칙상 걸리는 것은 확인했으나 실제 호출은 못 해봤습니다
- [ ] 연타 시나리오 수동 검증 — UI(④단계) 필요

## 남겨둔 것

- **RestDocs 문서 없음.** 커뮤니티 RestDocs 컨트롤러 테스트가 `77b945e5` 에서 삭제된 뒤 복구되지 않아 `.adoc` 13개가 이미 고아 상태입니다. 여기에 3개를 더 얹는 대신 별건으로 다루는 게 맞다고 판단했습니다.
- **`enrichAuthors` 는 여전히 두 벌**입니다. 호출부가 4곳이 되어 공용 추출이 맞지만, `PostService` 의 기존 테스트가 그 동작을 직접 검증하고 있어 기능과 섞지 않았습니다. 최소한 분기는 없앴습니다.
- **MP 번호 없음** — 발급받지 못해 커밋·브랜치에 Linear 키가 없습니다. 주시면 정리하겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCTseN4Lk5uXhMTkJZjWVM