### PR TITLE
fix: google redirect-uri 를 {baseUrl} 대신 OAUTH_REDIRECT_BASE_URL 로 고정

### DIFF
--- a/module/app/application/src/main/resources/api-dev.yml
+++ b/module/app/application/src/main/resources/api-dev.yml
@@ -19,7 +19,7 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: openid, email, profile
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: ${OAUTH_REDIRECT_BASE_URL}/login/oauth2/code/google
           riot:
             client-id: ${RIOT_RSO_CLIENT_ID}
             client-secret: ${RIOT_RSO_CLIENT_SECRET}

--- a/module/app/application/src/main/resources/api-local.yml
+++ b/module/app/application/src/main/resources/api-local.yml
@@ -15,7 +15,7 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: openid, email, profile
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: ${OAUTH_REDIRECT_BASE_URL}/login/oauth2/code/google
           riot:
             client-id: ${RIOT_RSO_CLIENT_ID}
             client-secret: ${RIOT_RSO_CLIENT_SECRET}

--- a/module/app/application/src/main/resources/api-prod.yml
+++ b/module/app/application/src/main/resources/api-prod.yml
@@ -19,7 +19,7 @@ spring:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
             scope: openid, email, profile
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: ${OAUTH_REDIRECT_BASE_URL}/login/oauth2/code/google
           riot:
             client-id: ${RIOT_RSO_CLIENT_ID}
             client-secret: ${RIOT_RSO_CLIENT_SECRET}


### PR DESCRIPTION
## 관련 이슈
- 없음

## 변경 유형
- [x] fix

## 변경 사항
google 등록의 `redirect-uri` 를 riot 과 같은 환경변수 방식으로 통일했다.

**`module/app/application/src/main/resources/api-local.yml`** — 🟡 수정
**`module/app/application/src/main/resources/api-dev.yml`** — 🟡 수정
**`module/app/application/src/main/resources/api-prod.yml`** — 🟡 수정

- 세 파일 모두 google 의 `redirect-uri` 한 줄: `"{baseUrl}/login/oauth2/code/{registrationId}"` → `${OAUTH_REDIRECT_BASE_URL}/login/oauth2/code/google`

## 변경 이유
- `{baseUrl}` 은 설정값이 아니라 `DefaultOAuth2AuthorizationRequestResolver#expandRedirectUri` 가 `UrlUtils.buildFullRequestUrl(request)` 로 **매 인증 요청마다 요청 객체에서 계산**하는 값이다. 리버스 프록시 뒤에서는 톰캣이 보는 내부 주소로 확장되는데, `server.forward-headers-strategy` 는 어느 프로파일에도 설정돼 있지 않다.
- 대안이던 `forward-headers-strategy: framework` 추가 대신 환경변수 방식을 택했다 — 바로 아래 riot 등록이 이미 같은 이유로 `${OAUTH_REDIRECT_BASE_URL}` 을 쓰고 있고, 요청에서 유도하지 않아 프록시 구성과 무관하게 결정적이다.
- 경로를 `{registrationId}` 대신 `google` 로 고정해도 안전하다 — `SecurityConfig` 는 `authorizationEndpoint.baseUri` 만 커스터마이즈하고 `redirectionEndpoint` 는 기본값(`/login/oauth2/code/*`)을 그대로 둔다.

## 테스트
- [ ] 단위 테스트 통과 (`./gradlew test`)
- [ ] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
- [ ] 로컬 빌드 확인 (`./gradlew build`)

위 세 가지는 **실행하지 않았다**(Docker 의존 서비스 필요). 실제로 확인한 것은 3개 yml 의 YAML 파싱 유효성, `spring-security-oauth2-client` 바이트코드상의 `{baseUrl}` 산출 경로, `SecurityConfig` 에 `redirectionEndpoint` 커스터마이즈가 없다는 점이다. 부팅 시점 프로퍼티 바인딩은 실환경 확인이 필요하다.

## 리뷰 포인트
- **`OAUTH_REDIRECT_BASE_URL` 이 dev/prod 에 실제로 주입되는지 확인 필요.** 이 변수는 3개 yml 에서 참조만 하고 레포 안에 정의가 없다(배포는 별도 CD 레포). 미설정이면 플레이스홀더 해석 실패로 부팅이 실패한다. riot 이 이미 같은 변수를 쓰므로 설정돼 있을 가능성이 높다.
- **Google Cloud Console 의 승인된 리디렉션 URI 가 새 값과 정확히 일치해야 한다.** 기존 `{baseUrl}` 확장 결과와 달라지면 콘솔 등록값도 함께 갱신해야 한다.
- **local**: `.env` / `.env.example` 어디에도 이 변수가 없다. `.env` 에 `OAUTH_REDIRECT_BASE_URL=http://localhost:8085` 추가가 필요하고, `.env.example` 반영은 저장소 보호 훅에 막혀 수동 조치로 남긴다.
- prod 만 대상으로 시작했으나 dev·local 도 동일한 불일치라 3개를 함께 맞췄다. prod 만 원하면 나머지는 되돌린다.
