### PR TITLE
feat: MP-110 패치노트 목록 응답에 patchUrl 추가

### DIFF
--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/mapper/PatchNoteMapper.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/mapper/PatchNoteMapper.java
@@ -25,6 +25,7 @@ public class PatchNoteMapper {
         return new PatchNoteSummaryReadModel(
                 entity.getVersionId(),
                 entity.getTitle(),
+                entity.getPatchUrl(),
                 formatDate(entity.getCreatedAt())
         );
     }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/model/readmodel/PatchNoteSummaryReadModel.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/model/readmodel/PatchNoteSummaryReadModel.java
@@ -3,5 +3,6 @@ package com.example.lolserver.gamedata.application.model.readmodel;
 public record PatchNoteSummaryReadModel(
     String versionId,
     String title,
+    String patchUrl,
     String createdAt
 ) {}

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/in/web/PatchNoteControllerTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/in/web/PatchNoteControllerTest.java
@@ -41,8 +41,10 @@ class PatchNoteControllerTest extends RestDocsSupport {
     void getAllPatchNotes_성공() throws Exception {
         // given
         List<PatchNoteSummaryReadModel> patchNotes = List.of(
-                new PatchNoteSummaryReadModel("26.S1.1", "패치 26.1 노트", "2026-01-15"),
-                new PatchNoteSummaryReadModel("26.S1.2", "패치 26.2 노트", "2026-01-01")
+                new PatchNoteSummaryReadModel("26.S1.1", "패치 26.1 노트",
+                        "https://www.leagueoflegends.com/ko-kr/news/game-updates/patch-26-1-notes/", "2026-01-15"),
+                new PatchNoteSummaryReadModel("26.S1.2", "패치 26.2 노트",
+                        "https://www.leagueoflegends.com/ko-kr/news/game-updates/patch-26-2-notes/", "2026-01-01")
         );
 
         given(patchNoteService.getAllPatchNotes()).willReturn(patchNotes);
@@ -68,6 +70,9 @@ class PatchNoteControllerTest extends RestDocsSupport {
                                         .description("패치노트 버전 ID"),
                                 fieldWithPath("data[].title").type(JsonFieldType.STRING)
                                         .description("패치노트 제목"),
+                                fieldWithPath("data[].patchUrl").type(JsonFieldType.STRING)
+                                        .optional()
+                                        .description("패치노트 원본 URL (없으면 null)"),
                                 fieldWithPath("data[].createdAt").type(JsonFieldType.STRING)
                                         .description("패치노트 생성 일시")
                         )


### PR DESCRIPTION
## 배경

메인(홈) 패치노트 목록에서 라이엇 공식 페이지로 바로 이동하려면 목록 응답에 원본 URL 이 필요하다. `patch_note.patch_url` 은 이미 저장 중이고 상세 API 에서만 노출되고 있었다.

Linear: [MP-110](https://linear.app/metapick/issue/MP-110)

## 변경

- `PatchNoteSummaryReadModel` 에 `patchUrl` 필드 추가
- `PatchNoteMapper.toSummaryReadModel` 에서 `entity.getPatchUrl()` 매핑
- `PatchNoteControllerTest` RestDocs 응답 필드 문서화 갱신 (`patchUrl` optional)

기존 필드는 그대로라 하위 호환된다. 값이 없는 패치노트는 `null` 로 내려간다.

## 검증

- `./gradlew :module:domain:gamedata:test --tests "*PatchNoteControllerTest*"` 통과
- `./gradlew :module:app:application:asciidoctor` 성공 — 생성 스니펫에 `patchUrl` 반영 확인

## 연관

- padosol/lol-ui#197 — 이 필드를 사용해 새 탭으로 여는 프론트 변경

🤖 Generated by Padosol