### PR TITLE
fix: 언랭 계정 듀오 등록·신청 차단 (500 수정)

### DIFF
--- a/module/common/src/main/java/com/example/lolserver/common/error/ErrorType.java
+++ b/module/common/src/main/java/com/example/lolserver/common/error/ErrorType.java
@@ -68,7 +68,12 @@ public enum ErrorType {
             "수락된 요청만 확인할 수 있습니다."),
     DUO_REQUEST_ALREADY_COMPLETED(400, ErrorCode.E400,
             "이미 처리 완료된 요청입니다."),
-    INVALID_LANE(400, ErrorCode.E400, "유효하지 않은 라인입니다.");
+    INVALID_LANE(400, ErrorCode.E400, "유효하지 않은 라인입니다."),
+    // 전적 데이터가 적재된 적 없는 계정과 실제 언랭 계정은 사용자가 취할 행동이 다르므로 구분한다.
+    SUMMONER_SEARCH_REQUIRED(400, ErrorCode.E400,
+            "전적 정보가 없습니다. 소환사 검색을 먼저 진행해주세요."),
+    DUO_UNRANKED_NOT_ALLOWED(400, ErrorCode.E400,
+            "솔로랭크 티어가 없는 계정은 듀오를 등록할 수 없습니다.");
 
     private final int httpStatus;
     private final ErrorCode errorCode;

--- a/module/domain/duo/src/main/java/com/example/lolserver/duo/application/RiotAccountResolver.java
+++ b/module/domain/duo/src/main/java/com/example/lolserver/duo/application/RiotAccountResolver.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.Supplier;
 
 @Component
@@ -51,12 +52,30 @@ public class RiotAccountResolver {
                 CompletableFuture.supplyAsync(() -> withMdc(contextMap, () -> lookupRecentGameSummary(puuid)));
 
         return new RiotAccountStats(
-                tierFuture.join(),
-                championsFuture.join(),
-                recentGameFuture.join()
+                join(tierFuture),
+                join(championsFuture),
+                join(recentGameFuture)
         );
     }
 
+    /**
+     * join() 이 씌우는 CompletionException 을 벗겨 원래 예외를 그대로 던진다.
+     * 래핑된 채로 올라가면 CoreException 이 전역 핸들러에 잡히지 않아 전부 500 이 된다.
+     */
+    private <T> T join(CompletableFuture<T> future) {
+        try {
+            return future.join();
+        } catch (CompletionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            if (cause instanceof Error error) {
+                throw error;
+            }
+            throw e;
+        }
+    }
 
     private <T> T withMdc(Map<String, String> contextMap, Supplier<T> supplier) {
         if (contextMap != null) {

--- a/module/domain/duo/src/main/java/com/example/lolserver/duo/application/RiotAccountResolver.java
+++ b/module/domain/duo/src/main/java/com/example/lolserver/duo/application/RiotAccountResolver.java
@@ -11,6 +11,7 @@ import com.example.lolserver.match.application.model.readmodel.PlayerMatchReadMo
 import com.example.lolserver.match.application.port.in.MatchQueryUseCase;
 import com.example.lolserver.member.application.port.in.MemberQueryUseCase;
 import com.example.lolserver.summoner.application.port.in.LeagueQueryUseCase;
+import com.example.lolserver.summoner.application.port.in.SummonerQueryUseCase;
 import com.example.lolserver.common.error.CoreException;
 import com.example.lolserver.common.error.ErrorType;
 import lombok.RequiredArgsConstructor;
@@ -35,13 +36,29 @@ public class RiotAccountResolver {
     private final MemberQueryUseCase memberQueryUseCase;
     private final LeagueQueryUseCase leagueQueryUseCase;
     private final MatchQueryUseCase matchQueryUseCase;
+    private final SummonerQueryUseCase summonerQueryUseCase;
 
     public String extractRiotPuuid(Long memberId) {
         return memberQueryUseCase.findRiotPuuid(memberId)
                 .orElseThrow(() -> new CoreException(ErrorType.RIOT_ACCOUNT_NOT_LINKED));
     }
 
+    /**
+     * 전적 데이터가 적재된 적 없는 계정을 언랭과 구분해 걸러낸다.
+     *
+     * <p>리그·매치 조회는 DB 만 보므로, 소환사 자체가 색인된 적 없으면 실제 티어와 무관하게
+     * 언랭으로 보인다. 그대로 두면 "언랭이라 등록 불가"라는 잘못된 안내가 나가므로,
+     * 이 경우는 소환사 검색을 먼저 하도록 별도 에러로 알린다.
+     */
+    public void validateSummonerIndexed(String puuid) {
+        if (summonerQueryUseCase.findSummonerByPuuid(puuid).isEmpty()) {
+            throw new CoreException(ErrorType.SUMMONER_SEARCH_REQUIRED);
+        }
+    }
+
     public RiotAccountStats lookupAllStats(String puuid) {
+        validateSummonerIndexed(puuid);
+
         Map<String, String> contextMap = MDC.getCopyOfContextMap();
 
         CompletableFuture<TierInfo> tierFuture =

--- a/module/domain/duo/src/main/java/com/example/lolserver/duo/application/model/resultmodel/DuoPostResultModel.java
+++ b/module/domain/duo/src/main/java/com/example/lolserver/duo/application/model/resultmodel/DuoPostResultModel.java
@@ -3,6 +3,7 @@ package com.example.lolserver.duo.application.model.resultmodel;
 import com.example.lolserver.duo.domain.DuoPost;
 import com.example.lolserver.duo.domain.vo.MostChampion;
 import com.example.lolserver.duo.domain.vo.RecentGameSummary;
+import com.example.lolserver.duo.domain.vo.TierInfo;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -38,7 +39,7 @@ public class DuoPostResultModel {
                 .leaguePoints(post.getLeaguePoints())
                 .memo(post.getMemo())
                 .status(post.getStatus().name())
-                .tierAvailable(post.getTier() != null)
+                .tierAvailable(!TierInfo.isUnranked(post.getTier()))
                 .mostChampions(post.getMostChampions())
                 .recentGameSummary(post.getRecentGameSummary())
                 .expiresAt(post.getExpiresAt())

--- a/module/domain/duo/src/main/java/com/example/lolserver/duo/domain/DuoPost.java
+++ b/module/domain/duo/src/main/java/com/example/lolserver/duo/domain/DuoPost.java
@@ -42,6 +42,8 @@ public class DuoPost {
             Lane primaryLane, Lane desiredLane, boolean hasMicrophone, String memo,
             RiotAccountStats stats) {
         TierInfo tierInfo = stats.tierInfo();
+        tierInfo.validateRanked();
+
         LocalDateTime now = LocalDateTime.now();
         return DuoPost.builder()
                 .memberId(memberId)

--- a/module/domain/duo/src/main/java/com/example/lolserver/duo/domain/DuoRequest.java
+++ b/module/domain/duo/src/main/java/com/example/lolserver/duo/domain/DuoRequest.java
@@ -42,6 +42,8 @@ public class DuoRequest {
             String requesterPuuid, Lane primaryLane, Lane desiredLane,
             boolean hasMicrophone, String memo, RiotAccountStats stats) {
         TierInfo tierInfo = stats.tierInfo();
+        tierInfo.validateRanked();
+
         LocalDateTime now = LocalDateTime.now();
         return DuoRequest.builder()
                 .duoPostId(duoPostId)

--- a/module/domain/duo/src/main/java/com/example/lolserver/duo/domain/vo/TierInfo.java
+++ b/module/domain/duo/src/main/java/com/example/lolserver/duo/domain/vo/TierInfo.java
@@ -1,5 +1,8 @@
 package com.example.lolserver.duo.domain.vo;
 
+import com.example.lolserver.common.error.CoreException;
+import com.example.lolserver.common.error.ErrorType;
+
 public record TierInfo(
         String tier,
         String rank,
@@ -22,5 +25,15 @@ public record TierInfo(
 
     public boolean isUnranked() {
         return isUnranked(tier);
+    }
+
+    /**
+     * 듀오 게시글/신청은 솔로랭크 티어가 있어야 등록할 수 있다.
+     * 티어 없는 글은 매칭 정보로서 가치가 없고, tier·tier_rank 는 NOT NULL 이다.
+     */
+    public void validateRanked() {
+        if (isUnranked()) {
+            throw new CoreException(ErrorType.DUO_UNRANKED_NOT_ALLOWED);
+        }
     }
 }

--- a/module/domain/duo/src/main/java/com/example/lolserver/duo/domain/vo/TierInfo.java
+++ b/module/domain/duo/src/main/java/com/example/lolserver/duo/domain/vo/TierInfo.java
@@ -5,5 +5,22 @@ public record TierInfo(
         String rank,
         int leaguePoints
 ) {
-    public static final TierInfo UNRANKED = new TierInfo(null, null, 0);
+    /**
+     * 랭크 정보가 없을 때 쓰는 표식 값.
+     *
+     * <p>duo_post/duo_request 의 tier·tier_rank 는 NOT NULL 이므로 null 대신
+     * V18 마이그레이션이 기존 행에 채운 값과 동일한 문자열을 사용한다.
+     */
+    public static final String UNRANKED_TIER = "UNRANKED";
+    public static final String UNRANKED_RANK = "I";
+
+    public static final TierInfo UNRANKED = new TierInfo(UNRANKED_TIER, UNRANKED_RANK, 0);
+
+    public static boolean isUnranked(String tier) {
+        return tier == null || UNRANKED_TIER.equals(tier);
+    }
+
+    public boolean isUnranked() {
+        return isUnranked(tier);
+    }
 }

--- a/module/domain/duo/src/test/java/com/example/lolserver/duo/adapter/out/persistence/adapter/DuoUnrankedPersistenceTest.java
+++ b/module/domain/duo/src/test/java/com/example/lolserver/duo/adapter/out/persistence/adapter/DuoUnrankedPersistenceTest.java
@@ -1,0 +1,97 @@
+package com.example.lolserver.duo.adapter.out.persistence.adapter;
+
+import com.example.lolserver.common.test.RepositoryTestBase;
+import com.example.lolserver.duo.domain.DuoPost;
+import com.example.lolserver.duo.domain.DuoRequest;
+import com.example.lolserver.duo.domain.vo.Lane;
+import com.example.lolserver.duo.domain.vo.RecentGameSummary;
+import com.example.lolserver.duo.domain.vo.RiotAccountStats;
+import com.example.lolserver.duo.domain.vo.TierInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 랭크 정보가 없는 계정도 듀오 글/신청을 저장할 수 있어야 한다.
+ *
+ * <p>duo_post·duo_request 의 tier / tier_rank 는 NOT NULL 이므로 UNRANKED 표식이
+ * null 로 돌아가면 저장 단계에서 제약 위반(500)이 난다. 단위 테스트는 영속 포트를
+ * mock 으로 두어 이 경로를 타지 않으므로 실제 스키마로 검증한다.
+ */
+@Import(DuoUnrankedPersistenceTest.RedisStubConfig.class)
+class DuoUnrankedPersistenceTest extends RepositoryTestBase {
+
+    /**
+     * duo 의 lock/notification 어댑터는 JPA 슬라이스에 없는 Redis 빈을 요구하므로 stub 으로 채운다.
+     * 이 테스트가 검증하는 저장 경로에서는 호출되지 않는다.
+     */
+    @TestConfiguration
+    static class RedisStubConfig {
+
+        @Bean
+        RedissonClient redissonClient() {
+            return Mockito.mock(RedissonClient.class);
+        }
+
+        @Bean
+        @SuppressWarnings("unchecked")
+        RedisTemplate<String, Object> redisTemplate() {
+            return Mockito.mock(RedisTemplate.class);
+        }
+    }
+
+    private static final RiotAccountStats UNRANKED_STATS = new RiotAccountStats(
+            TierInfo.UNRANKED,
+            Collections.emptyList(),
+            new RecentGameSummary(0, 0, Collections.emptyList()));
+
+    @Autowired
+    private DuoPostPersistenceAdapter duoPostPersistenceAdapter;
+
+    @Autowired
+    private DuoRequestPersistenceAdapter duoRequestPersistenceAdapter;
+
+    @DisplayName("언랭 계정의 듀오 글도 저장된다 - tier/tier_rank NOT NULL 위반 없음")
+    @Test
+    void saveDuoPost_withUnrankedTier() {
+        // given
+        DuoPost duoPost = DuoPost.create(1L, "unranked-puuid",
+                Lane.TOP, Lane.SUPPORT, false, "랭크 없음", UNRANKED_STATS);
+
+        // when
+        DuoPost saved = duoPostPersistenceAdapter.save(duoPost);
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getTier()).isEqualTo(TierInfo.UNRANKED_TIER);
+        assertThat(saved.getRank()).isEqualTo(TierInfo.UNRANKED_RANK);
+        assertThat(saved.getLeaguePoints()).isZero();
+    }
+
+    @DisplayName("언랭 계정의 듀오 신청도 저장된다 - tier/tier_rank NOT NULL 위반 없음")
+    @Test
+    void saveDuoRequest_withUnrankedTier() {
+        // given
+        DuoRequest duoRequest = DuoRequest.create(1L, 2L, "unranked-puuid",
+                Lane.MID, Lane.JUNGLE, false, "랭크 없음", UNRANKED_STATS);
+
+        // when
+        DuoRequest saved = duoRequestPersistenceAdapter.save(duoRequest);
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getTier()).isEqualTo(TierInfo.UNRANKED_TIER);
+        assertThat(saved.getRank()).isEqualTo(TierInfo.UNRANKED_RANK);
+        assertThat(saved.getLeaguePoints()).isZero();
+    }
+}

--- a/module/domain/duo/src/test/java/com/example/lolserver/duo/adapter/out/persistence/adapter/DuoUnrankedPersistenceTest.java
+++ b/module/domain/duo/src/test/java/com/example/lolserver/duo/adapter/out/persistence/adapter/DuoUnrankedPersistenceTest.java
@@ -3,9 +3,10 @@ package com.example.lolserver.duo.adapter.out.persistence.adapter;
 import com.example.lolserver.common.test.RepositoryTestBase;
 import com.example.lolserver.duo.domain.DuoPost;
 import com.example.lolserver.duo.domain.DuoRequest;
+import com.example.lolserver.duo.domain.vo.DuoPostStatus;
+import com.example.lolserver.duo.domain.vo.DuoRequestStatus;
 import com.example.lolserver.duo.domain.vo.Lane;
 import com.example.lolserver.duo.domain.vo.RecentGameSummary;
-import com.example.lolserver.duo.domain.vo.RiotAccountStats;
 import com.example.lolserver.duo.domain.vo.TierInfo;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,16 +18,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * 랭크 정보가 없는 계정도 듀오 글/신청을 저장할 수 있어야 한다.
+ * UNRANKED 표식이 NOT NULL 컬럼에 저장 가능한 값이어야 한다.
  *
- * <p>duo_post·duo_request 의 tier / tier_rank 는 NOT NULL 이므로 UNRANKED 표식이
- * null 로 돌아가면 저장 단계에서 제약 위반(500)이 난다. 단위 테스트는 영속 포트를
+ * <p>등록 경로는 {@code TierInfo.validateRanked()} 가 언랭을 막지만, 표식 자체가 다시
+ * null 로 돌아가면 guard 를 우회하는 경로(기존 행 재저장 등)에서 제약 위반(500)이 난다.
+ * duo_post·duo_request 의 tier / tier_rank 는 NOT NULL 이고, 단위 테스트는 영속 포트를
  * mock 으로 두어 이 경로를 타지 않으므로 실제 스키마로 검증한다.
+ *
+ * <p>도메인 guard 를 우회해야 하므로 팩토리 대신 빌더로 직접 조립한다.
  */
 @Import(DuoUnrankedPersistenceTest.RedisStubConfig.class)
 class DuoUnrankedPersistenceTest extends RepositoryTestBase {
@@ -50,23 +55,34 @@ class DuoUnrankedPersistenceTest extends RepositoryTestBase {
         }
     }
 
-    private static final RiotAccountStats UNRANKED_STATS = new RiotAccountStats(
-            TierInfo.UNRANKED,
-            Collections.emptyList(),
-            new RecentGameSummary(0, 0, Collections.emptyList()));
-
     @Autowired
     private DuoPostPersistenceAdapter duoPostPersistenceAdapter;
 
     @Autowired
     private DuoRequestPersistenceAdapter duoRequestPersistenceAdapter;
 
-    @DisplayName("언랭 계정의 듀오 글도 저장된다 - tier/tier_rank NOT NULL 위반 없음")
+    @DisplayName("UNRANKED 표식이 실린 듀오 글은 저장된다 - tier/tier_rank NOT NULL 위반 없음")
     @Test
     void saveDuoPost_withUnrankedTier() {
         // given
-        DuoPost duoPost = DuoPost.create(1L, "unranked-puuid",
-                Lane.TOP, Lane.SUPPORT, false, "랭크 없음", UNRANKED_STATS);
+        LocalDateTime now = LocalDateTime.now();
+        DuoPost duoPost = DuoPost.builder()
+                .memberId(1L)
+                .puuid("unranked-puuid")
+                .primaryLane(Lane.TOP)
+                .desiredLane(Lane.SUPPORT)
+                .hasMicrophone(false)
+                .tier(TierInfo.UNRANKED.tier())
+                .rank(TierInfo.UNRANKED.rank())
+                .leaguePoints(TierInfo.UNRANKED.leaguePoints())
+                .memo("랭크 없음")
+                .status(DuoPostStatus.ACTIVE)
+                .mostChampions(Collections.emptyList())
+                .recentGameSummary(new RecentGameSummary(0, 0, Collections.emptyList()))
+                .expiresAt(now.plusHours(1))
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
 
         // when
         DuoPost saved = duoPostPersistenceAdapter.save(duoPost);
@@ -78,12 +94,28 @@ class DuoUnrankedPersistenceTest extends RepositoryTestBase {
         assertThat(saved.getLeaguePoints()).isZero();
     }
 
-    @DisplayName("언랭 계정의 듀오 신청도 저장된다 - tier/tier_rank NOT NULL 위반 없음")
+    @DisplayName("UNRANKED 표식이 실린 듀오 신청은 저장된다 - tier/tier_rank NOT NULL 위반 없음")
     @Test
     void saveDuoRequest_withUnrankedTier() {
         // given
-        DuoRequest duoRequest = DuoRequest.create(1L, 2L, "unranked-puuid",
-                Lane.MID, Lane.JUNGLE, false, "랭크 없음", UNRANKED_STATS);
+        LocalDateTime now = LocalDateTime.now();
+        DuoRequest duoRequest = DuoRequest.builder()
+                .duoPostId(1L)
+                .requesterId(2L)
+                .requesterPuuid("unranked-puuid")
+                .primaryLane(Lane.MID)
+                .desiredLane(Lane.JUNGLE)
+                .hasMicrophone(false)
+                .tier(TierInfo.UNRANKED.tier())
+                .rank(TierInfo.UNRANKED.rank())
+                .leaguePoints(TierInfo.UNRANKED.leaguePoints())
+                .memo("랭크 없음")
+                .status(DuoRequestStatus.PENDING)
+                .mostChampions(Collections.emptyList())
+                .recentGameSummary(new RecentGameSummary(0, 0, Collections.emptyList()))
+                .createdAt(now)
+                .updatedAt(now)
+                .build();
 
         // when
         DuoRequest saved = duoRequestPersistenceAdapter.save(duoRequest);

--- a/module/domain/duo/src/test/java/com/example/lolserver/duo/application/DuoRequestServiceTest.java
+++ b/module/domain/duo/src/test/java/com/example/lolserver/duo/application/DuoRequestServiceTest.java
@@ -257,6 +257,40 @@ class DuoRequestServiceTest {
             assertThat(result.getRecentGameSummary().wins()).isEqualTo(10);
             then(duoRequestPersistencePort).should().save(any(DuoRequest.class));
         }
+
+        @DisplayName("솔로랭크 티어가 없으면 DUO_UNRANKED_NOT_ALLOWED 에러 - 저장되지 않는다")
+        @Test
+        void unranked_throwsException() {
+            // given
+            Long memberId = 2L;
+            Long duoPostId = 100L;
+            String puuid = "test-puuid";
+            DuoPost duoPost = createTestDuoPost(duoPostId, 1L);
+            CreateDuoRequestCommand command = CreateDuoRequestCommand.builder()
+                    .primaryLane("ADC")
+                    .desiredLane("SUPPORT")
+                    .hasMicrophone(true)
+                    .memo("같이 하실 분")
+                    .build();
+
+            given(riotAccountResolver.extractRiotPuuid(memberId)).willReturn(puuid);
+            given(duoPostPersistencePort.findById(duoPostId))
+                    .willReturn(Optional.of(duoPost));
+            given(duoRequestPersistencePort.existsByDuoPostIdAndRequesterIdAndStatusIn(
+                    eq(duoPostId), eq(memberId), anyList()))
+                    .willReturn(false);
+            given(riotAccountResolver.lookupAllStats(puuid)).willReturn(new RiotAccountStats(
+                    TierInfo.UNRANKED, Collections.emptyList(),
+                    new RecentGameSummary(0, 0, Collections.emptyList())));
+
+            // when & then
+            assertThatThrownBy(() ->
+                    duoRequestService.createDuoRequest(memberId, duoPostId, command))
+                    .isInstanceOf(CoreException.class)
+                    .extracting(e -> ((CoreException) e).getErrorType())
+                    .isEqualTo(ErrorType.DUO_UNRANKED_NOT_ALLOWED);
+            then(duoRequestPersistencePort).should(never()).save(any(DuoRequest.class));
+        }
     }
 
     @Nested

--- a/module/domain/duo/src/test/java/com/example/lolserver/duo/application/DuoServiceTest.java
+++ b/module/domain/duo/src/test/java/com/example/lolserver/duo/application/DuoServiceTest.java
@@ -255,8 +255,9 @@ class DuoServiceTest {
 
             // then
             assertThat(result).isNotNull();
-            assertThat(result.getTier()).isNull();
-            assertThat(result.getRank()).isNull();
+            // tier/tier_rank 는 NOT NULL 컬럼이므로 null 이 아닌 UNRANKED 표식이 실린다.
+            assertThat(result.getTier()).isEqualTo(TierInfo.UNRANKED_TIER);
+            assertThat(result.getRank()).isEqualTo(TierInfo.UNRANKED_RANK);
             assertThat(result.isTierAvailable()).isFalse();
         }
 

--- a/module/domain/duo/src/test/java/com/example/lolserver/duo/application/DuoServiceTest.java
+++ b/module/domain/duo/src/test/java/com/example/lolserver/duo/application/DuoServiceTest.java
@@ -205,9 +205,9 @@ class DuoServiceTest {
                     .executeWithLock(eq("duo:member:post:" + memberId), any());
         }
 
-        @DisplayName("티어 정보 없을 때 tierAvailable=false")
+        @DisplayName("솔로랭크 티어가 없으면 DUO_UNRANKED_NOT_ALLOWED 에러 - 저장되지 않는다")
         @Test
-        void success_withoutTier() {
+        void unranked_throwsException() {
             // given
             Long memberId = 1L;
             String puuid = "test-puuid";
@@ -227,38 +227,13 @@ class DuoServiceTest {
             given(duoPostPersistencePort.existsActiveByMemberId(memberId))
                     .willReturn(false);
             given(riotAccountResolver.lookupAllStats(puuid)).willReturn(stats);
-            given(duoPostPersistencePort.save(any(DuoPost.class)))
-                    .willAnswer(invocation -> {
-                        DuoPost post = invocation.getArgument(0);
-                        return DuoPost.builder()
-                                .id(101L)
-                                .memberId(post.getMemberId())
-                                .puuid(post.getPuuid())
-                                .primaryLane(post.getPrimaryLane())
-                                .desiredLane(post.getDesiredLane())
-                                .hasMicrophone(post.isHasMicrophone())
-                                .tier(post.getTier())
-                                .rank(post.getRank())
-                                .leaguePoints(post.getLeaguePoints())
-                                .memo(post.getMemo())
-                                .status(post.getStatus())
-                                .mostChampions(post.getMostChampions())
-                                .recentGameSummary(post.getRecentGameSummary())
-                                .expiresAt(post.getExpiresAt())
-                                .createdAt(post.getCreatedAt())
-                                .updatedAt(post.getUpdatedAt())
-                                .build();
-                    });
 
-            // when
-            DuoPostResultModel result = duoService.createDuoPost(memberId, command);
-
-            // then
-            assertThat(result).isNotNull();
-            // tier/tier_rank 는 NOT NULL 컬럼이므로 null 이 아닌 UNRANKED 표식이 실린다.
-            assertThat(result.getTier()).isEqualTo(TierInfo.UNRANKED_TIER);
-            assertThat(result.getRank()).isEqualTo(TierInfo.UNRANKED_RANK);
-            assertThat(result.isTierAvailable()).isFalse();
+            // when & then
+            assertThatThrownBy(() -> duoService.createDuoPost(memberId, command))
+                    .isInstanceOf(CoreException.class)
+                    .extracting(e -> ((CoreException) e).getErrorType())
+                    .isEqualTo(ErrorType.DUO_UNRANKED_NOT_ALLOWED);
+            then(duoPostPersistencePort).should(never()).save(any(DuoPost.class));
         }
 
         @DisplayName("락 획득 실패 시 LOCK_ACQUISITION_FAILED 에러 - 게시글은 저장되지 않는다")
@@ -305,7 +280,7 @@ class DuoServiceTest {
                     .memo("듀오 구합니다")
                     .build();
             RiotAccountStats stats = new RiotAccountStats(
-                    TierInfo.UNRANKED, Collections.emptyList(),
+                    new TierInfo("GOLD", "I", 50), Collections.emptyList(),
                     new RecentGameSummary(0, 0, Collections.emptyList()));
             List<DuoPost> savedPosts = Collections.synchronizedList(new ArrayList<>());
 

--- a/module/domain/duo/src/test/java/com/example/lolserver/duo/application/RiotAccountResolverTest.java
+++ b/module/domain/duo/src/test/java/com/example/lolserver/duo/application/RiotAccountResolverTest.java
@@ -10,7 +10,9 @@ import com.example.lolserver.match.application.model.readmodel.PlayerMatchReadMo
 import com.example.lolserver.match.application.port.in.MatchQueryUseCase;
 import com.example.lolserver.member.application.port.in.MemberQueryUseCase;
 import com.example.lolserver.summoner.application.model.readmodel.LeagueReadModel;
+import com.example.lolserver.summoner.application.model.readmodel.SummonerReadModel;
 import com.example.lolserver.summoner.application.port.in.LeagueQueryUseCase;
+import com.example.lolserver.summoner.application.port.in.SummonerQueryUseCase;
 import com.example.lolserver.common.error.CoreException;
 import com.example.lolserver.common.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
@@ -48,6 +50,14 @@ class RiotAccountResolverTest {
 
     @Mock
     private MatchQueryUseCase matchQueryUseCase;
+
+    @Mock
+    private SummonerQueryUseCase summonerQueryUseCase;
+
+    private void givenSummonerIndexed(String puuid) {
+        given(summonerQueryUseCase.findSummonerByPuuid(puuid))
+                .willReturn(Optional.of(SummonerReadModel.builder().puuid(puuid).build()));
+    }
 
     @Nested
     @DisplayName("extractRiotPuuid")
@@ -235,11 +245,27 @@ class RiotAccountResolverTest {
     @MockitoSettings(strictness = Strictness.LENIENT)
     class LookupAllStats {
 
+        @DisplayName("전적 색인이 없는 계정은 언랭이 아니라 SUMMONER_SEARCH_REQUIRED 로 구분한다")
+        @Test
+        void summonerNotIndexed_throwsSearchRequired() {
+            // given
+            String puuid = "test-puuid";
+            given(summonerQueryUseCase.findSummonerByPuuid(puuid))
+                    .willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> riotAccountResolver.lookupAllStats(puuid))
+                    .isInstanceOf(CoreException.class)
+                    .extracting(e -> ((CoreException) e).getErrorType())
+                    .isEqualTo(ErrorType.SUMMONER_SEARCH_REQUIRED);
+        }
+
         @DisplayName("랭크 정보 없어도 tier/rank 는 null 이 아니다 - NOT NULL 컬럼 저장 가능")
         @Test
         void noRankedData_returnsNonNullTierMarker() {
             // given
             String puuid = "test-puuid";
+            givenSummonerIndexed(puuid);
             given(leagueQueryUseCase.getLeagueSummariesByPuuid(puuid))
                     .willReturn(Collections.emptyList());
             given(matchQueryUseCase.getRankChampionSummaries(any(MSChampionCommand.class)))
@@ -261,6 +287,7 @@ class RiotAccountResolverTest {
         void upstreamFailure_propagatesCoreException() {
             // given
             String puuid = "test-puuid";
+            givenSummonerIndexed(puuid);
             given(leagueQueryUseCase.getLeagueSummariesByPuuid(puuid))
                     .willThrow(new CoreException(ErrorType.MEMBER_NOT_FOUND));
             given(matchQueryUseCase.getRankChampionSummaries(any(MSChampionCommand.class)))

--- a/module/domain/duo/src/test/java/com/example/lolserver/duo/application/RiotAccountResolverTest.java
+++ b/module/domain/duo/src/test/java/com/example/lolserver/duo/application/RiotAccountResolverTest.java
@@ -2,6 +2,7 @@ package com.example.lolserver.duo.application;
 
 import com.example.lolserver.duo.domain.vo.MostChampion;
 import com.example.lolserver.duo.domain.vo.RecentGameSummary;
+import com.example.lolserver.duo.domain.vo.RiotAccountStats;
 import com.example.lolserver.duo.domain.vo.TierInfo;
 import com.example.lolserver.match.application.command.MSChampionCommand;
 import com.example.lolserver.match.application.model.readmodel.MSChampionReadModel;
@@ -19,6 +20,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import java.util.Collections;
 import java.util.List;
@@ -224,6 +227,52 @@ class RiotAccountResolverTest {
             assertThat(result.wins()).isEqualTo(0);
             assertThat(result.losses()).isEqualTo(0);
             assertThat(result.playedChampions()).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("lookupAllStats")
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    class LookupAllStats {
+
+        @DisplayName("랭크 정보 없어도 tier/rank 는 null 이 아니다 - NOT NULL 컬럼 저장 가능")
+        @Test
+        void noRankedData_returnsNonNullTierMarker() {
+            // given
+            String puuid = "test-puuid";
+            given(leagueQueryUseCase.getLeagueSummariesByPuuid(puuid))
+                    .willReturn(Collections.emptyList());
+            given(matchQueryUseCase.getRankChampionSummaries(any(MSChampionCommand.class)))
+                    .willReturn(Collections.emptyList());
+            given(matchQueryUseCase.getRecentPlayerMatches(eq(puuid), eq(420), anyInt()))
+                    .willReturn(Collections.emptyList());
+
+            // when
+            RiotAccountStats stats = riotAccountResolver.lookupAllStats(puuid);
+
+            // then
+            assertThat(stats.tierInfo().tier()).isNotNull();
+            assertThat(stats.tierInfo().rank()).isNotNull();
+            assertThat(stats.tierInfo()).isEqualTo(TierInfo.UNRANKED);
+        }
+
+        @DisplayName("상위 조회 예외는 CompletionException 으로 감싸지 않고 그대로 전파한다")
+        @Test
+        void upstreamFailure_propagatesCoreException() {
+            // given
+            String puuid = "test-puuid";
+            given(leagueQueryUseCase.getLeagueSummariesByPuuid(puuid))
+                    .willThrow(new CoreException(ErrorType.MEMBER_NOT_FOUND));
+            given(matchQueryUseCase.getRankChampionSummaries(any(MSChampionCommand.class)))
+                    .willReturn(Collections.emptyList());
+            given(matchQueryUseCase.getRecentPlayerMatches(eq(puuid), eq(420), anyInt()))
+                    .willReturn(Collections.emptyList());
+
+            // when & then
+            assertThatThrownBy(() -> riotAccountResolver.lookupAllStats(puuid))
+                    .isInstanceOf(CoreException.class)
+                    .extracting(e -> ((CoreException) e).getErrorType())
+                    .isEqualTo(ErrorType.MEMBER_NOT_FOUND);
         }
     }
 }

--- a/module/domain/duo/src/test/resources/application-test.yml
+++ b/module/domain/duo/src/test/resources/application-test.yml
@@ -1,0 +1,17 @@
+spring:
+  flyway:
+    enabled: false
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+    show-sql: true
+
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:


### PR DESCRIPTION
## 관련 이슈
- N/A (이 저장소 관례에 따라 Linear 키 없이 진행)

## 변경 유형
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] chore

## 변경 사항
- `duo/domain/vo/TierInfo.java` — `UNRANKED` 표식을 `(null, null, 0)` 에서 `("UNRANKED", "I", 0)` 으로 변경하고, 언랭 등록을 막는 `validateRanked()` guard 추가
- `duo/domain/DuoPost.java`, `duo/domain/DuoRequest.java` — 팩토리에서 `validateRanked()` 호출로 언랭 등록·신청 차단
- `duo/application/RiotAccountResolver.java` — 전적 색인이 없는 계정을 `validateSummonerIndexed()` 로 분리 검증, `CompletableFuture.join()` 의 `CompletionException` 언래핑
- `common/error/ErrorType.java` — `SUMMONER_SEARCH_REQUIRED`(400), `DUO_UNRANKED_NOT_ALLOWED`(400) 추가
- `duo` 테스트 — 언랭 차단·미색인 차단 케이스 추가, NOT NULL 계약을 실제 스키마로 검증하는 `DuoUnrankedPersistenceTest` 및 duo 모듈 테스트 프로파일(`application-test.yml`) 신설

## 변경 이유
듀오 글 등록(`POST /api/duo/posts`)과 신청이 랭크 데이터가 없는 계정에서 항상 500 을 반환했습니다.

`RiotAccountResolver.lookupTierInfo` 는 `LeagueService` 를 통해 **DB 의 league 테이블만** 조회하므로 솔로랭크 행이 없으면 `TierInfo.UNRANKED` 를 돌려주는데, 그 값이 `(null, null, 0)` 이었습니다. 이 null 이 `DuoPost.create` → MapStruct → `DuoPostEntity.tier`/`tierRank` 로 흘러가지만 해당 컬럼은 `V18__alter_duo_tables_add_columns.sql` 에서 **NOT NULL** 로 확정돼 있어 `DataIntegrityViolationException` 이 나고, `CoreExceptionAdvice` 의 `Exception` 핸들러가 500 + `DEFAULT_ERROR` 로 변환했습니다.

**해결 방향은 "언랭은 애초에 등록 불가"입니다.** 티어 없는 글은 듀오 매칭 정보로서 가치가 없으므로, `tierAvailable` 같은 우회 필드로 표현하는 대신 도메인 규칙으로 막았습니다.

여기에 함정이 하나 있어 에러를 둘로 나눴습니다. 리그·매치 조회가 DB 만 보기 때문에 **현재 코드에서 "언랭"은 "진짜 언랭"이 아니라 "우리 DB에 리그 데이터가 없음"** 을 뜻합니다. 확인한 사실:

- 소환사·리그 데이터가 DB 에 처음 적재되는 경로는 **전적 검색**입니다
- `member` 모듈의 RSO 연동 코드에는 소환사·리그 적재 호출이 **없습니다**
- `renewalSummonerInfo` 는 `findById(puuid).orElseThrow(NOT_FOUND_PUUID)` 라 DB 에 소환사가 이미 있어야 동작합니다
- `getSummonerByPuuid` 는 Riot API 를 부르지만 소환사 기본 정보만 가져오고 리그는 가져오지 않습니다

따라서 구분 없이 차단하면 전적 검색을 거치지 않은 회원이 실제 티어와 무관하게 "언랭이라 등록 불가" 안내를 받게 됩니다. 그래서 소환사 미색인은 `SUMMONER_SEARCH_REQUIRED`("소환사 검색을 먼저 진행해주세요"), 색인은 됐지만 솔로랭크가 없으면 `DUO_UNRANKED_NOT_ALLOWED` 로 분리했습니다. 사용자가 취할 행동이 달라지기 때문입니다.

`UNRANKED` 표식을 non-null 로 되돌린 변경은 그대로 유지했습니다. guard 를 우회하는 경로(기존 행 재저장 등)에서도 NOT NULL 저장이 깨지지 않게 하는 방어선이고, V18 이 기존 행에 채운 값(`'UNRANKED'`, `'I'`)과 동일해 **데이터 마이그레이션이 필요 없습니다.**

부수적으로 `lookupAllStats` 의 `join()` 이 `CoreException` 을 `CompletionException` 으로 감싸 전역 핸들러가 잡지 못하게 만들고 있었습니다. 상위 조회의 모든 예외가 의도한 상태 코드 대신 500 으로 뭉개지므로 함께 언래핑했습니다.

## 테스트
- [x] 단위 테스트 통과 (`./gradlew test`) — 전 모듈, `archTest` 포함
- [x] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
- [x] 로컬 빌드 확인 (`./gradlew build`)
- [x] 언랭 차단 검증 — 게시글·신청 양쪽에서 `DUO_UNRANKED_NOT_ALLOWED` 가 나고 `save` 가 호출되지 않음을 확인
- [x] 미색인 구분 검증 — 소환사 데이터가 없으면 `SUMMONER_SEARCH_REQUIRED` 로 분기함을 확인
- [x] NOT NULL 계약 검증 — H2 실제 스키마에 UNRANKED 표식을 저장해 제약 위반이 없음을 확인 (표식을 null 로 되돌리면 `ConstraintViolationException` 으로 실패)

## 리뷰 포인트
- **`tierAvailable` 필드가 사실상 죽은 필드가 됩니다.** 언랭 등록이 차단되므로 `DuoPostResultModel.tierAvailable` / `DuoPostResponse.tierAvailable` 은 항상 `true` 입니다. 응답 스펙 변경(breaking change)이라 이번 PR 에서는 남겨 뒀는데, 프론트 사용처를 확인한 뒤 제거하는 게 깔끔할 것 같습니다.
- **UX 흐름 확인 필요**: 전적 검색을 거치지 않은 신규 회원은 듀오 등록 시 `SUMMONER_SEARCH_REQUIRED` 를 받습니다. 프론트에서 소환사 검색으로 유도하는 안내가 필요합니다. 근본적으로는 RSO 연동 시점에 소환사·리그를 적재하는 편이 나을 수 있는데, 이 PR 범위 밖이라 별도 이슈로 두는 게 좋겠습니다.
- **테스트 구성**: 기존 duo 단위 테스트는 영속 포트를 mock 으로 두어 저장 경로를 아예 타지 않았기 때문에 원래 버그를 놓쳤습니다. `DuoUnrankedPersistenceTest` 는 `RepositoryTestBase` 로 실제 스키마 제약을 검증합니다. duo 의 lock/notification 어댑터가 JPA 슬라이스에 없는 Redis 빈을 요구해 `@TestConfiguration` 으로 stub 을 주입했는데, 이 방식이 적절한지 봐주시면 좋겠습니다.

🤖 Generated by Padosol
