### PR TITLE
fix: 챔피언 로테이션 주간 evict 를 실제 Redis 캐시에 연결

### DIFF
--- a/module/app/application/src/main/java/com/example/lolserver/config/CacheScheduler.java
+++ b/module/app/application/src/main/java/com/example/lolserver/config/CacheScheduler.java
@@ -1,8 +1,8 @@
 package com.example.lolserver.config;
 
+import com.example.lolserver.gamedata.application.port.in.ChampionRotateUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -11,9 +11,16 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class CacheScheduler {
 
-    @Scheduled(cron = "0 10 0 * * 2")
-    @CacheEvict(value = "rotation", allEntries = true)
+    private final ChampionRotateUseCase championRotateUseCase;
+
+    /**
+     * 챔피언 로테이션은 매주 화요일 패치와 함께 갱신되므로, 화요일 00:10 KST 에 캐시를 비운다.
+     * 이후 첫 요청이 Riot 에서 새 로테이션을 받아 다시 캐싱한다.
+     * (JVM 기본 타임존은 {@link TimeZoneConfig} 가 Asia/Seoul 로 고정한다.)
+     */
+    @Scheduled(cron = "0 10 0 * * TUE")
     public void evictRotationCache() {
+        championRotateUseCase.evictChampionRotate();
         log.info("Rotation cache has been evicted.");
     }
 }

--- a/module/app/application/src/test/java/com/example/lolserver/config/CacheSchedulerTest.java
+++ b/module/app/application/src/test/java/com/example/lolserver/config/CacheSchedulerTest.java
@@ -1,0 +1,62 @@
+package com.example.lolserver.config;
+
+import com.example.lolserver.gamedata.application.port.in.ChampionRotateUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.support.CronExpression;
+
+import java.lang.reflect.Method;
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class CacheSchedulerTest {
+
+    @InjectMocks
+    private CacheScheduler scheduler;
+
+    @Mock
+    private ChampionRotateUseCase championRotateUseCase;
+
+    @Nested
+    @DisplayName("evictRotationCache")
+    class EvictRotationCache {
+
+        @DisplayName("로테이션 캐시 제거 유스케이스를 호출한다")
+        @Test
+        void delegatesToUseCase() {
+            // when
+            scheduler.evictRotationCache();
+
+            // then
+            then(championRotateUseCase).should().evictChampionRotate();
+        }
+
+        @DisplayName("@Scheduled cron 은 매주 화요일 00:10 에 실행된다")
+        @Test
+        void scheduledEveryTuesdayAtTenPastMidnight() throws NoSuchMethodException {
+            // given
+            Method method = CacheScheduler.class.getDeclaredMethod("evictRotationCache");
+            Scheduled scheduled = method.getAnnotation(Scheduled.class);
+            assertThat(scheduled).isNotNull();
+
+            // when: 화요일 00:10 실행 직후 기준 다음 발화 시각
+            CronExpression cron = CronExpression.parse(scheduled.cron());
+            LocalDateTime justAfterFiring = LocalDateTime.of(2026, 8, 11, 0, 11);
+            LocalDateTime next = cron.next(justAfterFiring);
+
+            // then: 정확히 일주일 뒤 화요일 00:10
+            assertThat(next).isEqualTo(LocalDateTime.of(2026, 8, 18, 0, 10));
+            assertThat(next.getDayOfWeek()).isEqualTo(DayOfWeek.TUESDAY);
+        }
+    }
+}

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionCacheAdapter.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionCacheAdapter.java
@@ -4,10 +4,14 @@ import com.example.lolserver.gamedata.application.port.out.ChampionPersistencePo
 import com.example.lolserver.gamedata.domain.ChampionRotate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -23,6 +27,7 @@ public class ChampionCacheAdapter implements ChampionPersistencePort {
     // upstream→Riot 으로 관통해 rate limit 을 소모하고, 1시간을 캐싱하면 upstream 이 복구된 뒤에도
     // 빈 값이 고착된다. 짧은 TTL 의 negative cache 로 두 문제를 동시에 방지한다.
     private static final Duration EMPTY_CACHE_TTL = Duration.ofSeconds(60);
+    private static final int SCAN_COUNT = 100;
 
     @Override
     public Optional<ChampionRotate> getChampionRotate(String platformId) {
@@ -36,5 +41,32 @@ public class ChampionCacheAdapter implements ChampionPersistencePort {
         log.info("Caching champion rotation for platformId: {} (empty={}, ttl={})",
                 platformId, championRotate.isEmpty(), ttl);
         redisTemplate.opsForValue().set(CACHE_KEY_PREFIX + platformId, championRotate, ttl);
+    }
+
+    /**
+     * platformId 는 요청마다 자유롭게 들어오므로 캐시에 어떤 플랫폼이 적재돼 있는지 미리 알 수 없다.
+     * KEYS 대신 SCAN 으로 접두사 매칭 키를 모아 한 번에 삭제한다.
+     */
+    @Override
+    public void evictChampionRotate() {
+        ScanOptions options = ScanOptions.scanOptions()
+                .match(CACHE_KEY_PREFIX + "*")
+                .count(SCAN_COUNT)
+                .build();
+
+        List<String> keys = new ArrayList<>();
+        try (Cursor<String> cursor = redisTemplate.scan(options)) {
+            while (cursor.hasNext()) {
+                keys.add(cursor.next());
+            }
+        }
+
+        if (keys.isEmpty()) {
+            log.info("Champion rotation cache evict - 삭제 대상 키 없음");
+            return;
+        }
+
+        Long deleted = redisTemplate.delete(keys);
+        log.info("Champion rotation cache evicted - 대상: {}, 삭제: {}", keys.size(), deleted);
     }
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/ChampionService.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/ChampionService.java
@@ -33,4 +33,9 @@ public class ChampionService implements ChampionRotateUseCase {
             return newChampionRotate;
         }
     }
+
+    @Override
+    public void evictChampionRotate() {
+        championPersistencePort.evictChampionRotate();
+    }
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/port/in/ChampionRotateUseCase.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/port/in/ChampionRotateUseCase.java
@@ -4,4 +4,10 @@ import com.example.lolserver.gamedata.domain.ChampionRotate;
 
 public interface ChampionRotateUseCase {
     ChampionRotate getChampionRotate(String platformId);
+
+    /**
+     * 챔피언 로테이션 캐시를 전 플랫폼 제거한다.
+     * 로테이션은 매주 화요일 갱신되므로 주간 스케줄러가 호출한다.
+     */
+    void evictChampionRotate();
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/port/out/ChampionPersistencePort.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/port/out/ChampionPersistencePort.java
@@ -6,4 +6,10 @@ import java.util.Optional;
 public interface ChampionPersistencePort {
     Optional<ChampionRotate> getChampionRotate(String platformId);
     void saveChampionRotate(String platformId, ChampionRotate championRotate);
+
+    /**
+     * 캐시된 모든 플랫폼의 챔피언 로테이션을 제거한다.
+     * 로테이션은 매주 화요일 갱신되므로, 주간 스케줄러가 이 시점에 캐시를 비운다.
+     */
+    void evictChampionRotate();
 }

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionCacheAdapterTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/ChampionCacheAdapterTest.java
@@ -7,7 +7,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
@@ -15,9 +18,13 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class ChampionCacheAdapterTest {
@@ -170,5 +177,43 @@ class ChampionCacheAdapterTest {
 
         assertThat(naResult).isPresent();
         assertThat(naResult.get().getFreeChampionIds()).containsExactly(200, 201);
+    }
+
+    @DisplayName("evict 는 접두사에 매칭되는 모든 플랫폼 캐시 키를 한 번에 삭제한다")
+    @Test
+    @SuppressWarnings("unchecked")
+    void evictChampionRotate_deletesAllMatchedKeys() {
+        // given: kr / na1 두 플랫폼이 캐시에 적재된 상태
+        Cursor<String> cursor = mock(Cursor.class);
+        given(cursor.hasNext()).willReturn(true, true, false);
+        given(cursor.next()).willReturn(CACHE_KEY_PREFIX + "kr", CACHE_KEY_PREFIX + "na1");
+        given(redisTemplate.scan(any(ScanOptions.class))).willReturn(cursor);
+
+        // when
+        adapter.evictChampionRotate();
+
+        // then: SCAN 패턴은 로테이션 접두사로 한정되고, 매칭 키는 일괄 삭제된다
+        ArgumentCaptor<ScanOptions> optionsCaptor = ArgumentCaptor.forClass(ScanOptions.class);
+        then(redisTemplate).should().scan(optionsCaptor.capture());
+        assertThat(optionsCaptor.getValue().getPattern()).isEqualTo(CACHE_KEY_PREFIX + "*");
+
+        then(redisTemplate).should().delete(
+                List.of(CACHE_KEY_PREFIX + "kr", CACHE_KEY_PREFIX + "na1"));
+    }
+
+    @DisplayName("evict 대상 키가 없으면 삭제를 호출하지 않는다")
+    @Test
+    @SuppressWarnings("unchecked")
+    void evictChampionRotate_noKeys_skipsDelete() {
+        // given
+        Cursor<String> cursor = mock(Cursor.class);
+        given(cursor.hasNext()).willReturn(false);
+        given(redisTemplate.scan(any(ScanOptions.class))).willReturn(cursor);
+
+        // when
+        adapter.evictChampionRotate();
+
+        // then
+        then(redisTemplate).should(never()).delete(anyCollection());
     }
 }

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/ChampionServiceTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/ChampionServiceTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
@@ -113,5 +114,16 @@ class ChampionServiceTest {
         assertThat(result).isEqualTo(emptyRotate);
         then(championClientPort).should().getChampionRotate(platformId);
         then(championPersistencePort).should().saveChampionRotate(platformId, emptyRotate);
+    }
+
+    @DisplayName("로테이션 캐시 제거는 영속 포트에 위임하고 Riot 재조회를 유발하지 않는다")
+    @Test
+    void evictChampionRotate_포트에위임() {
+        // when
+        championService.evictChampionRotate();
+
+        // then: 제거만 하고, 다음 조회 요청이 들어올 때 비로소 클라이언트를 호출한다
+        then(championPersistencePort).should().evictChampionRotate();
+        then(championClientPort).should(never()).getChampionRotate(anyString());
     }
 }


### PR DESCRIPTION
## 관련 이슈
- 미지정 — 머지 전 Linear 키(MP-<번호>) 기입 필요

## 변경 유형
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] chore

## 변경 사항
- `CacheScheduler` — `@CacheEvict("rotation")` 제거, `ChampionRotateUseCase.evictChampionRotate()` 호출로 교체 (cron 표기만 `0 10 0 * * 2` → `0 10 0 * * TUE`, 발화 시각 동일)
- `ChampionPersistencePort` · `ChampionRotateUseCase` — `evictChampionRotate()` 추가
- `ChampionCacheAdapter` — `SCAN`(`champion_rotation_*`) 으로 전 플랫폼 키를 모아 일괄 삭제하는 evict 구현
- `ChampionService` — evict 를 영속 포트로 위임
- 테스트 — `CacheSchedulerTest`(신규, cron 발화 시각 검증 포함), `ChampionCacheAdapterTest`·`ChampionServiceTest` 케이스 추가

## 변경 이유
- 기존 `CacheScheduler` 에는 매주 화요일 00:10 cron 이 이미 걸려 있었지만, 비우는 대상이 아무도 사용하지 않는 `ConcurrentMapCacheManager("rotation")` 이었다. 실제 로테이션 캐시는 Redis `champion_rotation_{platformId}` (`ChampionCacheAdapter`) 라서, 스케줄러가 돌아도 실제 캐시에는 아무 영향이 없는 no-op 이었다.
- 챔피언 로테이션은 매주 화요일 갱신되므로 그 시점에 실제 캐시를 비우고, 이후 첫 요청이 Riot 에서 새 로테이션을 받아 다시 캐싱하도록 연결한다.

## 테스트
- [x] 단위 테스트 통과 (`./gradlew test`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
- [x] 로컬 빌드 확인 (`./gradlew build`)

추가로 `./gradlew archTest` 통과 (헥사고날 의존 규칙 위반 없음).

## 리뷰 포인트
- `platformId` 는 요청마다 자유롭게 들어와 캐시에 어떤 지역이 적재됐는지 미리 알 수 없어, `KEYS` 대신 `SCAN` 접두사 매칭으로 삭제 대상을 모읍니다 (`SummonerCacheAdapter.getRefreshingPuuids()` 와 동일 패턴). 운영 Redis 키 규모에서 문제 없는지 봐주시면 좋겠습니다.
- 캐시 TTL 1시간(`ChampionCacheAdapter.CACHE_TTL`)은 이번 변경에서 건드리지 않았습니다. 현 상태에서 evict 의 역할은 "화요일 00:10 즉시 갱신 보장" 이고, 그 외 시간에도 1시간마다 Riot 재조회가 계속됩니다. 로테이션이 주간 데이터인 만큼 TTL 을 주 단위로 늘려 evict 를 유일한 갱신 트리거로 삼을지는 별도 판단이 필요합니다.
- `CacheConfig` 의 `ConcurrentMapCacheManager("rotation")` 은 이번 변경으로 참조가 완전히 사라졌습니다. `@EnableCaching` 과 얽혀 있어 제거는 별도 정리로 남겨 두었습니다.

🤖 Generated by Padosol
