### PR TITLE
docs: LCK e스포츠 기록 테이블·API 설계 + V34 스키마 반영

### DIFF
--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -1,0 +1,609 @@
+# e스포츠 리그 기록 (LCK 순위표) — 테이블 · API 설계
+
+> 참고 화면: `https://game.naver.com/esports/League_of_Legends/record/lck/team/lck_2026`
+> 작성일: 2026-08-11 · 상태: 설계 초안 (구현 전)
+
+네이버 게임 e스포츠 "기록" 페이지와 동일한 화면을 제공하기 위한 백엔드 설계.
+새 바운디드 컨텍스트 `module/domain/esports` 를 추가하고, 리그/시즌 메타 · 팀 순위 · 선수 순위를 서빙한다.
+
+---
+
+## 1. 참고 화면 분석
+
+### 1.1 URL / 라우팅 구조
+
+```
+/esports/{loungeId}/record/{topLeagueId}/{group}/{seasonId}?position={position}
+                            └ lck        └ team|player  └ lck_2026  └ ALL|TOP|JGL|MID|AD|SPT
+```
+
+| 요소 | 값 | 비고 |
+|---|---|---|
+| `topLeagueId` | `lck`, `lpl`, `lec`, `lta` … | 상위 리그 (리그 필터) |
+| `seasonId` | `lck_2026`, `lck_2026_event` … | 시즌 (= 하위 리그 ID) |
+| `group` | `team` \| `player` | 유형 필터 (팀 순위 / 개인 순위) |
+| `position` | `ALL` \| `TOP` \| `JGL` \| `MID` \| `AD` \| `SPT` | 선수 유형일 때만 노출 |
+
+필터 UI 는 4개: **리그 · 시즌 · 유형 · 포지션**. 포지션은 유형이 `player` 일 때만 보인다.
+
+### 1.2 팀 순위표 컬럼
+
+그룹(`LEGEND` / `RISE`)별로 테이블이 분리되어 렌더링된다.
+
+| # | 헤더 | 필드 | 타입 | 정렬 | 표시 |
+|---|---|---|---|---|---|
+| 1 | 순위 | `rank` | int | – | `1` |
+| 2 | 팀 | `team` | object | – | 로고 + 팀명 |
+| 3 | 승 | `wins` | int | ✅ | `16` |
+| 4 | 패 | `loses` | int | ✅ | `6` |
+| 5 | 득실차 | `score` | int | ✅ | `+21` / `-32` |
+| 6 | 승률 | `winRate` | double | ✅ | `73%` (0.73 → 백분율) |
+| 7 | KDA | `kda` | double | ✅ | `3.92` |
+| 8 | 킬 | `kills` | int | ✅ | `822` |
+| 9 | 데스 | `deaths` | int | ✅ | `673` |
+| 10 | 어시스트 | `assists` | int | ✅ | `1,819` |
+
+- **승/패는 매치(Bo3) 기준**, **득실차는 세트 득실차**다. 예) T1 16승 6패(=22매치) / 득실차 +21.
+  같은 16승 6패라도 득실차(T1 21 > HLE 19 > GEN 18)로 순위가 갈린다.
+- 그룹 분리(LEGEND/RISE)는 확인된 범위(`lck_2025`, `lck_2026`)에서 동일하게 나타난다.
+  다만 리그·시즌마다 그룹이 없을 수 있으므로 `group_name` 은 nullable 로 두고, 없으면 단일 테이블로 렌더링한다.
+
+### 1.3 선수 순위표 컬럼
+
+| # | 헤더 | 필드 | 타입 | 정렬 | 표시 |
+|---|---|---|---|---|---|
+| 1 | 순위 | `rank` | int | – | `1` |
+| 2 | 선수 | `player` | object | – | 프로필 + 닉네임(`Duro`) |
+| 3 | 소속 | `team` | object | – | 팀 로고 + 약칭(`GEN`) |
+| 4 | 포지션 | `position` | enum | – | 아이콘 + `SPT` |
+| 5 | 포인트 | `pogPoint` | int | ✅ | `900` (POG 포인트) |
+| 6 | KDA | `kda` | double | ✅ | `6.52` |
+| 7 | 킬 | `kills` | int | ✅ | `40` |
+| 8 | 데스 | `deaths` | int | ✅ | `84` |
+| 9 | 어시스트 | `assists` | int | ✅ | `508` |
+| 10 | 킬관여율 | `killInvolveRate` | double | ✅ | `77%` |
+| 11 | 출전세트수 | `competeSetCount` | int | ✅ | `41` |
+
+- `competeTimes`(총 출전 시간, 분)는 정렬 키로만 존재하고 기본 컬럼에는 없다. 응답에는 포함시켜 두고 화면 노출은 선택.
+- 선수의 `wins`/`loses`/`score`/`winRate` 는 **해당 선수가 출전한 매치 기준** 집계값 (기본 컬럼 아님, 응답에는 포함).
+
+### 1.4 원본 데이터 소스 (참고용 · 스키마 근거)
+
+네이버 e스포츠 공개 API 를 호출해 실제 응답 스키마를 확인했다.
+
+```
+GET https://esports-api.game.naver.com/service/v1/ranking/{seasonId}/team
+GET https://esports-api.game.naver.com/service/v1/ranking/{seasonId}/player
+GET https://esports-api.game.naver.com/service/v1/meta/topLeagues
+GET https://esports-api.game.naver.com/service/v1/meta/{topLeagueId}/leagues
+```
+
+팀 응답 1건 (로고 URL 생략):
+
+```json
+{
+  "teamId": "R1040", "leagueId": "lck_2026",
+  "bracket": "split", "bracketName": "정규시즌 1-2R",
+  "groupName": "LEGEND", "groupSort": 1,
+  "rank": 1, "wins": 16, "loses": 6, "draws": 0, "score": 21, "winRate": 0.73,
+  "addInfo": {
+    "kda": 3.92, "kills": 822, "deaths": 673, "assists": 1819,
+    "firstKillRate": 1.25, "firstTowerRate": 1.25, "firstBaronRate": 1.1
+  },
+  "team": { "teamId": "R1040", "gameCode": "lol", "name": "T1",
+            "nameAcronym": "T1", "nameEng": "T1", "nameEngAcronym": "T1", "orderPoint": 1990 }
+}
+```
+
+선수 응답 1건:
+
+```json
+{
+  "playerId": "10785", "teamId": "R479", "leagueId": "lck_2026",
+  "bracket": "regular", "groupName": null,
+  "rank": 1, "wins": 14, "loses": 4, "draws": 0, "score": 19, "winRate": 0.78,
+  "position": "SPT",
+  "addInfo": { "kda": 6.52, "kills": 40, "deaths": 84, "assists": 508,
+               "killInvolveRate": 0.77, "competeSetCount": 41,
+               "competeTimes": 1279, "pogPoint": 0 },
+  "player": { "playerId": "10785", "teamId": "R479", "gameCode": "lol",
+              "name": "주민규", "nameEng": "Joo Min-kyu", "nickName": "Duro" },
+  "team": { "teamId": "R479", "name": "젠지", "nameEngAcronym": "GEN", "orderPoint": 2000 }
+}
+```
+
+> ⚠️ **데이터 출처 결정 필요.** 위 API 는 네이버 내부용 공개 엔드포인트로, 상시 의존은 약관·안정성 리스크가 있다.
+> 아래 설계는 **수집 어댑터를 포트 뒤로 숨겨** 출처를 교체 가능하게 둔다 (`EsportsRecordClientPort`).
+> 후보: ① 네이버 e스포츠 API ② LoL Esports 공식 피드(`esports-api.lolesports.com`) ③ 자체 집계(경기 결과 직접 적재).
+> 스키마 자체는 ①/②가 거의 동형이라 테이블은 그대로 재사용 가능하다.
+
+---
+
+## 2. 모듈 구조
+
+기존 컨벤션(수직 바운디드 컨텍스트 + 헥사고날)에 맞춰 `module/domain/esports` 를 신설한다.
+
+```
+module/domain/esports/
+└── src/main/java/com/example/lolserver/esports/
+    ├── domain/
+    │   ├── EsportsLeague.java          # 상위 리그 (lck)
+    │   ├── EsportsSeason.java          # 시즌 (lck_2026)
+    │   ├── EsportsTeam.java
+    │   ├── EsportsPlayer.java
+    │   ├── TeamStanding.java           # 팀 순위 행 (validate* guard 보유)
+    │   ├── PlayerStanding.java         # 선수 순위 행
+    │   ├── EsportsPosition.java        # TOP/JGL/MID/AD/SPT (+ ALL 은 필터 전용)
+    │   ├── StandingGroup.java          # LEGEND / RISE / NONE
+    │   └── Bracket.java                # SPLIT / REGULAR / PLAYOFF
+    ├── application/
+    │   ├── port/in/
+    │   │   ├── EsportsMetaQueryUseCase.java
+    │   │   ├── TeamStandingQueryUseCase.java
+    │   │   ├── PlayerStandingQueryUseCase.java
+    │   │   └── EsportsRecordSyncUseCase.java     # 수집 트리거 (스케줄러가 호출)
+    │   ├── port/out/
+    │   │   ├── EsportsMetaPersistencePort.java
+    │   │   ├── TeamStandingPersistencePort.java
+    │   │   ├── PlayerStandingPersistencePort.java
+    │   │   ├── EsportsRecordClientPort.java      # 외부 수집 (출처 교체 지점)
+    │   │   └── EsportsRecordCachePort.java
+    │   ├── command/EsportsRecordSyncCommand.java
+    │   ├── model/
+    │   │   ├── query/TeamStandingQuery.java      # seasonId, group, sort
+    │   │   ├── query/PlayerStandingQuery.java    # seasonId, position, sort
+    │   │   └── readmodel/
+    │   │       ├── LeagueReadModel.java
+    │   │       ├── SeasonReadModel.java
+    │   │       ├── TeamStandingReadModel.java
+    │   │       ├── TeamStandingGroupReadModel.java   # 그룹 헤더 + rows
+    │   │       └── PlayerStandingReadModel.java
+    │   ├── EsportsMetaService.java
+    │   ├── TeamStandingService.java
+    │   ├── PlayerStandingService.java
+    │   └── EsportsRecordSyncService.java
+    └── adapter/
+        ├── in/web/
+        │   ├── EsportsMetaController.java
+        │   ├── TeamStandingController.java
+        │   └── PlayerStandingController.java
+        └── out/
+            ├── persistence/  (Entity · JpaRepository · MapStruct Mapper · PersistenceAdapter)
+            ├── client/naver/ (NaverEsportsRecordClientAdapter · 응답 DTO · Mapper)
+            └── cache/        (EsportsRecordRedisAdapter)
+```
+
+`settings.gradle` 에 `"module:domain:esports"` 추가, `module/app/application/build.gradle` 에
+`implementation project(":module:domain:esports")` 추가. 컴포지션 루트에 `EsportsRecordSyncScheduler` 배치.
+
+`build.gradle` 는 `gamedata` 와 동일 (`web-conventions` + `persistence-conventions` + common/shared/logging + data-redis).
+
+---
+
+## 3. DB 테이블 설계
+
+마이그레이션 파일: `lol-db-schema/db/migration/V31__add_esports_record_tables.sql`
+(현재 최신은 `V30__idempotent_guards.sql`)
+
+> `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
+> 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
+
+### 3.1 ERD
+
+```
+esports_league (lck)
+   └─< esports_season (lck_2026)
+          ├─< esports_team_standing >─ esports_team
+          └─< esports_player_standing >─ esports_player
+                                       └─ esports_team
+```
+
+### 3.2 DDL
+
+```sql
+-- =============================================================
+-- V31: e스포츠 리그 기록 (팀/선수 순위표) 테이블 추가
+-- =============================================================
+-- 외부 e스포츠 API 를 주기 수집해 스냅샷으로 적재한다.
+-- 순위표는 "시즌 × 대진(bracket)" 단위로 전량 교체(upsert)되는 성격이라
+-- 이력 테이블을 따로 두지 않고 현재 상태만 유지한다.
+-- =============================================================
+
+-- 상위 리그 (LCK, LPL, LEC …)
+CREATE TABLE IF NOT EXISTS esports_league (
+    league_id         VARCHAR(50)  NOT NULL,      -- 'lck'
+    game_code         VARCHAR(20)  NOT NULL,      -- 'lol'
+    name              VARCHAR(200) NOT NULL,
+    name_acronym      VARCHAR(50),
+    name_eng          VARCHAR(200),
+    image_url         VARCHAR(500),
+    dark_image_url    VARCHAR(500),
+    sort_order        INTEGER      NOT NULL DEFAULT 0,
+    active            BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_league PRIMARY KEY (league_id)
+);
+
+-- 시즌 (= 하위 리그. 'lck_2026', 'lck_2026_event')
+CREATE TABLE IF NOT EXISTS esports_season (
+    season_id         VARCHAR(80)  NOT NULL,      -- 'lck_2026'
+    league_id         VARCHAR(50)  NOT NULL,      -- FK -> esports_league
+    name              VARCHAR(200) NOT NULL,      -- '2026 LoL 챔피언스 코리아'
+    name_acronym      VARCHAR(80),                -- '2026 LCK'
+    year              INTEGER,
+    start_date        DATE,
+    end_date          DATE,
+    sort_order        INTEGER      NOT NULL DEFAULT 0,
+    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_season PRIMARY KEY (season_id),
+    CONSTRAINT fk_esports_season_league
+        FOREIGN KEY (league_id) REFERENCES esports_league (league_id)
+);
+CREATE INDEX IF NOT EXISTS idx_esports_season_league
+    ON esports_season (league_id, sort_order DESC);
+
+-- 팀 (시즌 무관 마스터)
+CREATE TABLE IF NOT EXISTS esports_team (
+    team_id           VARCHAR(30)  NOT NULL,      -- 'R1040'
+    game_code         VARCHAR(20)  NOT NULL,
+    name              VARCHAR(100) NOT NULL,      -- 'T1'
+    name_acronym      VARCHAR(50),
+    name_eng          VARCHAR(100),
+    name_eng_acronym  VARCHAR(20),                -- 'GEN'
+    image_url         VARCHAR(500),
+    dark_image_url    VARCHAR(500),
+    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_team PRIMARY KEY (team_id)
+);
+
+-- 선수 (시즌 무관 마스터)
+CREATE TABLE IF NOT EXISTS esports_player (
+    player_id         VARCHAR(30)  NOT NULL,      -- '10785'
+    game_code         VARCHAR(20)  NOT NULL,
+    nick_name         VARCHAR(100) NOT NULL,      -- 'Duro'
+    name              VARCHAR(100),               -- '주민규'
+    name_eng          VARCHAR(100),               -- 'Joo Min-kyu'
+    image_url         VARCHAR(500),
+    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_player PRIMARY KEY (player_id)
+);
+
+-- 팀 순위표
+CREATE TABLE IF NOT EXISTS esports_team_standing (
+    season_id         VARCHAR(80)  NOT NULL,
+    bracket           VARCHAR(30)  NOT NULL,      -- 'split' | 'regular' | 'playoff'
+    team_id           VARCHAR(30)  NOT NULL,
+    bracket_name      VARCHAR(100),               -- '정규시즌 1-2R'
+    group_name        VARCHAR(50),                -- 'LEGEND' | 'RISE' | NULL
+    group_sort        INTEGER      NOT NULL DEFAULT 0,
+    team_rank         INTEGER      NOT NULL,      -- rank 는 예약어라 team_rank
+    wins              INTEGER      NOT NULL DEFAULT 0,   -- 매치 승
+    loses             INTEGER      NOT NULL DEFAULT 0,   -- 매치 패
+    draws             INTEGER      NOT NULL DEFAULT 0,
+    score             INTEGER      NOT NULL DEFAULT 0,   -- 세트 득실차
+    win_rate          NUMERIC(5,4) NOT NULL DEFAULT 0,   -- 0.7300
+    kda               NUMERIC(6,2) NOT NULL DEFAULT 0,
+    kills             INTEGER      NOT NULL DEFAULT 0,
+    deaths            INTEGER      NOT NULL DEFAULT 0,
+    assists           INTEGER      NOT NULL DEFAULT 0,
+    first_kill_rate   NUMERIC(6,2),
+    first_tower_rate  NUMERIC(6,2),
+    first_baron_rate  NUMERIC(6,2),
+    synced_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_team_standing PRIMARY KEY (season_id, bracket, team_id),
+    CONSTRAINT fk_ets_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_ets_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ets_season_group_rank
+    ON esports_team_standing (season_id, bracket, group_sort, team_rank);
+
+-- 선수 순위표
+CREATE TABLE IF NOT EXISTS esports_player_standing (
+    season_id           VARCHAR(80)  NOT NULL,
+    bracket             VARCHAR(30)  NOT NULL,
+    player_id           VARCHAR(30)  NOT NULL,
+    team_id             VARCHAR(30)  NOT NULL,
+    position            VARCHAR(10)  NOT NULL,    -- TOP|JGL|MID|AD|SPT
+    group_name          VARCHAR(50),
+    player_rank         INTEGER      NOT NULL,
+    wins                INTEGER      NOT NULL DEFAULT 0,
+    loses               INTEGER      NOT NULL DEFAULT 0,
+    draws               INTEGER      NOT NULL DEFAULT 0,
+    score               INTEGER      NOT NULL DEFAULT 0,
+    win_rate            NUMERIC(5,4) NOT NULL DEFAULT 0,
+    pog_point           INTEGER      NOT NULL DEFAULT 0,
+    kda                 NUMERIC(6,2) NOT NULL DEFAULT 0,
+    kills               INTEGER      NOT NULL DEFAULT 0,
+    deaths              INTEGER      NOT NULL DEFAULT 0,
+    assists             INTEGER      NOT NULL DEFAULT 0,
+    kill_involve_rate   NUMERIC(5,4) NOT NULL DEFAULT 0,
+    compete_set_count   INTEGER      NOT NULL DEFAULT 0,
+    compete_times       INTEGER      NOT NULL DEFAULT 0,  -- 총 출전 시간(분)
+    synced_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_player_standing PRIMARY KEY (season_id, bracket, player_id),
+    CONSTRAINT fk_eps_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_eps_player FOREIGN KEY (player_id) REFERENCES esports_player (player_id),
+    CONSTRAINT fk_eps_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+);
+CREATE INDEX IF NOT EXISTS idx_eps_season_position_rank
+    ON esports_player_standing (season_id, bracket, position, player_rank);
+CREATE INDEX IF NOT EXISTS idx_eps_season_rank
+    ON esports_player_standing (season_id, bracket, player_rank);
+```
+
+`COMMENT ON TABLE/COLUMN` 은 `V2`/`V25` 컨벤션대로 마이그레이션 하단에 함께 작성한다.
+
+### 3.3 설계 근거
+
+| 결정 | 근거 |
+|---|---|
+| `rank` → `team_rank` / `player_rank` | PostgreSQL 에서 `rank` 자체는 컬럼명으로 쓸 수 있지만 윈도우 함수 `rank()` 와 겹쳐 쿼리 가독성이 나쁘고, MySQL 8+ 에서는 예약어다. 이식성·가독성 목적 |
+| PK = `(season_id, bracket, team_id)` | 순위표는 시즌×대진 단위 스냅샷. 서로게이트 키 없이 자연키로 멱등 upsert |
+| 순위(`team_rank`)를 저장 | 원본이 리그 규정(득실차·상대전적 등)으로 계산한 값. 서버가 재계산하면 규정 차이로 어긋남 |
+| `win_rate` `NUMERIC(5,4)` | 원본이 소수(0.73)로 내려옴. 표시 시 ×100. 부동소수 누적 오차 회피 |
+| 팀/선수 마스터 분리 | 시즌마다 반복되는 이름·로고를 정규화. 로고 URL 변경이 한 곳에서 반영 |
+| `first_*_rate` NULL 허용 | 선수 순위엔 없고 리그에 따라 미제공. 화면 기본 컬럼도 아님 |
+| 이력 테이블 없음 | "현재 순위표"만 보여주는 화면. 추후 순위 추이가 필요하면 `esports_team_standing_history` 를 별도 추가 |
+
+---
+
+## 4. REST API 설계
+
+베이스 경로 `/api/v1/esports`. 응답은 프로젝트 컨벤션대로 `ApiResponse<T>` 래핑, 조회는 200.
+봉투 형태는 `{ "result": "SUCCESS" | "ERROR", "data": …, "errorMessage": … }` 이며 아래 예시의 `data` 안쪽만
+엔드포인트별로 달라진다.
+
+### 4.1 엔드포인트 요약
+
+| Method | Path | 설명 |
+|---|---|---|
+| GET | `/api/v1/esports/leagues` | 리그 목록 (리그 필터) |
+| GET | `/api/v1/esports/leagues/{leagueId}/seasons` | 시즌 목록 (시즌 필터) |
+| GET | `/api/v1/esports/seasons/{seasonId}/team-standings` | 팀 순위표 |
+| GET | `/api/v1/esports/seasons/{seasonId}/player-standings` | 선수 순위표 |
+
+> 화면 진입 시 리그·시즌 필터가 먼저 필요하므로 메타 2개를 분리했다.
+> 첫 화면 왕복을 줄이려면 `/leagues?includeSeasons=true` 로 한 번에 내려주는 옵션을 둘 수 있다.
+
+### 4.2 `GET /api/v1/esports/leagues`
+
+```json
+{
+  "result": "SUCCESS",
+  "data": [
+    {
+      "leagueId": "lck",
+      "name": "LoL 챔피언스 코리아",
+      "nameAcronym": "LCK",
+      "imageUrl": "https://.../lck.png",
+      "darkImageUrl": "https://.../lck_black.png",
+      "latestSeasonId": "lck_2026"
+    }
+  ]
+}
+```
+
+`latestSeasonId` 는 리그 전환 시 곧바로 이동할 시즌. 프런트가 시즌 목록을 기다리지 않아도 된다.
+
+### 4.3 `GET /api/v1/esports/leagues/{leagueId}/seasons`
+
+```json
+{
+  "result": "SUCCESS",
+  "data": [
+    { "seasonId": "lck_2026", "name": "2026 LoL 챔피언스 코리아",
+      "nameAcronym": "2026 LCK", "year": 2026,
+      "startDate": "2026-01-14", "endDate": null, "brackets": [
+        { "bracket": "SPLIT", "bracketName": "정규시즌 1-2R" }
+      ] }
+  ]
+}
+```
+
+### 4.4 `GET /api/v1/esports/seasons/{seasonId}/team-standings`
+
+**Query**
+
+| 파라미터 | 타입 | 기본 | 설명 |
+|---|---|---|---|
+| `bracket` | enum | 시즌의 최신 대진 | `SPLIT` \| `REGULAR` \| `PLAYOFF` |
+| `sort` | enum | `RANK` | `RANK`,`WINS`,`LOSES`,`SCORE`,`WIN_RATE`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS` |
+| `order` | enum | `ASC`(RANK) / `DESC`(그 외) | `ASC` \| `DESC` |
+
+**응답** — 그룹(LEGEND/RISE)별로 묶어서 내려준다. 그룹이 없는 리그는 `groupName: null` 인 단일 그룹.
+
+```json
+{
+  "result": "SUCCESS",
+  "data": {
+    "seasonId": "lck_2026",
+    "bracket": "SPLIT",
+    "bracketName": "정규시즌 1-2R",
+    "sort": "RANK",
+    "order": "ASC",
+    "syncedAt": "2026-08-11T04:10:00",
+    "groups": [
+      {
+        "groupName": "LEGEND",
+        "groupSort": 1,
+        "standings": [
+          {
+            "rank": 1,
+            "team": {
+              "teamId": "R1040", "name": "T1", "nameAcronym": "T1",
+              "nameEngAcronym": "T1",
+              "imageUrl": "https://.../t1.png", "darkImageUrl": "https://.../t1_black.png"
+            },
+            "wins": 16, "loses": 6, "draws": 0,
+            "score": 21,
+            "winRate": 0.73,
+            "kda": 3.92, "kills": 822, "deaths": 673, "assists": 1819,
+            "firstKillRate": 1.25, "firstTowerRate": 1.25, "firstBaronRate": 1.1
+          }
+        ]
+      },
+      { "groupName": "RISE", "groupSort": 2, "standings": [] }
+    ]
+  }
+}
+```
+
+- `winRate` 는 **소수 그대로** 내려주고 백분율 변환은 프런트가 한다 (표시 포맷은 UI 책임).
+- `sort` 가 `RANK` 가 아니면 그룹을 유지한 채 그룹 내부만 재정렬한다.
+  전체 통합 정렬이 필요하면 `groupBy=NONE` 옵션을 추가하는 방향으로 확장.
+
+### 4.5 `GET /api/v1/esports/seasons/{seasonId}/player-standings`
+
+**Query**
+
+| 파라미터 | 타입 | 기본 | 설명 |
+|---|---|---|---|
+| `bracket` | enum | 시즌의 최신 대진 | `SPLIT` \| `REGULAR` \| `PLAYOFF` |
+| `position` | enum | `ALL` | `ALL`,`TOP`,`JGL`,`MID`,`AD`,`SPT` |
+| `sort` | enum | `RANK` | `RANK`,`POG_POINT`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS`,`KILL_INVOLVE_RATE`,`COMPETE_SET_COUNT`,`COMPETE_TIMES` |
+| `order` | enum | `ASC`(RANK) / `DESC`(그 외) | `ASC` \| `DESC` |
+
+**응답**
+
+```json
+{
+  "result": "SUCCESS",
+  "data": {
+    "seasonId": "lck_2026",
+    "bracket": "REGULAR",
+    "position": "ALL",
+    "sort": "RANK",
+    "order": "ASC",
+    "syncedAt": "2026-08-11T04:10:00",
+    "standings": [
+      {
+        "rank": 1,
+        "player": {
+          "playerId": "10785", "nickName": "Duro",
+          "name": "주민규", "nameEng": "Joo Min-kyu",
+          "imageUrl": "https://.../duro.png"
+        },
+        "team": {
+          "teamId": "R479", "name": "젠지", "nameEngAcronym": "GEN",
+          "imageUrl": "https://.../gen.png", "darkImageUrl": "https://.../gen_black.png"
+        },
+        "position": "SPT",
+        "pogPoint": 0,
+        "kda": 6.52, "kills": 40, "deaths": 84, "assists": 508,
+        "killInvolveRate": 0.77,
+        "competeSetCount": 41,
+        "competeTimes": 1279,
+        "wins": 14, "loses": 4, "draws": 0, "score": 19, "winRate": 0.78
+      }
+    ]
+  }
+}
+```
+
+- **페이징 없음.** 시즌당 선수 60~70명, 팀 10팀 규모라 전량 반환이 화면 요구(정렬 시 전체 재정렬)에 맞다.
+  다른 리그를 붙여 규모가 커지면 그때 `PageResponse` 로 전환.
+- `position=ALL` 이 아니면 필터 후 **순위를 재계산하지 않고** 원본 `rank` 를 유지한다 (네이버 동작과 동일).
+  포지션 내 순번이 필요하면 프런트에서 인덱스로 표시.
+
+### 4.6 에러
+
+| 상황 | 코드 | 처리 |
+|---|---|---|
+| 없는 `seasonId` | 404 | `EsportsSeasonNotFoundException` → 공통 핸들러 |
+| 잘못된 `sort`/`position`/`bracket` | 400 | enum 바인딩 실패 → 공통 핸들러 |
+| 순위 데이터 미수집 (시즌 개막 전) | 200 | 빈 `groups`/`standings` + `syncedAt: null` |
+
+---
+
+## 5. 정렬 · 필터 처리 위치
+
+시즌 × 대진 단위 데이터가 최대 70행이므로, **DB 에서는 `(season_id, bracket)` 기준 flat 리스트를
+`rank` 순으로 한 번만 읽어 캐시**하고, `position` 필터와 `sort` 는 애플리케이션에서 처리한다.
+
+| 항목 | 처리 위치 | 이유 |
+|---|---|---|
+| `seasonId` + `bracket` | DB (PK 선행 컬럼) | 캐시 미스 시 기본 조회 단위. 인덱스 선두 |
+| `position` 필터 | 애플리케이션 (캐시된 리스트) | 캐시 키 폭발 방지 (포지션 6종 × 정렬 9종 = 54키). 70행 필터는 무시할 비용 |
+| `sort` | 애플리케이션 `Comparator` (화이트리스트 enum) | 위와 동일. 정렬 키를 enum 으로 강제해 매직 스트링 차단 |
+| 그룹 묶음 | 애플리케이션 | `groupSort` 순 flat 결과를 ReadModel 조립 시 `LinkedHashMap` 으로 그룹핑 |
+
+> 리그를 확장해 한 응답이 수백~수천 행이 되면 이 판단을 뒤집어야 한다.
+> 그때는 `position` 필터를 `idx_eps_season_position_rank` 로, `sort` 를 QueryDSL `ORDER BY` 로 내리고
+> 캐시는 페이지 단위로 잘게 쪼갠다.
+
+정렬 키는 도메인 enum 으로 정의하고, 각 키에서 `Comparator` 를 얻는 매핑은 애플리케이션에 둔다.
+
+```java
+public enum TeamStandingSort {
+    RANK, WINS, LOSES, SCORE, WIN_RATE, KDA, KILLS, DEATHS, ASSISTS
+}
+```
+
+---
+
+## 6. 캐시 전략
+
+| 키 | 값 | TTL | 무효화 |
+|---|---|---|---|
+| `esports:leagues` | 리그 목록 | 24h | 수집 성공 시 evict |
+| `esports:seasons:{leagueId}` | 시즌 목록 | 24h | 수집 성공 시 evict |
+| `esports:standings:team:{seasonId}:{bracket}` | 팀 순위 flat 리스트 | 10m | 수집 성공 시 evict |
+| `esports:standings:player:{seasonId}:{bracket}` | 선수 순위 flat 리스트 | 10m | 수집 성공 시 evict |
+
+- **정렬/포지션 필터는 캐시 키에 넣지 않는다** (§5 참고). 캐시에는 `rank` 순 flat 리스트만 담는다.
+- 값 클래스는 `GenericJackson2JsonRedisSerializer` 로 직렬화된다. **캐시 대상 ReadModel 에
+  파생 boolean getter 를 추가하면 기존 엔트리 역직렬화가 전량 실패**하므로, 파생 getter 에는 `@JsonIgnore` 를 붙이고
+  클래스 이동·리네임 시에는 배포 때 해당 키를 flush 한다.
+
+---
+
+## 7. 수집 (Sync)
+
+```java
+// 경기 시간대(KST 18~23시) 10분 간격 — 경기 종료 직후 순위 반영
+@Scheduled(cron = "0 0/10 18-23 * * *")
+public void syncActiveSeasons() { ... }
+
+// 새벽 전체 정합성 보정 (메타 + 종료 직전 시즌 포함)
+@Scheduled(cron = "0 30 4 * * *")
+public void syncAll() { ... }
+```
+
+- 컴포지션 루트(`module/app/application/src/main/java/.../config/EsportsRecordSyncScheduler.java`)에 배치.
+  `CacheScheduler` 와 동일 패턴 (`@Scheduled` + UseCase 호출).
+- 수집 단위: **시즌 × 대진**. `EsportsRecordSyncService` 가
+  ① 메타(리그·시즌) 동기화 → ② 활성 시즌 목록 산출 → ③ 팀/선수 순위 upsert → ④ 캐시 evict 순으로 진행.
+- **upsert 는 전량 교체가 아니라 `INSERT ... ON CONFLICT DO UPDATE`** 로 처리한다.
+  선수 로스터 변동으로 사라진 행은 `synced_at` 이 갱신되지 않으므로, 수집 종료 시
+  `DELETE ... WHERE season_id=? AND bracket=? AND synced_at < ?` 로 정리한다.
+- 외부 호출 실패 시 기존 데이터를 유지하고 로그만 남긴다 (순위표는 stale 해도 화면이 비는 것보다 낫다).
+- 활성 시즌 판별: `esports_season.end_date IS NULL OR end_date >= today()`. 종료된 시즌은 수집 대상에서 제외.
+
+---
+
+## 8. 구현 순서
+
+1. `module/domain/esports` 모듈 생성 + `settings.gradle` / 컴포지션 루트 등록 (빈 컨트롤러로 부팅 확인)
+2. `V31` 마이그레이션 작성 + 엔티티/JPA 리포지토리
+3. 도메인 모델 + 포트 정의, `ArchUnit` 아키텍처 테스트 추가 (다른 컨텍스트와 동일 규칙)
+4. 수집 어댑터(`EsportsRecordClientAdapter`) + `EsportsRecordSyncService` — 여기서 **데이터 출처 확정 필요**
+5. 조회 서비스 + 컨트롤러 + ReadModel
+6. Redis 캐시 어댑터 연결
+7. RestDocs 테스트 → `./gradlew :module:infra:api:asciidoctor`
+8. 스케줄러 등록 및 운영 프로파일 cron 조정
+
+---
+
+## 9. 열린 이슈
+
+| # | 이슈 | 필요한 결정 |
+|---|---|---|
+| 1 | **데이터 출처** | 네이버 API 상시 의존 여부. 약관 확인 필요. 대안은 LoL Esports 공식 피드 또는 자체 집계 |
+| 2 | 지원 리그 범위 | LCK 만인지, LPL/LEC/LTA 까지인지. 후자면 수집량·캐시 키 설계는 그대로지만 페이징 검토 필요 |
+| 3 | 플레이오프 대진 | 현재 확인된 bracket 은 `split`(팀) / `regular`(선수) 뿐. 플레이오프 진행 시 값 추가 확인 필요 |
+| 4 | 선수 프로필 이미지 | 네이버 응답의 이미지 URL 을 그대로 저장·노출할지, 자체 CDN 으로 미러링할지 |
+| 5 | 순위 추이 | 주차별 순위 변동 그래프가 요구사항이면 `*_history` 테이블을 초기 설계에 포함하는 편이 낫다 |

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -227,14 +227,19 @@ module/domain/esports/src/main/java/com/example/lolserver/esports/
 
 ## 6. DB 테이블 설계
 
-마이그레이션: `lol-db-schema/db/migration/V33__add_esports_record_tables.sql`
+마이그레이션: **`lol-db-schema/db/migration/V33__add_esports_record_tables.sql` — 작성 완료**
+(`lol-db-schema` 브랜치 `feature/MP-XXX-esports-record`)
 
 > `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
 > 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
 >
-> **버전 번호는 착수 시점에 다시 확인한다.** 서브모듈은 이 리포와 독립적으로 진행되므로
-> 문서에 적힌 번호가 그사이 선점될 수 있다 (`V31`·`V32` 가 커뮤니티 작업으로 이미 사용됐다).
-> `ls db/migration | sort -V | tail -1` 로 최신을 확인하고 그다음 번호를 쓴다.
+> **머지 순서 주의**: 현재 포인터는 서브모듈의 *브랜치* 커밋을 가리킨다.
+> 이 브랜치를 `develop` 에 머지하기 전에 서브모듈 PR 을 먼저 머지하고 포인터를 `main` 커밋으로 옮겨야 한다.
+>
+> **버전 번호는 머지 직전에 다시 확인한다.** 서브모듈은 이 리포와 독립적으로 진행되므로
+> 그사이 `V33` 이 선점될 수 있다 (`V31`·`V32` 가 커뮤니티 작업으로 이미 그렇게 됐다).
+> `ls db/migration | sort -V | tail -1` 로 최신을 확인하고, 선점됐다면 파일명을 리넘버링한다
+> (서브모듈 README 의 Flyway checksum 가드 참고).
 
 | 서브모듈 최신 (`origin/main` `23723cc`) | 내용 |
 |---|---|
@@ -699,11 +704,16 @@ SELECT 'lck_2026', team_id, 1, 'worlds_2026', 1 FROM esports_team WHERE team_cod
 
 ### 6.9 스키마 검증
 
-로컬 Postgres 16 에서 DDL 과 제약 동작을 실행하고 `ROLLBACK` 했다.
+`V33` 을 단독으로 실행한 것이 아니라 **빈 DB 에 `V1`~`V33` 전체 마이그레이션 체인을 순서대로 적용**해
+실제 스키마 위에 올라가는지 확인했다 (로컬 `postgres:16-alpine`). 이후 제약 동작은 `ROLLBACK` 으로 검증했다.
 
 | 확인 | 기대 | 실제 |
 |---|---|---|
-| DDL 전체 생성 | 성공 | **테이블 15 · 인덱스 11 · 뷰 4** |
+| V1~V33 전체 체인 적용 | 29개 파일 전부 성공 | **전부 성공** |
+| V33 이 만든 객체 | 테이블 15 · 인덱스 11 · 뷰 4 | **일치** (테이블 코멘트 누락 0) |
+| `btree_gist` 확장 | 생성됨 | **생성됨** |
+| `ck_roster_period` (`left_at <= joined_at`) | CHECK 가 거부 | **거부** |
+| `ck_esports_stage_format` (정의 밖 포맷) | CHECK 가 거부 | **거부** |
 | 리그 국제/지역 구분 | `worlds`=국제, `lck`·`lpl`=지역 | 일치 |
 | 롤드컵 스테이지 3단 | `SWISS` 는 `standing_key` 보유, `BRACKET` 은 NULL | 일치 |
 | 팀 → 홈 리그 조회 | `T1→한국`, `BLG→중국` | 일치 |
@@ -1134,8 +1144,8 @@ DDL → 시즌 구조 시드 → 매치 입력 → 검증 뷰 3종 → 집계 �
 **1단계 — 팀 순위표 (외부 의존 0)**
 
 1. `module/domain/esports` 생성 + `settings.gradle` / 컴포지션 루트 등록
-2. `V33` 마이그레이션 (마스터 + 로스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)
-   — 착수 시점에 서브모듈 최신 번호를 다시 확인할 것 (§6 머리말)
+2. ~~`V33` 마이그레이션 (마스터 + 로스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)~~
+   **완료** — V1~V33 전체 체인을 빈 DB 에 적용해 검증했다 (§6.9)
 3. 마스터 시드: LCK 10팀 · `lck_2026` 시즌 · **스테이지 5개**(§8.1)
 4. **`StandingCalculator` · `GroupSplitter` · `TieBreakRule` 단위 테스트 먼저**
    — 동률 3팀(§2.4), 공동 순위, 누적 합산(§2.2) 시나리오를 재현

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -7,8 +7,8 @@
 새 바운디드 컨텍스트 `module/domain/esports` 를 추가한다.
 
 > **v2 개정 요지** — v1은 외부 API가 이미 집계해 둔 순위표를 스냅샷으로 적재하는 설계였다.
-> 실제 API 3종을 호출해 검증한 결과(§2) **공식 API만으로는 화면 컬럼의 절반을 채울 수 없고**,
-> 전부 채워주는 유일한 출처는 비공식 API였다. 따라서 **경기 원장을 우리 DB의 진실원천으로 두고
+> 실제 API 3종을 호출해 검증한 결과(§2) **라이엇에는 문서화된 e스포츠 공개 API 자체가 없고**,
+> 실제로 쓸 수 있는 세 출처는 전부 비문서화 내부 API였다. 따라서 **경기 원장을 우리 DB의 진실원천으로 두고
 > 순위표는 집계 산출물로 만드는 구조**로 전환한다. 이력(순위 추이) 테이블도 다시 포함한다.
 
 ---
@@ -75,7 +75,17 @@
 
 세 경로를 모두 직접 호출해 확인했다. **셋 다 실재하고 응답한다.** 차이는 "무엇까지 주는가"다.
 
-### 2.1 라이엇 공식 LoL Esports API
+### 2.1 lolesports.com 내부 API — ⚠️ "공식"이 아니다
+
+> **용어 정정.** 이 문서 v2 초판은 이 출처를 "라이엇 공식 API" 라고 불렀다. **부정확하다.**
+> `esports-api.lolesports.com` 은 라이엇이 소유·운영하는 lolesports.com 의 백엔드이고 데이터도 라이엇 1차 출처지만,
+> **Riot Developer Portal 에 문서화된 공개 API 가 아니다.** 개발자 포털 API 목록(`developer.riotgames.com/apis`)을
+> 확인한 결과 **프로 e스포츠 경기·순위 API 는 존재하지 않는다** — `tournament-v5` 는 서드파티가 자체 대회를 여는
+> 용도지 LCK 데이터가 아니다.
+>
+> 인증에 쓰는 `x-api-key` 는 웹 클라이언트에 하드코딩되어 커뮤니티에 알려진 공개 키다.
+> 즉 **성격상 네이버 API 와 같은 범주(비문서화 내부 API)** 이며, 차이는 "라이엇 1차 데이터냐 3자 가공이냐" 뿐이다.
+> 레이트리밋·스키마 안정성·사용 허가 어느 것도 보장되지 않는다.
 
 ```
 GET https://esports-api.lolesports.com/persisted/gw/getLeagues?hl=ko-KR
@@ -132,15 +142,73 @@ GET https://esports-api.game.naver.com/service/v1/meta/{topLeagueId}/leagues
 
 ### 2.3 판단
 
-| 출처 | 팀 승/패 | 득실차·승률 | 팀·선수 KDA | POG | 상시 의존 |
+| 출처 | 문서화된 공개 API | 팀 승/패 | 득실차·승률 | 팀·선수 KDA | POG |
 |---|---|---|---|---|---|
-| 공식 Esports API | ✅ | ❌ (원장에서 유도 가능) | ❌ (livestats 별도 수집) | ❌ | ✅ |
-| livestats 피드 | – | – | ⚠️ 세트별 수집·파싱 필요 | ❌ | ⚠️ |
-| 네이버 API | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Riot Developer Portal | ✅ | **e스포츠 API 자체가 없음** | – | – | – |
+| lolesports.com 내부 API | ❌ | ✅ | ❌ (원장에서 유도) | ❌ (livestats 별도) | ❌ |
+| livestats 피드 | ❌ | – | – | ⚠️ 세트별 수집·파싱 | ❌ |
+| 네이버 API | ❌ | ✅ | ✅ | ✅ | ✅ |
 
-**→ 지적하신 방향이 맞다.** 어떤 단일 API도 화면을 그대로 채워주지 않고, 채워주는 하나는 의존할 수 없다.
+### 2.4 직접 확인용 URL
+
+각 출처를 눈으로 검증할 수 있는 주소. **브라우저에 그대로 붙여넣어 열리는 것**과 헤더가 필요한 것이 갈린다.
+
+**브라우저에서 바로 열림** (인증 헤더 불필요, HTTP 200 확인)
+
+```
+# 네이버 — LCK 2026 팀 순위 (화면의 팀 탭 원본)
+https://esports-api.game.naver.com/service/v1/ranking/lck_2026/team
+
+# 네이버 — LCK 2026 선수 순위 (화면의 선수 탭 원본)
+https://esports-api.game.naver.com/service/v1/ranking/lck_2026/player
+
+# 네이버 — LCK 시즌 목록 (시즌 필터 원본)
+https://esports-api.game.naver.com/service/v1/meta/lck/leagues
+
+# 네이버 — 리그 목록 (리그 필터 원본)
+https://esports-api.game.naver.com/service/v1/meta/topLeagues
+
+# lolesports livestats — 세트별 선수 K/D/A (프레임 시계열)
+https://feed.lolesports.com/livestats/v1/window/116951349275512133
+```
+
+**헤더 필요** — 주소창에 붙여넣으면 `403 Forbidden` 이다. `x-api-key` 를 넣어야 한다.
+
+```bash
+K=0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z
+
+# 리그 목록 (LCK leagueId = 98767991310872058)
+curl -s -H "x-api-key: $K" \
+  "https://esports-api.lolesports.com/persisted/gw/getLeagues?hl=ko-KR" | jq .
+
+# LCK 토너먼트(시즌) 목록
+curl -s -H "x-api-key: $K" \
+  "https://esports-api.lolesports.com/persisted/gw/getTournamentsForLeague?hl=ko-KR&leagueId=98767991310872058" | jq .
+
+# 2026 스플릿3 순위 — 레전드/라이즈 그룹 구조가 보인다
+curl -s -H "x-api-key: $K" \
+  "https://esports-api.lolesports.com/persisted/gw/getStandingsV3?hl=ko-KR&tournamentId=115548147890329817" | jq .
+
+# 완료된 경기 — 팀코드·gameWins·주차(blockName), 그리고 §2.1 의 미플레이 세트 함정
+curl -s -H "x-api-key: $K" \
+  "https://esports-api.lolesports.com/persisted/gw/getCompletedEvents?hl=ko-KR&leagueId=98767991310872058" | jq .
+```
+
+헤더가 필요하다는 사실 자체가 **이것이 웹 클라이언트 전용 내부 API** 라는 방증이다.
+브라우저에서 보려면 <https://lolesports.com> 에 접속해 개발자도구 Network 탭을 여는 편이 정확하다.
+
+**참고** — 라이엇 공식 개발자 포털: <https://developer.riotgames.com/apis>
+(위 목록 어디에도 e스포츠 경기·순위 API 는 없다. 직접 확인 가능)
+
+**→ 지적하신 방향이 맞다.** 정리하면:
+
+1. **문서화된 공식 경로는 아예 없다.** 라이엇이 프로 e스포츠 데이터를 퍼블릭 API 로 제공하지 않는다.
+2. 실제로 쓸 수 있는 세 출처는 **전부 비문서화 내부 API** 다. 안정성·허가가 보장되는 곳이 하나도 없다.
+3. 화면을 그대로 채워주는 유일한 곳(네이버)은 3자 가공 데이터라 더더욱 의존할 수 없다.
+
+세 출처 모두 언제든 막힐 수 있다는 뜻이므로, **어디에도 상시 의존하지 않는 설계가 유일한 안전한 선택**이다.
 따라서 **경기 원장을 우리 DB에 두고 순위표를 집계로 만든다.** 외부 API 는 원장을 채우는
-*선택적 보조 입력*으로 격하하고, 없어도 시스템이 성립하게 한다.
+*일회성·선택적 보조 입력*으로 격하하고, 전부 막혀도 관리자 입력만으로 시스템이 성립하게 한다.
 
 ---
 
@@ -337,7 +405,7 @@ CREATE TABLE IF NOT EXISTS esports_match (
     home_score    SMALLINT     NOT NULL,         -- 세트 승수 (2)
     away_score    SMALLINT     NOT NULL,         -- 세트 승수 (1)
     status        VARCHAR(20)  NOT NULL DEFAULT 'COMPLETED',  -- SCHEDULED|COMPLETED|CANCELED
-    external_ref  VARCHAR(60),                   -- 공식 API match id (중복 적재 방지)
+    external_ref  VARCHAR(60),                   -- 외부 출처 match id (중복 적재 방지)
     created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_match PRIMARY KEY (match_id),
@@ -773,7 +841,7 @@ public void aggregateActiveSeasons() { ... }
 
 | # | 이슈 | 결정 필요 사항 |
 |---|---|---|
-| 1 | **원장 초기 적재** | 공식 API `getCompletedEvents` 로 1회 임포트 — **권장**. LCK 매치가 실제로 내려오는 것과 팀코드·`gameWins`·주차(`blockName`)까지 확보되는 것을 확인했다. 단 ① 응답이 전 리그 혼합 최근 300건이라 **시즌 전체를 긁으려면 페이징 확인 필요** ② §2.1 의 미플레이 세트 함정 처리 필수 |
+| 1 | **원장 초기 적재** | lolesports 내부 API `getCompletedEvents` 로 1회 임포트 — 조건부 권장. LCK 매치가 실제로 내려오고 팀코드·`gameWins`·주차(`blockName`)까지 확보되는 것은 확인했다. 단 ① **비문서화 API 이므로 1회성 임포트로 한정**하고 상시 호출 경로로 만들지 말 것 ② 응답이 전 리그 혼합 최근 300건이라 시즌 전체는 페이징 확인 필요 ③ §2.1 의 미플레이 세트 함정 처리 필수. 법무/약관 판단이 걸리면 **수기 입력 110건이 현실적 대안**이다 |
 | 2 | 동점 규칙 | LCK 규정의 정확한 타이브레이커 순서(득실차 → 상대전적 → ?) 확인 필요. `TieBreakRule` 구현 전 확정해야 함 |
 | 3 | POG 산정 단위 | 원본 POG 총합 9,000점(=90회)이 총 매치 110건과 맞지 않음. 세트당인지 매치당인지, 미집계 구간이 있는지 확인 필요 |
 | 4 | 선수 기록 확보 경로 | livestats 수집(세트 245회 호출·파싱) vs CSV 일괄 적재 vs 2단계 자체 보류 |

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -1,22 +1,29 @@
 # e스포츠 리그 기록 (LCK 순위표) — 테이블 · API 설계
 
 > 참고 화면: `https://game.naver.com/esports/League_of_Legends/record/lck/team/lck_2026`
-> 작성일: 2026-08-11 · 개정: **v3 (LCK 시즌 구조 반영 + 수기 입력 확정)** · 상태: 설계 초안
-
-네이버 게임 e스포츠 "기록" 페이지와 동일한 화면을 제공하기 위한 백엔드 설계.
-새 바운디드 컨텍스트 `module/domain/esports` 를 추가한다.
-
-**개정 이력**
-
-| 버전 | 변경 |
-|---|---|
-| v1 | 외부 API 순위표를 스냅샷으로 적재하는 설계 |
-| v2 | API 3종 검증 → 어느 것도 화면을 못 채우거나 의존 불가 → **원장 기반 집계**로 전환, 이력 테이블 복원 |
-| **v3** | **LCK 시즌 구조(스테이지) 반영**, 그룹 편성을 집계 산출물로 재정의, **수기 입력 확정**에 따라 외부 수집 경로 제거 |
+> 상태: 설계 초안 · 최종 정리 2026-08-13
 
 ---
 
-## 1. LCK 시즌 구조
+## 1. 개요
+
+네이버 게임 e스포츠 "기록" 페이지와 동일한 화면(팀 순위표 · 선수 순위표 · 순위 추이)을
+제공하기 위한 백엔드 설계다. 새 바운디드 컨텍스트 `module/domain/esports` 를 추가한다.
+
+세 가지가 이 설계를 규정한다.
+
+| 전제 | 내용 |
+|---|---|
+| **데이터는 수기 입력** | 관리자 페이지가 없으므로 DB 에 직접 넣는다. 외부 수집 경로는 두지 않는다 (§3) |
+| **진실원천은 원장** | 경기 결과를 원장에 쌓고 순위표는 **집계 산출물**로 만든다. 언제든 버리고 다시 만들 수 있다 (§4) |
+| **시즌은 여러 단계로 쪼개진다** | LCK 한 시즌 안에 성격이 다른 5개 단계가 있고 팀당 매치 수도 다르다. `esports_stage` 가 이를 표현한다 (§6.3) |
+
+본 문서의 DDL 전체(**테이블 15 · 인덱스 11 · 뷰 4**)와 집계 산식은 로컬 `postgres:16-alpine` 에서
+`BEGIN … ROLLBACK` 으로 실제 실행해 검증했다 (§6.9, §8.5).
+
+---
+
+## 2. LCK 시즌 구조
 
 설계의 뼈대다. 이 구조를 테이블로 표현하지 못하면 나머지가 전부 어긋난다.
 
@@ -40,19 +47,19 @@
 [롤드컵] LCK 최종 순위에 따른 시드권
 ```
 
-### 1.1 실제 데이터로 검증한 결과
+### 2.1 실제 데이터 대조
 
-주신 구조가 실제 데이터와 정확히 일치하는지 대조했다.
+위 구조가 실제 데이터와 일치하는지 확인했다.
 
-| 주신 설명 | 실제 데이터 | 확인 |
+| 구조 | 실제 데이터 | 확인 |
 |---|---|---|
 | 1~2R 10팀 단일 풀리그 | `lck_split_2_2026` 의 `regular_season` 스테이지 — 10팀, 팀당 18매치 | ✅ |
 | 2R 성적으로 Legend/Rise 분리 | 1~2R 상위5 = HLE·T1·GEN·KT·DK / 하위5 = BRO·BFX·KRX·NS·DNS | ✅ |
-| 3~5R 그룹 내부 리그 | `lck_split_3_2026` 의 `groups` 스테이지 — **레전드 그룹 5팀 / 라이즈 그룹 5팀** | ✅ 편성 완전 일치 |
+| 3~5R 그룹 내부 리그 | `lck_split_3_2026` 의 `groups` 스테이지 — 레전드 그룹 5팀 / 라이즈 그룹 5팀 | ✅ 편성 완전 일치 |
 | MSI 진출전 | `lck_split_2_2026` 의 `road_to_msi` (bracket) | ✅ |
 | 플레이인 / 플레이오프 | `lck_split_3_2026` 의 `play_ins`, `regional_championship` (bracket) | ✅ |
 
-### 1.2 ★ 결정적 발견 — 화면의 순위표는 **여러 스테이지의 누적 합산**이다
+### 2.2 ★ 순위표는 여러 스테이지의 누적 합산이다
 
 네이버 화면이 `정규시즌 1-2R` 이라 표기한 순위표를 스테이지별로 분해해 보았다.
 
@@ -66,15 +73,17 @@
 | KRX | 5승 13패 | 2승 2패 | **7승 15패** | 7승 15패 ✅ |
 
 10팀 중 6팀이 정확히 일치했고, 나머지 4팀(KT·DK·NS·DNS)은 **정확히 경기 2건만큼** 어긋났다 —
-`DK 1승 ↔ KT 1패`, `DNS 1승 ↔ NS 1패` 로 승패가 짝을 이룬다. **두 출처의 스냅샷 시점 차이**이지
-집계 규칙 차이가 아니다(공식 데이터가 최신).
+`DK 1승 ↔ KT 1패`, `DNS 1승 ↔ NS 1패` 로 승패가 짝을 이룬다. 두 출처의 **스냅샷 시점 차이**이지
+집계 규칙 차이가 아니다.
 
 > **설계 요구사항으로 번역하면:**
 > 1. 순위표는 단일 스테이지가 아니라 **"어떤 스테이지들을 합산할지"** 를 지정할 수 있어야 한다.
 > 2. 팀당 매치 수가 스테이지마다 다르다 (1~2R 18매치, 3~5R 12매치). **라운드 수를 코드에 박으면 안 된다.**
 > 3. 합산 순위표의 그룹 표시는 **3~5R 의 편성**을 따른다 (1~2R 에는 그룹이 없다).
 
-### 1.3 화면 컬럼
+이 요구를 `esports_stage.standing_key` 하나로 흡수한다 (§6.3).
+
+### 2.3 화면 컬럼
 
 **팀 순위표** — 그룹별로 테이블이 분리된다.
 
@@ -97,24 +106,29 @@
 | 킬관여율 | `killInvolveRate` | ✅ | ⚠️ (선수 K+A) ÷ 팀 킬 |
 | 출전세트수 | `competeSetCount` | ✅ | ⚠️ 세트별 선수 기록 |
 
-### 1.4 데이터 정합성 검증
+### 2.4 데이터 정합성 규칙
+
+원본 수치를 교차 검증해 집계 단위를 확정했다.
 
 | 항목 | 결과 | 의미 |
 |---|---|---|
-| 팀 `wins` 합계 | **110** | `wins`/`loses` 는 **매치(Bo3) 단위** |
+| 팀 `wins` 합계 | **110** (= 10팀 × 22 ÷ 2) | `wins`/`loses` 는 **매치(Bo3) 단위** |
 | 팀 `score` 합계 | **0** | 제로섬 → `score` 는 **세트 득실차** |
 | 동률 처리 | T1·HLE·GEN 모두 16승 6패 | 득실차(21 > 19 > 18)로 갈림 → **동점 규칙 필수** |
 | 공동 순위 존재 | 3~5R 에서 GEN·T1 둘 다 2위 | 순위에 **동순위(gap)** 가 실제로 발생한다 |
-| `pogPoint` 합계 | 9,000 (=90회) | 100점 단위. 총 매치 수와 불일치 → 산정 규칙 확인 필요(§11-3) |
+| `pogPoint` 합계 | 9,000 (=90회) | 100점 단위. 총 매치 수와 불일치 → 산정 규칙 확인 필요 (§12-3) |
+
+앞의 두 줄이 §8.4 검증 뷰의 근거가 된다 — 세트 수는 매치 스코어와 맞아야 하고,
+득실차 총합은 순위표 단위로 반드시 0 이어야 한다.
 
 ---
 
-## 2. 데이터 입력 — 수기 확정
+## 3. 데이터 입력 정책 — 수기
 
-**외부 API 수집 경로는 설계에서 제거한다.** 관리자가 DB 에 직접 입력한다.
-따라서 이 설계의 성패는 **입력이 감당 가능한가 + 오입력을 잡아내는가** 에 달려 있다.
+관리자가 DB 에 직접 입력한다. 따라서 이 설계의 성패는
+**입력이 감당 가능한가 + 오입력을 잡아내는가** 에 달려 있다.
 
-### 2.1 입력량 산정
+### 3.1 입력량 산정과 단계 구분
 
 | 원장 | 산정 근거 | 행 수 | 수기 |
 |---|---|---|---|
@@ -125,9 +139,8 @@
 | POG 선정 | 세트 또는 매치당 1명 | **약 165행** | ✅ |
 | **세트별 선수 기록** | 400세트 × 10명 | **약 4,000행** | ❌ **비현실적** |
 
-**→ 매치·세트·POG 는 수기로 충분하다. 선수별 K/D/A 4,000행은 수기로 불가능하다.**
-
-이건 의지의 문제가 아니라 산술의 문제다. 그래서 단계를 나눈다.
+매치·세트·POG 는 수기로 충분하지만 선수별 K/D/A 4,000행은 불가능하다.
+의지가 아니라 산술의 문제이므로 단계를 나눈다.
 
 | 단계 | 입력 | 완성되는 화면 |
 |---|---|---|
@@ -135,24 +148,22 @@
 | **2단계** | POG (약 165행) | 선수 순위표의 **포인트** 컬럼 |
 | **3단계** | 세트별 선수 기록 (약 4,000행) | KDA·킬·데스·어시스트·킬관여율·출전세트수 |
 
-1단계만으로 **팀 탭은 네이버 화면과 동일하게 완성**된다. 3단계는 §11-4 의 결정이 필요하다.
+**1단계만으로 팀 탭은 네이버 화면과 동일하게 완성된다.** 3단계는 §12-4 의 결정이 필요하다.
 
-### 2.2 참고 — 외부 출처 (설계에서 제외, 기록 목적)
+### 3.2 외부 API 를 쓰지 않는 이유
 
-수기 입력이 확정이므로 아래는 **채택하지 않는다.** 나중에 방침이 바뀔 때를 위한 조사 기록이다.
-
-- **라이엇 공식 개발자 포털에는 프로 e스포츠 API 가 아예 없다** (`developer.riotgames.com/apis` 확인).
+- **라이엇 공식 개발자 포털에는 프로 e스포츠 API 가 아예 없다** (`developer.riotgames.com/apis`).
   `tournament-v5` 는 서드파티 자체 대회용이지 LCK 데이터가 아니다.
-- `esports-api.lolesports.com` — 라이엇 운영이지만 **문서화되지 않은 웹 클라이언트 내부 API**.
-  `x-api-key` 는 클라이언트 하드코딩 공개 키. §1.1 의 스테이지 구조 검증에 사용했다.
-- `esports-api.game.naver.com` — 화면의 모든 컬럼을 집계된 상태로 주지만 3자 가공 데이터.
-- 어느 쪽도 문서화·허가·안정성이 보장되지 않는다. **수기 입력 결정이 이 리스크를 전부 제거한다.**
+- `esports-api.lolesports.com` — 라이엇이 운영하지만 **문서화되지 않은 웹 클라이언트 내부 API**.
+  `x-api-key` 는 클라이언트에 하드코딩된 공개 키다. §2.1 의 구조 검증에만 사용했다.
+- `esports-api.game.naver.com` — 화면의 모든 컬럼을 집계된 상태로 주지만 3자 가공 데이터다.
+- 어느 쪽도 문서화·허가·안정성이 보장되지 않는다. **수기 입력이 이 리스크를 전부 제거한다.**
 
-검증에 쓴 주소는 부록 §12 에 남겨 둔다.
+설계 근거를 재확인할 때 쓸 주소는 부록 A 에 남겨 둔다.
 
 ---
 
-## 3. 설계 방향
+## 4. 설계 방향
 
 ```
 [입력: 관리자 SQL]            [집계]                        [조회]
@@ -168,18 +179,20 @@ esports_pog          ─┘          └→ esports_standing_snapshot (순위 �
 - **집계 산출물**: 순위표, 그룹 편성. **언제든 버리고 다시 만들 수 있다.**
 - **이력**: 집계 시점마다 순위 스냅샷 1벌.
 
-집계 로직 버그를 고치면 전 시즌 재집계로 바로잡을 수 있다는 점이 스냅샷 적재형과의 결정적 차이다.
+집계 로직 버그를 고치면 전 시즌 재집계로 바로잡을 수 있다는 점이 순위표를 그대로 적재하는 방식과의
+결정적 차이다. 화면 수치는 전부 원장에서 재현 가능해야 한다.
 
 ---
 
-## 4. 모듈 구조
+## 5. 모듈 구조
 
 ```
 module/domain/esports/src/main/java/com/example/lolserver/esports/
 ├── domain/
 │   ├── EsportsLeague · EsportsSeason · EsportsTeam · EsportsPlayer
+│   ├── Roster.java             # 계약 기간 (validateNoOverlap)
 │   ├── Stage.java              # 스테이지 (포맷·그룹여부·집계단위)
-│   ├── StageFormat.java        # ROUND_ROBIN | BRACKET
+│   ├── StageFormat.java        # ROUND_ROBIN | SWISS | BRACKET
 │   ├── Match.java              # validateGameConsistency() guard
 │   ├── Game.java · GamePlayerStat.java
 │   ├── TeamStanding · PlayerStanding
@@ -191,28 +204,28 @@ module/domain/esports/src/main/java/com/example/lolserver/esports/
 ├── application/
 │   ├── port/in/   EsportsMetaQueryUseCase · TeamStandingQueryUseCase
 │   │              PlayerStandingQueryUseCase · StandingHistoryQueryUseCase
-│   │              StandingAggregateUseCase · GroupSplitUseCase
-│   ├── port/out/  StagePersistencePort · MatchPersistencePort
+│   │              RosterQueryUseCase · StandingAggregateUseCase · GroupSplitUseCase
+│   ├── port/out/  StagePersistencePort · MatchPersistencePort · RosterPersistencePort
 │   │              StandingPersistencePort · StandingSnapshotPersistencePort
 │   │              EsportsRecordCachePort
 │   ├── model/query · model/readmodel
 │   └── EsportsMetaService · TeamStandingService · PlayerStandingService
-│       StandingAggregateService · GroupSplitService · StandingHistoryService
+│       RosterService · StandingAggregateService · GroupSplitService · StandingHistoryService
 └── adapter/
     ├── in/web/       EsportsMetaController · TeamStandingController
     │                 PlayerStandingController · StandingHistoryController
-    │                 EsportsAdminController        # 집계·그룹확정 트리거
+    │                 RosterController · EsportsAdminController   # 집계·그룹확정 트리거
     └── out/persistence · out/cache
 ```
 
-**외부 client 어댑터가 없다.** 수기 입력 확정의 직접적 결과이며, 모듈이 그만큼 단순해진다.
+**외부 client 어댑터가 없다.** 수기 입력의 직접적 결과이며, 모듈이 그만큼 단순해진다.
 
 `StandingCalculator` · `GroupSplitter` · `TieBreakRule` 은 **순수 자바**로 둔다.
 승/패/득실차/순위/그룹분리는 리그 규정이지 SQL 이 아니고, 규정은 시즌마다 바뀐다.
 
 ---
 
-## 5. DB 테이블 설계
+## 6. DB 테이블 설계
 
 마이그레이션: `lol-db-schema/db/migration/V31__add_esports_record_tables.sql`
 (현재 최신은 `V30__idempotent_guards.sql`)
@@ -220,10 +233,7 @@ module/domain/esports/src/main/java/com/example/lolserver/esports/
 > `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
 > 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
 
-> ✅ 아래 DDL 전체(**테이블 15 · 인덱스 11 · 뷰 4**)는 로컬 `postgres:16-alpine` 에서
-> `BEGIN … ROLLBACK` 으로 실제 실행해 문법·제약·의존 순서를 검증했다 (§7.4 에 결과).
-
-### 5.1 마스터
+### 6.1 마스터
 
 ```sql
 -- 리그. 지역 리그(lck, lpl…)와 국제 대회(worlds, msi…)를 같은 테이블에 담는다.
@@ -290,9 +300,28 @@ CREATE TABLE IF NOT EXISTS esports_player (
     CONSTRAINT pk_esports_player PRIMARY KEY (player_id),
     CONSTRAINT uk_esports_player_nick UNIQUE (nick_name)
 );
+```
 
--- ★ 로스터는 "시즌별 소속" 이 아니라 "계약 기간" 으로 표현한다 (근거는 §5.8).
---   이적이 과거 소속을 덮어쓰지 못하게 기간 이력(temporal) 테이블로 둔다.
+### 6.2 로스터 — 계약 기간(temporal) 모델
+
+**선수-팀 소속은 시즌이 아니라 기간의 함수다.** 로스터를 `(시즌, 선수, 팀)` 으로 잡으면
+두 가지가 깨진다.
+
+| 상황 | 시즌 단위 로스터 | 계약 기간 로스터 |
+|---|---|---|
+| 시즌을 넘는 이적 (2025 GEN → 2026 T1) | 두 행이 남는다 ✅ | ✅ |
+| 시즌 중 이적 (2026 T1 → GEN) | 두 행이 공존한다 ✅ | ✅ |
+| **시즌 중 복귀** (GEN → T1 → GEN 재계약) | **PK 충돌로 저장 불가** ❌ | ✅ 3건 모두 보존 |
+| **이적을 `UPDATE` 로 처리** | **과거 소속이 흔적 없이 사라짐** ❌ | ✅ 기간이 남는다 |
+| 현재 소속의 유일성 | `left_at IS NULL` 2건도 통과 ❌ | ✅ DB 가 거부 |
+| 국제 대회 로스터 | 대회마다 재입력 필요 | ✅ 기간 겹침으로 자동 유도 |
+
+핵심은 "이력이 사라질 수 있다"가 아니라 **구조가 이력 보존을 강제하지 않는다**는 점이다.
+관리자가 새 행으로 넣으면 남고 기존 행을 고치면 사라진다 — 무결성이 입력자의 습관에 의존하면
+언젠가 깨진다. 그래서 기간으로 표현하고, 겹침 금지를 **DB 제약으로 강제**한다.
+
+```sql
+-- EXCLUDE 에서 player_id 를 등호(=)로 비교하기 위해 필요
 CREATE EXTENSION IF NOT EXISTS btree_gist;
 
 CREATE TABLE IF NOT EXISTS esports_roster (
@@ -328,10 +357,17 @@ SELECT s.season_id, r.player_id, r.team_id, r.position, r.joined_at, r.left_at
     && daterange(s.start_date, COALESCE(s.end_date, DATE '9999-12-31'));
 ```
 
-### 5.2 ★ 스테이지 — LCK 구조를 담는 핵심 테이블
+**운영 주의**
+
+- 이적 입력은 **기존 행의 `left_at` 을 채우고 새 행을 INSERT** 하는 2단계다 (§8.3).
+  `UPDATE team_id` 로 처리하면 안 된다 — 이력이 사라지는 유일한 경로다.
+- `btree_gist` 설치 권한이 없는 환경이라면 `UNIQUE (player_id, joined_at)` 만 남기고
+  겹침 검출을 `Roster.validateNoOverlap()` + 검증 뷰로 대체한다.
+
+### 6.3 ★ 스테이지 — 시즌 구조를 담는 핵심 테이블
 
 ```sql
--- 시즌을 구성하는 단계. §1 의 구조를 그대로 데이터로 표현한다.
+-- 시즌을 구성하는 단계. §2 의 구조를 그대로 데이터로 표현한다.
 CREATE TABLE IF NOT EXISTS esports_stage (
     stage_id        BIGSERIAL    NOT NULL,
     season_id       VARCHAR(80)  NOT NULL,
@@ -343,7 +379,7 @@ CREATE TABLE IF NOT EXISTS esports_stage (
     -- BRACKET     : 토너먼트 (플레이인·플레이오프·녹아웃) — 순위표 없음
     format          VARCHAR(20)  NOT NULL,
     grouped         BOOLEAN      NOT NULL DEFAULT FALSE,  -- 그룹별 진행 여부
-    -- ★ 같은 값을 가진 스테이지들이 하나의 순위표로 누적 집계된다 (§1.2).
+    -- ★ 같은 값을 가진 스테이지들이 하나의 순위표로 누적 집계된다 (§2.2).
     --   NULL 이면 순위표를 만들지 않는다 (BRACKET 스테이지).
     standing_key    VARCHAR(40),
     -- 그룹 편성 근거 스테이지 (1~2R 성적으로 Legend/Rise 를 가른다).
@@ -393,10 +429,10 @@ CREATE TABLE IF NOT EXISTS esports_stage_group (
 | `PLAYOFF` | 플레이오프 | BRACKET | false | *(NULL)* | – | 5 |
 
 **`REGULAR_R1_R2` 와 `REGULAR_R3_R5` 가 같은 `standing_key='REGULAR'`** 이므로
-두 스테이지가 하나의 순위표로 누적 집계된다 — §1.2 에서 검증한 네이버 화면의 동작이다.
+두 스테이지가 하나의 순위표로 누적 집계된다 — §2.2 에서 검증한 화면 동작이다.
 1~2R 만 따로 보고 싶으면 `standing_key` 를 분리하면 되고, **코드는 건드리지 않는다.**
 
-### 5.3 원장 (관리자 입력)
+### 6.4 원장 (관리자 입력)
 
 ```sql
 CREATE TABLE IF NOT EXISTS esports_match (
@@ -439,7 +475,7 @@ CREATE TABLE IF NOT EXISTS esports_game (
     CONSTRAINT fk_game_winner FOREIGN KEY (winner_team_id) REFERENCES esports_team (team_id)
 );
 
--- 3단계. 약 4,000행이라 수기 입력 대상이 아니다 (§2.1, §11-4)
+-- 3단계. 약 4,000행이라 수기 입력 대상이 아니다 (§3.1, §12-4)
 CREATE TABLE IF NOT EXISTS esports_game_player (
     game_id    BIGINT      NOT NULL,
     player_id  VARCHAR(30) NOT NULL,
@@ -467,9 +503,9 @@ CREATE TABLE IF NOT EXISTS esports_pog (
 );
 ```
 
-### 5.4 집계 산출물
+### 6.5 집계 산출물
 
-**`standing_key` 단위**로 만들어진다 (스테이지 단위가 아니다 — §1.2).
+**`standing_key` 단위**로 만들어진다 (스테이지 단위가 아니다 — §2.2).
 
 ```sql
 CREATE TABLE IF NOT EXISTS esports_team_standing (
@@ -528,7 +564,7 @@ CREATE INDEX IF NOT EXISTS idx_eps_position_rank
     ON esports_player_standing (season_id, standing_key, position, player_rank);
 ```
 
-### 5.5 이력 · 시즌 최종 결과
+### 6.6 이력 · 시즌 최종 결과
 
 ```sql
 CREATE TABLE IF NOT EXISTS esports_standing_snapshot (
@@ -575,57 +611,49 @@ CREATE INDEX IF NOT EXISTS idx_esr_qualified
     ON esports_season_result (qualified_season_id, seed_no);
 ```
 
-### 5.6 설계 근거
+### 6.7 설계 근거
 
 | 결정 | 근거 |
 |---|---|
 | `esports_stage` 도입 | LCK 는 시즌 안에 성격이 다른 5개 단계가 있고 팀당 매치 수도 다르다(18 vs 12). 스테이지 없이는 표현 불가 |
-| `standing_key` 로 누적 단위 지정 | §1.2 검증 — 화면 순위표가 1~2R + 3~5R 합산이다. 포맷이 바뀌어도 **시드 데이터만 고치면 된다** |
-| `format` (ROUND_ROBIN/BRACKET) | MSI 진출전·플레이인·플레이오프는 순위표가 없다. 집계 대상에서 자동 제외 |
+| `standing_key` 로 누적 단위 지정 | §2.2 검증 — 화면 순위표가 1~2R + 3~5R 합산이다. 포맷이 바뀌어도 **시드 데이터만 고치면 된다** |
+| `format` 3종 (ROUND_ROBIN/SWISS/BRACKET) | 토너먼트는 순위표가 없어 집계에서 자동 제외되고, 롤드컵 스위스는 풀리그가 아니면서 순위표가 있다 |
 | `esports_stage_group` 을 집계 산출물로 | 그룹은 관리자가 정하는 게 아니라 **1~2R 결과가 정한다**. 입력값으로 두면 원장과 어긋날 수 있다 |
 | `group_source_stage_id` + `group_size` | "어느 스테이지 상위 몇 팀" 을 데이터로. LCK 는 5팀이지만 리그마다 다르다 |
 | `overall_rank` 병기 | 그룹 순위(1~5)와 별개로 전체 순위(1~10)가 필요할 때가 있다 (MSI 진출전 시드) |
 | `set_wins`/`set_loses` 별도 보관 | `score` 만으로는 "20승10패"와 "10승0패"를 구분 못 한다. 동점 규칙에 세트 승률이 쓰일 수 있다 |
 | `esports_season_result` 분리 | 플레이오프 결과는 집계 불가. 최종 순위·롤드컵 시드는 관리자 확정값 |
-| `team_code` / `nick_name` UNIQUE | 수기 입력이 확정이므로 사람이 읽는 키가 필수다 |
-| `rank` → `team_rank` | PostgreSQL 에선 쓸 수 있으나 윈도우 함수 `rank()` 와 겹쳐 가독성이 나쁘고 MySQL 8+ 는 예약어 |
-| `esports_roster` 를 기간 이력으로 | 시즌 PK 구조에서는 같은 시즌 재계약이 저장되지 않고, 이적을 `UPDATE` 로 처리하면 과거 소속이 사라졌다. `EXCLUDE` 제약으로 겹침을 DB 가 막는다 (§5.8) |
-| 시즌 로스터를 저장하지 않고 유도 | 계약 기간 ∩ 시즌 기간으로 산출. 시즌·국제 대회마다 로스터를 재입력할 필요가 없다 (§5.8) |
-| `esports_team.home_league_id` | 국제 대회 순위표에 여러 리그 팀이 섞인다. "T1 (LCK)" 표시에 필요 (§5.7) |
-| `format` 에 `SWISS` 포함 | 롤드컵의 핵심 스테이지가 스위스다. 풀리그도 토너먼트도 아니면서 순위표가 있다 (§5.7) |
 | `qualified_season_id` + `seed_no` | LCK→롤드컵뿐 아니라 LCK→MSI, 플레이인→스위스도 같은 컬럼으로 표현 |
 | `best_of` 를 매치 단위로 | 스테이지 안에서도 Bo 가 달라진다 (스위스: 초반 Bo1, 진출·탈락전 Bo3) |
+| `esports_roster` 를 계약 기간으로 | 시즌 단위로 두면 같은 시즌 재계약을 저장할 수 없고, 이적을 `UPDATE` 로 처리하는 순간 과거 소속이 사라진다. `EXCLUDE` 제약이 겹침을 DB 에서 막는다 (§6.2) |
+| 시즌 로스터를 저장하지 않고 유도 | 계약 기간 ∩ 시즌 기간으로 산출. 시즌·국제 대회마다 로스터를 재입력할 필요가 없다 (§6.2) |
+| `esports_team.home_league_id` | 국제 대회 순위표에 여러 리그 팀이 섞인다. "T1 (LCK)" 표시에 필요 (§6.8) |
+| `team_code` / `nick_name` UNIQUE | 수기 입력이므로 사람이 읽고 쓰는 키가 필수다 |
+| `rank` → `team_rank` | PostgreSQL 에선 쓸 수 있으나 윈도우 함수 `rank()` 와 겹쳐 가독성이 나쁘고 MySQL 8+ 는 예약어 |
 
-### 5.7 국제 대회(롤드컵 · MSI) 커버리지 검토
+### 6.8 국제 대회(롤드컵 · MSI) 커버리지
 
-실제 대회 구조를 조회해 현재 테이블이 감당하는지 점검했다.
+실제 대회 구조는 다음과 같고, 위 스키마가 그대로 수용한다.
 
-**확인한 실제 구조**
-
-| 대회 | 스테이지 |
+| 대회 | 스테이지 구성 |
 |---|---|
-| 롤드컵 2026 | 플레이-인 → **스위스** → 녹아웃 |
-| MSI 2026 | 플레이-인 → 녹아웃 |
-| 국제 리그 목록 | `worlds`, `msi`, `first_stand`, `ewc_lol`, `wqs` — 전부 `region="국제 대회"` |
-| 팀 마스터 | `homeLeague: {name:"LCK", region:"한국"}` — **팀은 홈 리그를 갖는다** |
+| 롤드컵 | 플레이-인(BRACKET) → **스위스(SWISS)** → 녹아웃(BRACKET) |
+| MSI | 플레이-인(BRACKET) → 녹아웃(BRACKET) |
+| 국제 리그 | `worlds`, `msi`, `first_stand`, `ewc_lol`, `wqs` — 전부 `international = TRUE` |
 
-**점검 결과**
+| 요구 | 대응 |
+|---|---|
+| 스위스는 풀리그도 토너먼트도 아니면서 순위표가 있다 | `format='SWISS'` + `standing_key` 부여 |
+| 여러 리그 팀이 한 순위표에 섞인다 | `esports_team.home_league_id` 로 "T1 (LCK)" 표시 |
+| 지역 리그와 국제 대회를 구분해 노출 | `esports_league.region` + `international` |
+| 조 편성이 성적이 아닌 추첨 | `group_source_stage_id IS NULL` + `grouped=TRUE` = 수동 편성. `GroupSplitter` 가 건드리지 않는다 |
+| 대회 간 진출권 (LCK→롤드컵, 플레이인→스위스) | `qualified_season_id` + `seed_no` |
+| 한 스테이지 안에서 Bo1/Bo3 혼재 | `esports_match.best_of` + 검증 뷰가 위반 검출 |
+| 공동 순위 (8강 탈락 4팀 = 공동 5위) | `final_rank` 중복 허용 |
+| 대회별 참가 로스터 | `v_esports_season_roster` 가 계약 기간 겹침으로 유도 — **추가 입력 없음** |
+| 스테이지별 독립 순위표 | `standing_key` 를 다르게 부여 |
 
-| # | 항목 | 검토 전 | 조치 |
-|---|---|---|---|
-| 1 | **스위스 스테이지** | ❌ `format` CHECK 가 `ROUND_ROBIN`/`BRACKET` 만 허용해 **INSERT 가 막힘** | `SWISS` 추가. 순위표를 만들되 풀리그 가정을 두지 않는다 |
-| 2 | **팀의 소속 리그** | ❌ 컬럼 없음 → 국제 대회에서 소속 표시 불가 | `esports_team.home_league_id` 추가 |
-| 3 | 리그의 국제/지역 구분 | ❌ 없음 | `esports_league.region` + `international` 추가 |
-| 4 | 추첨 기반 조 편성 | ⚠️ 성적 기반 자동 분리만 상정 | `group_source_stage_id IS NULL` = 수동 편성으로 정의. `GroupSplitter` 가 건드리지 않는다 |
-| 5 | 다음 대회 진출권 | ⚠️ `worlds_seed` 가 특정 대회 종속 | `qualified_season_id` + `seed_no` 로 일반화 |
-| 6 | Bo 형식 혼재 | ⚠️ 미기록 | `esports_match.best_of` 추가 + 검증 뷰가 위반 검출 |
-| 7 | 여러 리그 팀이 한 대회에 | ✅ 팀 마스터가 대회와 무관 | 변경 없음 |
-| 8 | 다단계 대회 구조 | ✅ `esports_stage` 가 그대로 수용 | 변경 없음 |
-| 9 | 스테이지별 독립 순위표 | ✅ `standing_key` 를 다르게 주면 분리 | 변경 없음 |
-| 10 | 공동 순위(8강 탈락 = 공동 5위) | ✅ `final_rank` 중복 허용 | 변경 없음 |
-| 11 | Bo1 ~ Bo5 | ✅ `home_score`/`away_score` 로 표현 | 변경 없음 |
-
-**롤드컵 2026 시드 예시** — 위 조치만으로 표현된다.
+**롤드컵 시드 예시**
 
 ```sql
 INSERT INTO esports_league (league_id, name, name_acronym, region, international)
@@ -646,88 +674,38 @@ INSERT INTO esports_season_result (season_id, team_id, final_rank, qualified_sea
 SELECT 'lck_2026', team_id, 1, 'worlds_2026', 1 FROM esports_team WHERE team_code = 'T1';
 ```
 
-**검증 결과** — 위 시드와 조치를 Postgres 16 에서 실행하고 롤백했다.
+**이번 범위 밖**
+
+- **스위스 순위 규칙**: 승패 동률 시 상대 전적 강도(Buchholz)를 쓰는 경우가 있다.
+  `TieBreakRule` 의 스위스 구현이 별도로 필요하다 → §12-8.
+- **토너먼트 대진표**: `esports_match` 에 경기 결과는 남지만 **대진도(bracket tree)** 정보는 없다.
+  대진표 화면이 필요하면 별도 설계가 추가된다 → §12-5.
+- **개막 전 참가팀 명단**: 경기가 입력되기 전에는 참가팀을 알 수 없다.
+  필요하면 `esports_season_participant` 를 추가한다.
+
+### 6.9 스키마 검증
+
+로컬 Postgres 16 에서 DDL 과 제약 동작을 실행하고 `ROLLBACK` 했다.
 
 | 확인 | 기대 | 실제 |
 |---|---|---|
-| 리그 국제/지역 구분 | `worlds`=국제, `lck`·`lpl`=지역 | **일치** |
-| 롤드컵 스테이지 3단 | `SWISS` 는 `standing_key` 보유, `BRACKET` 은 NULL | **일치** |
-| 팀 → 홈 리그 조회 | `T1→한국`, `BLG→중국` | **일치** |
-| LCK 1위 → 롤드컵 1시드 | `qualified_season_id='worlds_2026'`, `seed_no=1` | **일치** |
-| 스위스 Bo1 매치(1:0) 입력 | 검증 뷰 0행 | **0행** |
-| `Bo3` 인데 `3:0` 주입 | 검증 뷰가 검출 | **1행 검출** |
-| `BRACKET` 에 `standing_key` 부여 | CHECK 제약이 거부 | **`ck_stage_bracket_no_standing` 위반으로 거부** |
-
-**남은 한계 (이번 범위 밖)**
-
-- **스위스 순위 규칙**: 승패 동률 시 상대 전적 강도(Buchholz)를 쓰는 경우가 있다.
-  `TieBreakRule` 을 스위스용으로 하나 더 만들어야 할 수 있다 → §11-8.
-- **토너먼트 대진표**: 8강·4강·결승의 대진 구조(누가 누구와 붙는지, 상위 진출 연결)는
-  `esports_match` 로 경기 결과는 남지만 **대진도(bracket tree)를 그릴 정보는 없다**.
-  대진표 화면이 필요하면 별도 설계가 추가로 필요하다 → §11-5.
-- **참가팀 명단(경기 전)**: 경기가 입력되기 전에는 참가팀을 알 수 없다.
-  개막 전 참가팀 목록 화면이 필요하면 `esports_season_participant` 를 추가한다.
-
-### 5.8 로스터 — 선수 커리어(과거 소속) 보존
-
-**초판의 `esports_roster` 는 `PRIMARY KEY (season_id, player_id, team_id)` 였다.**
-이 구조로 이적을 처리하면 어떻게 되는지 실제로 실행해 확인했다.
-
-| 시나리오 | 결과 | 판정 |
-|---|---|---|
-| 시즌을 넘는 이적 (2025 GEN → 2026 T1) | 시즌이 다르므로 두 행이 남는다 | ✅ 이력 보존 |
-| 시즌 중 이적 (2026 T1 → GEN) | `team_id` 가 PK 에 있어 두 행이 공존 | ✅ 이력 보존 |
-| **시즌 중 복귀** (GEN → T1 재계약) | **PK 충돌로 INSERT 실패** | ❌ 저장 불가 |
-| **이적을 `UPDATE` 로 처리** | **GEN 소속 이력이 흔적 없이 사라짐** | ❌ 이력 소실 |
-| 현재 소속의 유일성 | `left_at IS NULL` 이 2건이어도 통과 | ❌ 무결성 미보장 |
-
-**정확한 진단** — 이력이 항상 사라지는 건 아니다. 시즌이 다르면 남는다.
-문제는 **구조가 이력 보존을 강제하지 않는다**는 것이다. 관리자가 이적을 새 행으로 넣으면 남고
-기존 행을 고치면 사라진다. 데이터 무결성이 입력자의 습관에 의존하면 언젠가 깨진다.
-같은 시즌 재계약은 아예 저장할 수도 없다.
-
-**개선 — 계약 기간(temporal) 모델**
-
-`season_id` 를 버리고 `joined_at ~ left_at` 기간으로 표현한다. 선수-팀 계약은 시즌이 아니라
-기간의 함수이기 때문이다. `EXCLUDE USING gist` 로 **한 선수의 소속 기간이 겹칠 수 없게 DB 가 강제**한다.
-
-검증 결과 (Postgres 16, 실행 후 롤백):
-
-| 확인 | 결과 |
-|---|---|
-| GEN → T1 → GEN 재계약 3건 입력 | **전부 저장됨** (기존 PK 로는 불가능했던 케이스) |
-| 기간이 겹치는 오입력 | **`ex_roster_no_overlap` 위반으로 거부** |
-| 현재 소속 조회 (`left_at IS NULL`) | **정확히 1건** |
-| 시즌 로스터 유도 (`v_esports_season_roster`) | lck_2025→GEN, lck_2026→GEN·T1, **worlds_2026→GEN 자동 산출** |
-| 특정 시점 소속 (2026-07-01) | **T1** — 임의 시점 조회 가능 |
-
-**부수 효과 — 국제 대회 로스터 중복 입력이 사라진다.**
-§5.7 에서 "Worlds 참가 로스터를 또 입력해야 한다" 는 부담을 지적했는데,
-계약 기간이 대회 기간과 겹치면 자동으로 유도되므로 **입력 자체가 필요 없어진다.**
-
-**운영 주의**
-
-- `btree_gist` 확장이 필요하다(`EXCLUDE` 에서 `player_id WITH =` 를 쓰기 위해).
-  설치 권한이 없는 환경이라면 `UNIQUE (player_id, joined_at)` 만 남기고
-  겹침 검출은 검증 뷰 + `Roster` 도메인의 `validateNoOverlap()` 으로 대체한다.
-- 이적 입력은 **기존 행의 `left_at` 을 채우고 새 행을 INSERT** 하는 2단계다.
-  `UPDATE team_id` 로 처리하면 안 된다 — 그게 초판에서 이력이 사라지던 경로다.
-
-```sql
--- 2026-06-01 자로 GEN → T1 이적
-UPDATE esports_roster SET left_at = DATE '2026-06-01'
- WHERE player_id = 'P_CHOVY' AND left_at IS NULL;
-
-INSERT INTO esports_roster (player_id, team_id, position, joined_at)
-SELECT 'P_CHOVY', team_id, 'MID', DATE '2026-06-01'
-  FROM esports_team WHERE team_code = 'T1';
-```
+| DDL 전체 생성 | 성공 | **테이블 15 · 인덱스 11 · 뷰 4** |
+| 리그 국제/지역 구분 | `worlds`=국제, `lck`·`lpl`=지역 | 일치 |
+| 롤드컵 스테이지 3단 | `SWISS` 는 `standing_key` 보유, `BRACKET` 은 NULL | 일치 |
+| 팀 → 홈 리그 조회 | `T1→한국`, `BLG→중국` | 일치 |
+| LCK 1위 → 롤드컵 1시드 | `qualified_season_id='worlds_2026'`, `seed_no=1` | 일치 |
+| `BRACKET` 에 `standing_key` 부여 | CHECK 가 거부 | `ck_stage_bracket_no_standing` 위반으로 거부 |
+| 로스터 GEN → T1 → GEN 재계약 3건 | 전부 저장 | 3행 저장 |
+| 로스터 기간 겹침 입력 | EXCLUDE 가 거부 | `ex_roster_no_overlap` 위반으로 거부 |
+| 현재 소속 조회 (`left_at IS NULL`) | 1건 | 1건 |
+| 시즌 로스터 유도 | lck_2025→GEN, lck_2026→GEN·T1·GEN, worlds_2026→GEN | 입력 없이 자동 산출 |
+| 특정 시점 소속 (2026-07-01) | T1 | T1 |
 
 ---
 
-## 6. 집계 로직
+## 7. 집계 로직
 
-### 6.1 순위표 집계
+### 7.1 순위표 집계
 
 `StandingCalculator` 가 **`standing_key` 에 속한 모든 스테이지의 매치를 합산**한다.
 
@@ -735,7 +713,7 @@ SELECT 'P_CHOVY', team_id, 'MID', DATE '2026-06-01'
 |---|---|
 | `wins` / `loses` | 대상 스테이지들의 `COMPLETED` 매치에서 승패 판정 |
 | `set_wins` / `set_loses` | `esports_game.winner_team_id` 집계 |
-| `score` | `set_wins - set_loses` (시즌 합이 0이어야 정합 — §1.4) |
+| `score` | `set_wins - set_loses` (순위표 단위 합이 0이어야 정합 — §2.4) |
 | `win_rate` | `wins / (wins + loses)`, 분모 0이면 0 |
 | `group_name` | `standing_key` 에 속한 스테이지 중 **`grouped=true` 인 마지막 스테이지**의 편성 |
 | `team_rank` | 그룹 내 정렬 후 순번. 그룹이 없으면 전체 순번 |
@@ -747,7 +725,7 @@ SELECT 'P_CHOVY', team_id, 'MID', DATE '2026-06-01'
 | 선수 `kill_involve_rate` | `(선수 K + A) / 같은 세트 소속팀 총 킬` |
 | 선수 `pog_point` | `esports_pog.point` 합 |
 | 선수 `wins/loses/score` | 선수가 1세트 이상 출전한 매치만 대상 |
-| 선수 `team_id` · `position` | **해당 순위표 기간과 겹치는 계약 중 가장 최근 것** (§5.8). 시즌 중 이적한 선수는 순위표에 한 팀만 표시되므로 마지막 소속을 쓴다. 3단계 이후에는 `esports_game_player` 의 실제 출전 팀으로 교차 검증한다 |
+| 선수 `team_id` · `position` | **해당 순위표 기간과 겹치는 계약 중 가장 최근 것** (§6.2). 시즌 중 이적한 선수는 순위표에 한 팀만 표시되므로 마지막 소속을 쓴다. 3단계 이후에는 `esports_game_player` 의 실제 출전 팀으로 교차 검증한다 |
 
 **정렬(동점 규칙)** — `TieBreakRule` 로 분리한다. 리그마다 다르고 규정이 바뀐다.
 
@@ -755,10 +733,10 @@ SELECT 'P_CHOVY', team_id, 'MID', DATE '2026-06-01'
 ① 매치 승수 desc  ② 세트 득실차 desc  ③ 상대전적  ④ 세트 승률 desc
 ```
 
-§1.4 에서 확인했듯 **동순위가 실제로 발생한다**(3~5R 의 GEN·T1 공동 2위).
+§2.4 에서 확인했듯 **동순위가 실제로 발생한다**(3~5R 의 GEN·T1 공동 2위).
 타이브레이커로도 안 갈리면 같은 `team_rank` 를 부여하고 다음 순위를 건너뛴다.
 
-### 6.2 그룹 분리
+### 7.2 그룹 분리
 
 `GroupSplitter` 가 `group_source_stage_id` 스테이지의 순위를 기준으로 상위/하위를 가른다.
 
@@ -771,7 +749,10 @@ SELECT 'P_CHOVY', team_id, 'MID', DATE '2026-06-01'
 **자동 산출 + 관리자 확정** 2단계로 둔다. 리그 규정상 예외(승강전, 와일드카드)가 있을 수 있으므로
 집계가 제안하고 관리자가 확정 API 를 호출한다. 확정 후에는 3~5R 집계가 이 편성을 사용한다.
 
-### 6.3 실행
+`group_source_stage_id` 가 없는 `grouped` 스테이지(롤드컵 조 추첨 등)는
+`GroupSplitter` 대상이 아니며 관리자가 `esports_stage_group` 에 직접 넣는다.
+
+### 7.3 실행
 
 ```java
 // 컴포지션 루트 — 수기 입력이므로 잦은 폴링이 불필요하다
@@ -779,18 +760,18 @@ SELECT 'P_CHOVY', team_id, 'MID', DATE '2026-06-01'
 public void aggregateActiveSeasons() { ... }
 ```
 
-입력 직후 반영이 필요하면 관리자 트리거(§8)를 쓴다.
+입력 직후 반영이 필요하면 관리자 트리거(§9)를 쓴다.
 집계 성공 시 ① 순위표 upsert ② 스냅샷 upsert(오늘) ③ 캐시 evict 를 한 트랜잭션으로 처리한다.
 
 **전량 재계산**한다. 시즌 165매치 규모라 부분 갱신을 최적화할 이유가 없고 훨씬 안전하다.
 
 ---
 
-## 7. 관리자 입력 절차
+## 8. 관리자 입력 절차
 
 관리자 페이지가 없으므로 SQL 로 입력한다. 팀은 `'T1'`, 선수는 `'Duro'` 로 참조한다.
 
-### 7.1 시즌 구조 시드 (시즌당 1회)
+### 8.1 시즌 구조 시드 (시즌당 1회)
 
 ```sql
 INSERT INTO esports_stage
@@ -810,7 +791,7 @@ UPDATE esports_stage s
    AND src.season_id = 'lck_2026' AND src.stage_key = 'REGULAR_R1_R2';
 ```
 
-### 7.2 매치 입력 (반복 작업 — 약 165회)
+### 8.2 매치 입력 (반복 작업 — 약 165회)
 
 ```sql
 -- 2026-04-05 1R 3주차 · T1 2:1 GEN
@@ -834,7 +815,24 @@ SELECT m.match_id, g.game_no, t.team_id, g.duration_sec
 
 세트 시간을 모르면 `duration_sec` 를 `NULL` 로 둔다 — 선수 출전시간 집계에만 쓰인다.
 
-### 7.3 입력 검증 뷰
+### 8.3 로스터 · 이적 입력
+
+이적은 반드시 **기존 계약을 닫고 새 계약을 여는** 2단계로 넣는다.
+
+```sql
+-- 2026-06-01 자로 GEN → T1 이적
+UPDATE esports_roster SET left_at = DATE '2026-06-01'
+ WHERE player_id = 'P_CHOVY' AND left_at IS NULL;
+
+INSERT INTO esports_roster (player_id, team_id, position, joined_at)
+SELECT 'P_CHOVY', team_id, 'MID', DATE '2026-06-01'
+  FROM esports_team WHERE team_code = 'T1';
+```
+
+`UPDATE esports_roster SET team_id = …` 는 금지다. 과거 소속이 흔적 없이 사라진다.
+기간이 겹치면 `ex_roster_no_overlap` 이 INSERT 를 거부하므로, 거부되면 `left_at` 을 먼저 확인한다.
+
+### 8.4 입력 검증 뷰
 
 수기 입력은 반드시 틀린다. **집계 전에 걸러내는 뷰**를 함께 만든다.
 
@@ -867,7 +865,7 @@ HAVING COUNT(g.game_id) <> m.home_score + m.away_score
     OR (m.best_of IS NOT NULL AND m.home_score + m.away_score > m.best_of);
 
 -- ② 스테이지별 입력 진행률 — 어디까지 넣었는지 한눈에
---    주의: 팀 테이블을 JOIN 하면 매치당 2행이 되어 집계가 2배가 된다.
+--    주의: 팀 테이블을 JOIN 하면 매치당 2행이 되어 매치·세트 수가 2배로 집계된다.
 --          참가 팀 수는 상관 서브쿼리로 따로 센다.
 CREATE OR REPLACE VIEW v_esports_stage_progress AS
 SELECT st.season_id, st.stage_key, st.name,
@@ -884,9 +882,10 @@ SELECT st.season_id, st.stage_key, st.name,
  GROUP BY st.season_id, st.stage_id, st.stage_key, st.name, st.sort_order
  ORDER BY st.sort_order;
 
--- ③ 세트 득실 제로섬 검증 — 순위표 단위(standing_key)로 항상 0 이어야 한다
+-- ③ 세트 득실 제로섬 검증 — 순위표 단위(standing_key)로 항상 0 이어야 한다.
 --    한 매치가 양 팀 관점에서 (+d, -d) 로 더해지므로 합은 반드시 0 이 된다.
 --    0 이 아니면 세트 점수를 잘못 입력한 매치가 있다는 뜻이다.
+--    (홈팀 관점 SUM(home_score - away_score) 로는 제로섬이 성립하지 않는다.)
 CREATE OR REPLACE VIEW v_esports_score_zerosum AS
 SELECT st.season_id, st.standing_key,
        SUM(CASE WHEN m.home_team_id = t.team_id THEN m.home_score - m.away_score
@@ -902,32 +901,29 @@ SELECT st.season_id, st.standing_key,
 
 1. **①이 0행** — 매치 결과와 세트 수가 전부 맞는다.
 2. **③의 `score_sum` 이 0** — 세트 점수가 제로섬을 만족한다.
-3. ②로 스테이지별 입력량이 예상과 맞는지 본다 (1~2R 90매치 / 3~5R 60매치 — §2.1).
+3. ②로 스테이지별 입력량이 예상과 맞는지 본다 (1~2R 90매치 / 3~5R 60매치 — §3.1).
 
 같은 검증을 `Match` 도메인의 `validateGameConsistency()` 가 애플리케이션에서도 수행한다.
 
-### 7.4 실행 검증 결과
+### 8.5 입력 · 집계 검증
 
-로컬 Postgres 16 에서 DDL → 시즌 구조 시드 → 매치 입력 → 검증 뷰 3종 → 집계 산식까지
-한 트랜잭션으로 실행하고 `ROLLBACK` 했다 (`T1 2:1 GEN`, `GEN 2:0 HLE` 2건 입력).
+DDL → 시즌 구조 시드 → 매치 입력 → 검증 뷰 3종 → 집계 산식까지 한 트랜잭션으로 실행하고
+`ROLLBACK` 했다 (`T1 2:1 GEN`, `GEN 2:0 HLE` 2건 입력).
 
 | 단계 | 기대 | 실제 |
 |---|---|---|
-| DDL 전체 생성 | 성공 | **테이블 15 · 인덱스 11 · 뷰 4 생성** |
-| 스테이지 시드 + 그룹 근거 연결 | 5행 | **5행, `REGULAR_R3_R5 → REGULAR_R1_R2` 연결됨** |
-| 정상 입력 후 검증 뷰 ① | 0행 | **0행** |
-| 진행률 뷰 ② | 매치 2 · 세트 5 · 팀 3 | **정확히 일치** |
-| 제로섬 뷰 ③ | `score_sum = 0` | **0** |
-| 집계 산식 | T1 1승0패 `+1` / GEN 1승1패 `+1` / HLE 0승1패 `-2` | **일치** (합 0) |
-| 오입력 주입 (`2:1` 인데 세트 2개) | 뷰 ①이 검출 | **1행 검출** |
-
-> 이 검증 과정에서 진행률 뷰의 실제 버그 2건을 잡았다 — 팀 테이블 `JOIN` 때문에 매치당 2행이 되어
-> 매치·세트 수가 **2배로 집계**됐고, `SUM(home_score - away_score)` 는 홈팀 관점 합이라 제로섬이
-> 성립하지 않았다. 전자는 팀 수를 상관 서브쿼리로 분리해, 후자는 팀 관점 제로섬 뷰 ③으로 떼어내 고쳤다.
+| 스테이지 시드 + 그룹 근거 연결 | 5행 | 5행, `REGULAR_R3_R5 → REGULAR_R1_R2` 연결됨 |
+| 정상 입력 후 검증 뷰 ① | 0행 | 0행 |
+| 진행률 뷰 ② | 매치 2 · 세트 5 · 팀 3 | 정확히 일치 |
+| 제로섬 뷰 ③ | `score_sum = 0` | 0 |
+| 집계 산식 | T1 1승0패 `+1` / GEN 1승1패 `+1` / HLE 0승1패 `-2` | 일치 (합 0) |
+| 오입력 주입 (`2:1` 인데 세트 2개) | 뷰 ①이 검출 | 1행 검출 |
+| 스위스 Bo1 매치(1:0) 입력 | 뷰 ① 0행 | 0행 |
+| `Bo3` 인데 `3:0` 주입 | 뷰 ①이 검출 | 1행 검출 |
 
 ---
 
-## 8. REST API 설계
+## 9. REST API 설계
 
 베이스 `/api/v1/esports`. 봉투는 `{ "result": "SUCCESS" | "ERROR", "data": …, "errorMessage": … }`.
 
@@ -935,17 +931,17 @@ SELECT st.season_id, st.standing_key,
 |---|---|---|
 | GET | `/api/v1/esports/leagues` | 리그 목록 |
 | GET | `/api/v1/esports/leagues/{leagueId}/seasons` | 시즌 목록 |
-| GET | `/api/v1/esports/seasons/{seasonId}/stages` | **스테이지 목록 (신규)** |
+| GET | `/api/v1/esports/seasons/{seasonId}/stages` | 스테이지 목록 |
 | GET | `/api/v1/esports/seasons/{seasonId}/team-standings` | 팀 순위표 |
 | GET | `/api/v1/esports/seasons/{seasonId}/player-standings` | 선수 순위표 |
 | GET | `/api/v1/esports/seasons/{seasonId}/standing-history` | 순위 추이 |
 | GET | `/api/v1/esports/seasons/{seasonId}/result` | 최종 순위 · 진출권 |
-| GET | `/api/v1/esports/players/{playerId}/career` | **선수 커리어 (팀 이력) — 신규** |
-| GET | `/api/v1/esports/teams/{teamCode}/roster` | **팀 로스터 (현재 / 특정 시점) — 신규** |
+| GET | `/api/v1/esports/players/{playerId}/career` | 선수 커리어 (팀 이력) |
+| GET | `/api/v1/esports/teams/{teamCode}/roster` | 팀 로스터 (현재 / 특정 시점) |
 | POST | `/api/v1/admin/esports/seasons/{seasonId}/aggregate` | 집계 트리거 |
-| POST | `/api/v1/admin/esports/stages/{stageId}/split-groups` | **그룹 편성 확정** |
+| POST | `/api/v1/admin/esports/stages/{stageId}/split-groups` | 그룹 편성 확정 |
 
-### 8.1 팀 순위표
+### 9.1 팀 순위표
 
 `GET /seasons/lck_2026/team-standings?standingKey=REGULAR&sort=RANK`
 
@@ -987,15 +983,14 @@ SELECT st.season_id, st.standing_key,
 }
 ```
 
-`includedStages` 로 **이 순위표가 어떤 단계를 합산한 것인지** 화면에 표시할 수 있다.
-`kda` 등이 `null` 인 것은 3단계 미완을 뜻한다(에러가 아니다).
-`homeLeague` 는 국제 대회 순위표에서 `T1 (LCK)` · `BLG (LPL)` 처럼 소속을 표시할 때 쓴다.
-LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하면 된다.
+- `includedStages` 로 **이 순위표가 어떤 단계를 합산한 것인지** 화면에 표시한다.
+- `kda` 등이 `null` 인 것은 3단계 미완을 뜻한다 (에러가 아니다).
+- `homeLeague` 는 국제 대회 순위표에서 `T1 (LCK)` · `BLG (LPL)` 처럼 소속을 표시할 때 쓴다.
+  LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하면 된다.
+- `GET /leagues` 응답에도 `region` 과 `international` 이 포함되어, 리그 필터에서
+  지역 리그와 국제 대회를 구분해 그룹핑할 수 있다.
 
-`GET /leagues` 응답에도 `region` 과 `international` 이 포함되어, 리그 필터에서
-지역 리그와 국제 대회를 구분해 그룹핑할 수 있다.
-
-### 8.2 스테이지 목록 (신규)
+### 9.2 스테이지 목록
 
 `GET /seasons/lck_2026/stages`
 
@@ -1017,16 +1012,16 @@ LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하�
 
 프런트는 이걸로 **어떤 탭을 그릴지** 결정한다. 포맷이 바뀌어도 프런트 수정이 필요 없다.
 
-### 8.3 선수 순위표
+### 9.3 선수 순위표
 
 `GET /seasons/lck_2026/player-standings?standingKey=REGULAR&position=ALL&sort=RANK`
 
 `position`: `ALL`,`TOP`,`JGL`,`MID`,`AD`,`SPT` ·
 `sort`: `RANK`,`POG_POINT`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS`,`KILL_INVOLVE_RATE`,`COMPETE_SET_COUNT`
 
-페이징 없음(시즌당 60~70명). `position` 필터 시 원본 `rank` 유지(네이버 동작과 동일).
+페이징 없음(시즌당 60~70명). `position` 필터 시 원본 `rank` 를 유지한다(참고 화면과 동일 동작).
 
-### 8.4 순위 추이
+### 9.4 순위 추이
 
 `GET /seasons/lck_2026/standing-history?standingKey=REGULAR&teamCode=T1`
 
@@ -1048,11 +1043,9 @@ LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하�
 
 `teamCode` 생략 시 전 팀 시리즈. 그룹 분리 전후가 한 차트에 이어진다.
 
-### 8.5 선수 커리어 (신규)
+### 9.5 선수 커리어
 
 `GET /players/{playerId}/career`
-
-`esports_roster` 가 기간 이력이 되면서 가능해진 조회다(§5.8).
 
 ```json
 {
@@ -1077,29 +1070,30 @@ LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하�
 ```
 
 - `career` 는 **최신 계약이 먼저** 오도록 `joinedAt DESC` 정렬한다.
-- 같은 팀에 두 번 소속된 이력이 각각 별도 항목으로 남는다 — 초판 구조에서는 저장조차 불가능했다.
+- 같은 팀에 두 번 소속된 이력도 각각 별도 항목으로 남는다.
 - `seasons` 는 `v_esports_season_roster` 로 유도한 값이라 별도 입력이 없다.
+- 팀명은 현재 이름으로 표시된다. "당시 팀명"이 필요하면 §12-10 참고.
 
-### 8.6 팀 로스터 (신규)
+### 9.6 팀 로스터
 
 `GET /teams/{teamCode}/roster?asOf=2026-07-01`
 
 `asOf` 를 생략하면 현재 로스터(`left_at IS NULL`), 주면 그 시점의 로스터를 돌려준다.
 `asOf` 대신 `seasonId` 를 주면 해당 대회 기간과 겹치는 로스터가 나온다.
 
-### 8.7 에러
+### 9.7 에러
 
 | 상황 | 코드 |
 |---|---|
 | 없는 `seasonId` / `standingKey` | 404 |
 | 잘못된 `sort`/`position` | 400 |
 | 집계 전 (원장은 있으나 순위표 없음) | 200 + 빈 `groups` + `aggregatedAt: null` |
-| 집계 트리거 시 원장 정합성 위반 | 409 + 위반 매치 목록 (§7.3 뷰 ①) |
+| 집계 트리거 시 원장 정합성 위반 | 409 + 위반 매치 목록 (§8.4 뷰 ①) |
 | 그룹 확정 시 근거 스테이지 미완료 | 409 |
 
 ---
 
-## 9. 정렬 · 캐시
+## 10. 정렬 · 캐시
 
 `standing_key` 단위 최대 70행이므로 DB 는 `rank` 순 flat 리스트만 읽어 캐시하고,
 `position` 필터와 `sort` 는 애플리케이션 `Comparator`(화이트리스트 enum)로 처리한다.
@@ -1121,55 +1115,56 @@ LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하�
 
 ---
 
-## 10. 구현 순서
+## 11. 구현 순서
 
 **1단계 — 팀 순위표 (외부 의존 0)**
 
 1. `module/domain/esports` 생성 + `settings.gradle` / 컴포지션 루트 등록
-2. `V31` 마이그레이션 (마스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)
-3. 마스터 시드: LCK 10팀 · `lck_2026` 시즌 · **스테이지 5개**(§7.1)
+2. `V31` 마이그레이션 (마스터 + 로스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)
+3. 마스터 시드: LCK 10팀 · `lck_2026` 시즌 · **스테이지 5개**(§8.1)
 4. **`StandingCalculator` · `GroupSplitter` · `TieBreakRule` 단위 테스트 먼저**
-   — 동률 3팀(§1.4), 공동 순위, 누적 합산(§1.2) 시나리오를 재현
+   — 동률 3팀(§2.4), 공동 순위, 누적 합산(§2.2) 시나리오를 재현
 5. 집계 서비스 + 그룹 확정 API + 관리자 트리거 + 스케줄러
 6. 조회 API(리그·시즌·스테이지·팀 순위표) + Redis 캐시
 7. **1~2R 매치 90건 입력** → 검증 뷰 0행 → 집계 → 그룹 확정 → **3~5R 입력** → 재집계
-8. 네이버 화면과 순위·승패·득실차 대조
+8. 참고 화면과 순위·승패·득실차 대조
 
 **2단계 — POG · 선수 순위표 골격**
 
-9. POG 입력 + 선수 집계(포인트·승패만) + 선수 순위표 API
-10. 순위 추이 API + 최종 결과(`esports_season_result`) API
+9. 로스터 입력 + 선수 커리어·팀 로스터 API
+10. POG 입력 + 선수 집계(포인트·승패만) + 선수 순위표 API
+11. 순위 추이 API + 최종 결과(`esports_season_result`) API
 
-**3단계 — 선수 상세 스탯** (§11-4 결정 후)
+**3단계 — 선수 상세 스탯** (§12-4 결정 후)
 
-11. `esports_game_player` 적재 경로 확보 → KDA·킬관여율·출전세트수 집계
-12. RestDocs → `./gradlew :module:infra:api:asciidoctor`
+12. `esports_game_player` 적재 경로 확보 → KDA·킬관여율·출전세트수 집계
+13. RestDocs → `./gradlew :module:infra:api:asciidoctor`
 
-**8번의 네이버 대조가 1단계 완료 기준**이다. 순위·승패·득실차가 일치하면 집계 규칙이 맞은 것이다.
+**8번의 화면 대조가 1단계 완료 기준**이다. 순위·승패·득실차가 일치하면 집계 규칙이 맞은 것이다.
 
 ---
 
-## 11. 열린 이슈
+## 12. 열린 이슈
 
 | # | 이슈 | 결정 필요 사항 |
 |---|---|---|
 | 1 | **동점 규칙** | T1·HLE·GEN 이 모두 16승 6패였고 공동 순위도 실제로 발생한다. LCK 규정의 타이브레이커 순서(득실차 → 상대전적 → ?)를 확정해야 `TieBreakRule` 을 구현할 수 있다. **1단계 착수 전 필요** |
 | 2 | **순위표 노출 단위** | 화면에 `REGULAR`(1~2R+3~5R 누적) 하나만 둘지, `1~2R 단독` 탭도 줄지. `standing_key` 를 나누기만 하면 되므로 코드 변경은 없다 |
 | 3 | POG 산정 단위 | 원본 총합 9,000점(=90회)이 매치 수와 맞지 않는다. 세트당인지 매치당인지, 미집계 구간이 있는지 확인 필요 |
-| 4 | **선수 상세 스탯(3단계)** | 세트별 선수 기록 약 4,000행은 수기로 불가능(§2.1). ① 3단계 자체를 보류하고 선수 탭은 포인트·승패만 노출 ② 매치 단위 합계로 축소 입력(약 1,650행) ③ 별도 적재 경로 마련 — **①을 권장**(팀 탭이 먼저 완성되고 나중에 확장 가능) |
-| 5 | 토너먼트 대진표 | MSI·플레이오프·롤드컵 녹아웃의 **대진도**(누가 누구와, 승자가 어디로)는 현재 표현되지 않는다. 경기 결과는 `esports_match` 에 남지만 브래킷 트리는 없다. 대진표 화면이 필요하면 별도 설계 필요 (§5.7) |
+| 4 | **선수 상세 스탯(3단계)** | 세트별 선수 기록 약 4,000행은 수기로 불가능(§3.1). ① 3단계 자체를 보류하고 선수 탭은 포인트·승패만 노출 ② 매치 단위 합계로 축소 입력(약 1,650행) ③ 별도 적재 경로 마련 — **①을 권장**(팀 탭이 먼저 완성되고 나중에 확장 가능) |
+| 5 | 토너먼트 대진표 | MSI·플레이오프·롤드컵 녹아웃의 **대진도**(누가 누구와, 승자가 어디로)는 표현되지 않는다. 경기 결과는 `esports_match` 에 남지만 브래킷 트리는 없다 (§6.8) |
 | 6 | 진출권 표시 | `qualified_season_id`/`seed_no` 를 화면에 노출할지, 관리 목적으로만 둘지 |
 | 7 | 관리자 인증 | `/api/v1/admin/**` 권한 체계. 기존 member 컨텍스트 역할 재사용 여부 |
-| 8 | **스위스 순위 규칙** | 롤드컵 스위스는 승패 동률 시 상대 전적 강도(Buchholz) 등 풀리그와 다른 타이브레이커를 쓸 수 있다. 롤드컵을 실제로 다룰 때 `TieBreakRule` 의 스위스 구현이 필요 (§5.7) |
-| 9 | 국제 대회 도입 시점 | LCK 만 먼저 할지, 롤드컵·MSI 를 같이 열지. **테이블은 이미 커버하므로(§5.7) 시드 데이터와 입력량 문제일 뿐이다** |
+| 8 | **스위스 순위 규칙** | 롤드컵 스위스는 승패 동률 시 상대 전적 강도(Buchholz) 등 풀리그와 다른 타이브레이커를 쓸 수 있다. 롤드컵을 실제로 다룰 때 `TieBreakRule` 의 스위스 구현이 필요 (§6.8) |
+| 9 | 국제 대회 도입 시점 | LCK 만 먼저 할지, 롤드컵·MSI 를 같이 열지. **테이블은 이미 커버하므로(§6.8) 시드 데이터와 입력량 문제일 뿐이다** |
 | 10 | **팀 리브랜딩 시 "당시 팀명"** | 팀이 이름을 바꾸면(`DWG KIA → Dplus KIA` — 공식 데이터에도 `slug='dwg-kia'`, `name='Dplus KIA'` 로 흔적이 남아 있다) `team_id` 는 그대로라 **과거 기록도 새 이름으로 표시된다.** 커리어에 "2022 DWG KIA" 로 보여야 한다면 `esports_team_name_history` 가 필요하다. 현재 범위에서는 최신 이름으로 통일 |
 | 11 | 코치·감독 로스터 | `esports_roster.position` 이 선수 포지션 5종 전제다. 코칭스태프를 넣으려면 `role`(PLAYER/COACH) 구분이 필요 |
 
 ---
 
-## 12. 부록 — 검증에 사용한 주소
+## 부록 A. 검증에 사용한 주소
 
-설계 근거를 재확인할 때 쓴다. **채택한 데이터 경로가 아니다** (§2.2).
+설계 근거를 재확인할 때 쓴다. **채택한 데이터 경로가 아니다** (§3.2).
 
 **브라우저에서 바로 열림**
 
@@ -1185,7 +1180,7 @@ https://feed.lolesports.com/livestats/v1/window/116951349275512133
 ```bash
 K=0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z
 
-# §1.1 스테이지 구조 — split_2 정규리그 / split_3 레전드·라이즈 그룹
+# §2.1 스테이지 구조 — split_2 정규리그 / split_3 레전드·라이즈 그룹
 curl -s -H "x-api-key: $K" \
   "https://esports-api.lolesports.com/persisted/gw/getStandingsV3?hl=ko-KR&tournamentId=115548128960088078" | jq .
 curl -s -H "x-api-key: $K" \

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -220,17 +220,20 @@ module/domain/esports/src/main/java/com/example/lolserver/esports/
 > `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
 > 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
 
-> ✅ 아래 DDL 전체(**테이블 15 · 인덱스 7 · 뷰 3**)는 로컬 `postgres:16-alpine` 에서
+> ✅ 아래 DDL 전체(**테이블 15 · 인덱스 9 · 뷰 3**)는 로컬 `postgres:16-alpine` 에서
 > `BEGIN … ROLLBACK` 으로 실제 실행해 문법·제약·의존 순서를 검증했다 (§7.4 에 결과).
 
 ### 5.1 마스터
 
 ```sql
+-- 리그. 지역 리그(lck, lpl…)와 국제 대회(worlds, msi…)를 같은 테이블에 담는다.
 CREATE TABLE IF NOT EXISTS esports_league (
-    league_id      VARCHAR(50)  NOT NULL,          -- 'lck'
+    league_id      VARCHAR(50)  NOT NULL,          -- 'lck', 'worlds', 'msi'
     game_code      VARCHAR(20)  NOT NULL DEFAULT 'lol',
     name           VARCHAR(200) NOT NULL,
     name_acronym   VARCHAR(50),
+    region         VARCHAR(50),                    -- '한국', '중국', '국제 대회'
+    international  BOOLEAN      NOT NULL DEFAULT FALSE,  -- 국제 대회 여부
     image_url      VARCHAR(500),
     dark_image_url VARCHAR(500),
     sort_order     INTEGER      NOT NULL DEFAULT 0,
@@ -239,6 +242,7 @@ CREATE TABLE IF NOT EXISTS esports_league (
     updated_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_league PRIMARY KEY (league_id)
 );
+CREATE INDEX IF NOT EXISTS idx_league_intl ON esports_league (international, sort_order);
 
 CREATE TABLE IF NOT EXISTS esports_season (
     season_id      VARCHAR(80)  NOT NULL,          -- 'lck_2026'
@@ -256,10 +260,13 @@ CREATE TABLE IF NOT EXISTS esports_season (
         REFERENCES esports_league (league_id)
 );
 
+-- 팀 마스터는 대회와 무관하다. 국제 대회에서 여러 리그 팀이 한 순위표에 모이므로
+-- 소속(홈) 리그를 갖는다 — "T1 (LCK)" / "BLG (LPL)" 표시에 필요.
 CREATE TABLE IF NOT EXISTS esports_team (
     team_id          VARCHAR(30)  NOT NULL,
     team_code        VARCHAR(20)  NOT NULL,        -- 'T1' ← 수기 입력용 키
     game_code        VARCHAR(20)  NOT NULL DEFAULT 'lol',
+    home_league_id   VARCHAR(50),                  -- 'lck' (국제 대회 표시용)
     name             VARCHAR(100) NOT NULL,
     name_eng         VARCHAR(100),
     image_url        VARCHAR(500),
@@ -267,7 +274,9 @@ CREATE TABLE IF NOT EXISTS esports_team (
     created_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_team PRIMARY KEY (team_id),
-    CONSTRAINT uk_esports_team_code UNIQUE (game_code, team_code)
+    CONSTRAINT uk_esports_team_code UNIQUE (game_code, team_code),
+    CONSTRAINT fk_team_home_league FOREIGN KEY (home_league_id)
+        REFERENCES esports_league (league_id)
 );
 
 CREATE TABLE IF NOT EXISTS esports_player (
@@ -306,12 +315,17 @@ CREATE TABLE IF NOT EXISTS esports_stage (
     stage_key       VARCHAR(40)  NOT NULL,   -- 'REGULAR_R1_R2','MSI_QUALIFIER',
                                              -- 'REGULAR_R3_R5','PLAY_IN','PLAYOFF'
     name            VARCHAR(100) NOT NULL,   -- '정규시즌 1-2R'
-    format          VARCHAR(20)  NOT NULL,   -- 'ROUND_ROBIN' | 'BRACKET'
+    -- ROUND_ROBIN : 풀리그 (LCK 정규시즌)
+    -- SWISS       : 스위스 (롤드컵) — 풀리그가 아니지만 순위표가 존재한다
+    -- BRACKET     : 토너먼트 (플레이인·플레이오프·녹아웃) — 순위표 없음
+    format          VARCHAR(20)  NOT NULL,
     grouped         BOOLEAN      NOT NULL DEFAULT FALSE,  -- 그룹별 진행 여부
     -- ★ 같은 값을 가진 스테이지들이 하나의 순위표로 누적 집계된다 (§1.2).
-    --   NULL 이면 순위표를 만들지 않는다 (토너먼트 스테이지).
+    --   NULL 이면 순위표를 만들지 않는다 (BRACKET 스테이지).
     standing_key    VARCHAR(40),
-    -- 그룹 편성의 근거가 되는 이전 스테이지 (1~2R 성적으로 Legend/Rise 를 가른다)
+    -- 그룹 편성 근거 스테이지 (1~2R 성적으로 Legend/Rise 를 가른다).
+    -- NULL + grouped=TRUE 면 성적이 아닌 추첨 등으로 편성된 것이며,
+    -- 이 경우 GroupSplitter 가 건드리지 않고 관리자가 직접 입력한다 (롤드컵 조 추첨).
     group_source_stage_id BIGINT,
     group_size      SMALLINT,                -- 상위 N팀 / 하위 N팀 (LCK = 5)
     start_date      DATE,
@@ -320,7 +334,10 @@ CREATE TABLE IF NOT EXISTS esports_stage (
     created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_stage PRIMARY KEY (stage_id),
     CONSTRAINT uk_esports_stage UNIQUE (season_id, stage_key),
-    CONSTRAINT ck_esports_stage_format CHECK (format IN ('ROUND_ROBIN', 'BRACKET')),
+    CONSTRAINT ck_esports_stage_format CHECK (format IN ('ROUND_ROBIN', 'SWISS', 'BRACKET')),
+    -- BRACKET 은 순위표를 만들지 않는다
+    CONSTRAINT ck_stage_bracket_no_standing
+        CHECK (format <> 'BRACKET' OR standing_key IS NULL),
     CONSTRAINT fk_stage_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
     CONSTRAINT fk_stage_group_source FOREIGN KEY (group_source_stage_id)
         REFERENCES esports_stage (stage_id)
@@ -369,6 +386,9 @@ CREATE TABLE IF NOT EXISTS esports_match (
     away_team_id  VARCHAR(30)  NOT NULL,
     home_score    SMALLINT     NOT NULL,          -- 세트 승수
     away_score    SMALLINT     NOT NULL,
+    -- Bo 형식. 같은 스테이지 안에서도 달라진다 (롤드컵 스위스: 초반 Bo1, 진출·탈락전 Bo3).
+    -- 검증 뷰가 "Bo3 인데 4세트" 같은 오입력을 잡는 데 쓴다.
+    best_of       SMALLINT,
     status        VARCHAR(20)  NOT NULL DEFAULT 'COMPLETED',
     created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -509,19 +529,27 @@ CREATE TABLE IF NOT EXISTS esports_standing_snapshot (
 CREATE INDEX IF NOT EXISTS idx_ess_timeline
     ON esports_standing_snapshot (season_id, standing_key, team_id, snapshot_date);
 
--- 플레이오프까지 끝난 뒤의 최종 순위 + 롤드컵 시드.
+-- 대회 최종 순위 + 다음 대회 진출권.
 -- 토너먼트는 순위표로 집계되지 않으므로 관리자가 직접 확정한다.
+-- 공동 순위(8강 탈락 4팀 = 공동 5위)를 위해 final_rank 중복을 허용한다.
 CREATE TABLE IF NOT EXISTS esports_season_result (
-    season_id    VARCHAR(80) NOT NULL,
-    team_id      VARCHAR(30) NOT NULL,
-    final_rank   SMALLINT    NOT NULL,      -- 1=우승
-    worlds_seed  SMALLINT,                  -- 1~4시드, NULL=미진출
-    note         VARCHAR(200),
-    created_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    season_id           VARCHAR(80) NOT NULL,
+    team_id             VARCHAR(30) NOT NULL,
+    final_rank          SMALLINT    NOT NULL,   -- 1=우승 (중복 허용)
+    -- 다음 대회 진출권을 일반화한다. LCK→롤드컵뿐 아니라 LCK→MSI,
+    -- 롤드컵 플레이인→스위스 등 모든 진출 관계를 같은 컬럼으로 표현한다.
+    qualified_season_id VARCHAR(80),            -- 진출한 대회 (예: 'worlds_2026')
+    seed_no             SMALLINT,               -- 그 대회에서의 시드 번호
+    note                VARCHAR(200),
+    created_at          TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_season_result PRIMARY KEY (season_id, team_id),
-    CONSTRAINT fk_esr_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
-    CONSTRAINT fk_esr_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+    CONSTRAINT fk_esr_season    FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_esr_team      FOREIGN KEY (team_id)   REFERENCES esports_team (team_id),
+    CONSTRAINT fk_esr_qualified FOREIGN KEY (qualified_season_id)
+        REFERENCES esports_season (season_id)
 );
+CREATE INDEX IF NOT EXISTS idx_esr_qualified
+    ON esports_season_result (qualified_season_id, seed_no);
 ```
 
 ### 5.6 설계 근거
@@ -538,6 +566,82 @@ CREATE TABLE IF NOT EXISTS esports_season_result (
 | `esports_season_result` 분리 | 플레이오프 결과는 집계 불가. 최종 순위·롤드컵 시드는 관리자 확정값 |
 | `team_code` / `nick_name` UNIQUE | 수기 입력이 확정이므로 사람이 읽는 키가 필수다 |
 | `rank` → `team_rank` | PostgreSQL 에선 쓸 수 있으나 윈도우 함수 `rank()` 와 겹쳐 가독성이 나쁘고 MySQL 8+ 는 예약어 |
+| `esports_team.home_league_id` | 국제 대회 순위표에 여러 리그 팀이 섞인다. "T1 (LCK)" 표시에 필요 (§5.7) |
+| `format` 에 `SWISS` 포함 | 롤드컵의 핵심 스테이지가 스위스다. 풀리그도 토너먼트도 아니면서 순위표가 있다 (§5.7) |
+| `qualified_season_id` + `seed_no` | LCK→롤드컵뿐 아니라 LCK→MSI, 플레이인→스위스도 같은 컬럼으로 표현 |
+| `best_of` 를 매치 단위로 | 스테이지 안에서도 Bo 가 달라진다 (스위스: 초반 Bo1, 진출·탈락전 Bo3) |
+
+### 5.7 국제 대회(롤드컵 · MSI) 커버리지 검토
+
+실제 대회 구조를 조회해 현재 테이블이 감당하는지 점검했다.
+
+**확인한 실제 구조**
+
+| 대회 | 스테이지 |
+|---|---|
+| 롤드컵 2026 | 플레이-인 → **스위스** → 녹아웃 |
+| MSI 2026 | 플레이-인 → 녹아웃 |
+| 국제 리그 목록 | `worlds`, `msi`, `first_stand`, `ewc_lol`, `wqs` — 전부 `region="국제 대회"` |
+| 팀 마스터 | `homeLeague: {name:"LCK", region:"한국"}` — **팀은 홈 리그를 갖는다** |
+
+**점검 결과**
+
+| # | 항목 | 검토 전 | 조치 |
+|---|---|---|---|
+| 1 | **스위스 스테이지** | ❌ `format` CHECK 가 `ROUND_ROBIN`/`BRACKET` 만 허용해 **INSERT 가 막힘** | `SWISS` 추가. 순위표를 만들되 풀리그 가정을 두지 않는다 |
+| 2 | **팀의 소속 리그** | ❌ 컬럼 없음 → 국제 대회에서 소속 표시 불가 | `esports_team.home_league_id` 추가 |
+| 3 | 리그의 국제/지역 구분 | ❌ 없음 | `esports_league.region` + `international` 추가 |
+| 4 | 추첨 기반 조 편성 | ⚠️ 성적 기반 자동 분리만 상정 | `group_source_stage_id IS NULL` = 수동 편성으로 정의. `GroupSplitter` 가 건드리지 않는다 |
+| 5 | 다음 대회 진출권 | ⚠️ `worlds_seed` 가 특정 대회 종속 | `qualified_season_id` + `seed_no` 로 일반화 |
+| 6 | Bo 형식 혼재 | ⚠️ 미기록 | `esports_match.best_of` 추가 + 검증 뷰가 위반 검출 |
+| 7 | 여러 리그 팀이 한 대회에 | ✅ 팀 마스터가 대회와 무관 | 변경 없음 |
+| 8 | 다단계 대회 구조 | ✅ `esports_stage` 가 그대로 수용 | 변경 없음 |
+| 9 | 스테이지별 독립 순위표 | ✅ `standing_key` 를 다르게 주면 분리 | 변경 없음 |
+| 10 | 공동 순위(8강 탈락 = 공동 5위) | ✅ `final_rank` 중복 허용 | 변경 없음 |
+| 11 | Bo1 ~ Bo5 | ✅ `home_score`/`away_score` 로 표현 | 변경 없음 |
+
+**롤드컵 2026 시드 예시** — 위 조치만으로 표현된다.
+
+```sql
+INSERT INTO esports_league (league_id, name, name_acronym, region, international)
+VALUES ('worlds', '월드 챔피언십', 'Worlds', '국제 대회', TRUE);
+
+INSERT INTO esports_season (season_id, league_id, name, year, start_date, end_date)
+VALUES ('worlds_2026', 'worlds', '2026 월드 챔피언십', 2026, DATE '2026-10-20', DATE '2026-11-20');
+
+INSERT INTO esports_stage
+    (season_id, stage_key, name, format, grouped, standing_key, sort_order)
+VALUES
+    ('worlds_2026', 'PLAY_IN',  '플레이-인', 'BRACKET',     FALSE, NULL,    1),
+    ('worlds_2026', 'SWISS',    '스위스',    'SWISS',       FALSE, 'SWISS', 2),
+    ('worlds_2026', 'KNOCKOUT', '녹아웃',    'BRACKET',     FALSE, NULL,    3);
+
+-- LCK 1시드로 롤드컵 진출
+INSERT INTO esports_season_result (season_id, team_id, final_rank, qualified_season_id, seed_no)
+SELECT 'lck_2026', team_id, 1, 'worlds_2026', 1 FROM esports_team WHERE team_code = 'T1';
+```
+
+**검증 결과** — 위 시드와 조치를 Postgres 16 에서 실행하고 롤백했다.
+
+| 확인 | 기대 | 실제 |
+|---|---|---|
+| 리그 국제/지역 구분 | `worlds`=국제, `lck`·`lpl`=지역 | **일치** |
+| 롤드컵 스테이지 3단 | `SWISS` 는 `standing_key` 보유, `BRACKET` 은 NULL | **일치** |
+| 팀 → 홈 리그 조회 | `T1→한국`, `BLG→중국` | **일치** |
+| LCK 1위 → 롤드컵 1시드 | `qualified_season_id='worlds_2026'`, `seed_no=1` | **일치** |
+| 스위스 Bo1 매치(1:0) 입력 | 검증 뷰 0행 | **0행** |
+| `Bo3` 인데 `3:0` 주입 | 검증 뷰가 검출 | **1행 검출** |
+| `BRACKET` 에 `standing_key` 부여 | CHECK 제약이 거부 | **`ck_stage_bracket_no_standing` 위반으로 거부** |
+
+**남은 한계 (이번 범위 밖)**
+
+- **스위스 순위 규칙**: 승패 동률 시 상대 전적 강도(Buchholz)를 쓰는 경우가 있다.
+  `TieBreakRule` 을 스위스용으로 하나 더 만들어야 할 수 있다 → §11-8.
+- **토너먼트 대진표**: 8강·4강·결승의 대진 구조(누가 누구와 붙는지, 상위 진출 연결)는
+  `esports_match` 로 경기 결과는 남지만 **대진도(bracket tree)를 그릴 정보는 없다**.
+  대진표 화면이 필요하면 별도 설계가 추가로 필요하다 → §11-5.
+- **참가팀 명단(경기 전)**: 경기가 입력되기 전에는 참가팀을 알 수 없다.
+  개막 전 참가팀 목록 화면이 필요하면 `esports_season_participant` 를 추가한다.
 
 ---
 
@@ -654,11 +758,11 @@ SELECT m.match_id, g.game_no, t.team_id, g.duration_sec
 수기 입력은 반드시 틀린다. **집계 전에 걸러내는 뷰**를 함께 만든다.
 
 ```sql
--- ① 매치 결과와 세트 수가 어긋난 매치
+-- ① 매치 결과와 세트 수가 어긋난 매치 (+ Bo 형식 위반)
 CREATE OR REPLACE VIEW v_esports_match_invalid AS
 SELECT m.match_id, m.match_date, st.name AS stage,
        h.team_code AS home, a.team_code AS away,
-       m.home_score, m.away_score,
+       m.home_score, m.away_score, m.best_of,
        COUNT(g.game_id)                                          AS game_rows,
        COUNT(*) FILTER (WHERE g.winner_team_id = m.home_team_id)  AS home_game_wins,
        COUNT(*) FILTER (WHERE g.winner_team_id = m.away_team_id)  AS away_game_wins
@@ -668,10 +772,18 @@ SELECT m.match_id, m.match_date, st.name AS stage,
   JOIN esports_team a ON a.team_id = m.away_team_id
   LEFT JOIN esports_game g ON g.match_id = m.match_id
  WHERE m.status = 'COMPLETED'
- GROUP BY m.match_id, m.match_date, st.name, h.team_code, a.team_code, m.home_score, m.away_score
+ GROUP BY m.match_id, m.match_date, st.name, h.team_code, a.team_code,
+          m.home_score, m.away_score, m.best_of
+   -- 세트 행 수가 매치 스코어 합과 다름
 HAVING COUNT(g.game_id) <> m.home_score + m.away_score
+   -- 세트 승자 분포가 매치 스코어와 다름
     OR COUNT(*) FILTER (WHERE g.winner_team_id = m.home_team_id) <> m.home_score
-    OR COUNT(*) FILTER (WHERE g.winner_team_id = m.away_team_id) <> m.away_score;
+    OR COUNT(*) FILTER (WHERE g.winner_team_id = m.away_team_id) <> m.away_score
+   -- Bo 형식 위반: 승자는 정확히 과반 세트를 이겨야 한다 (Bo1→1, Bo3→2, Bo5→3)
+    OR (m.best_of IS NOT NULL
+        AND GREATEST(m.home_score, m.away_score) <> m.best_of / 2 + 1)
+   -- Bo 형식 초과: 총 세트가 best_of 를 넘을 수 없다
+    OR (m.best_of IS NOT NULL AND m.home_score + m.away_score > m.best_of);
 
 -- ② 스테이지별 입력 진행률 — 어디까지 넣었는지 한눈에
 --    주의: 팀 테이블을 JOIN 하면 매치당 2행이 되어 집계가 2배가 된다.
@@ -720,7 +832,7 @@ SELECT st.season_id, st.standing_key,
 
 | 단계 | 기대 | 실제 |
 |---|---|---|
-| DDL 전체 생성 | 성공 | **테이블 15 · 인덱스 7 · 뷰 3 생성** |
+| DDL 전체 생성 | 성공 | **테이블 15 · 인덱스 9 · 뷰 3 생성** |
 | 스테이지 시드 + 그룹 근거 연결 | 5행 | **5행, `REGULAR_R3_R5 → REGULAR_R1_R2` 연결됨** |
 | 정상 입력 후 검증 뷰 ① | 0행 | **0행** |
 | 진행률 뷰 ② | 매치 2 · 세트 5 · 팀 3 | **정확히 일치** |
@@ -777,7 +889,8 @@ SELECT st.season_id, st.standing_key,
           {
             "rank": 1, "overallRank": 1,
             "team": { "teamId": "R1040", "teamCode": "T1", "name": "T1",
-                      "imageUrl": "https://.../t1.png" },
+                      "imageUrl": "https://.../t1.png",
+                      "homeLeague": { "leagueId": "lck", "nameAcronym": "LCK", "region": "한국" } },
             "wins": 16, "loses": 6, "draws": 0,
             "setWins": 34, "setLoses": 13, "score": 21,
             "winRate": 0.7273,
@@ -793,6 +906,11 @@ SELECT st.season_id, st.standing_key,
 
 `includedStages` 로 **이 순위표가 어떤 단계를 합산한 것인지** 화면에 표시할 수 있다.
 `kda` 등이 `null` 인 것은 3단계 미완을 뜻한다(에러가 아니다).
+`homeLeague` 는 국제 대회 순위표에서 `T1 (LCK)` · `BLG (LPL)` 처럼 소속을 표시할 때 쓴다.
+LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하면 된다.
+
+`GET /leagues` 응답에도 `region` 과 `international` 이 포함되어, 리그 필터에서
+지역 리그와 국제 대회를 구분해 그룹핑할 수 있다.
 
 ### 8.2 스테이지 목록 (신규)
 
@@ -917,9 +1035,11 @@ SELECT st.season_id, st.standing_key,
 | 2 | **순위표 노출 단위** | 화면에 `REGULAR`(1~2R+3~5R 누적) 하나만 둘지, `1~2R 단독` 탭도 줄지. `standing_key` 를 나누기만 하면 되므로 코드 변경은 없다 |
 | 3 | POG 산정 단위 | 원본 총합 9,000점(=90회)이 매치 수와 맞지 않는다. 세트당인지 매치당인지, 미집계 구간이 있는지 확인 필요 |
 | 4 | **선수 상세 스탯(3단계)** | 세트별 선수 기록 약 4,000행은 수기로 불가능(§2.1). ① 3단계 자체를 보류하고 선수 탭은 포인트·승패만 노출 ② 매치 단위 합계로 축소 입력(약 1,650행) ③ 별도 적재 경로 마련 — **①을 권장**(팀 탭이 먼저 완성되고 나중에 확장 가능) |
-| 5 | MSI·플레이오프 대진표 | 토너먼트는 순위표로 표현되지 않는다. 대진표 화면이 필요하면 별도 테이블·API 설계가 추가로 필요하다. 현재 범위는 **최종 순위만 `esports_season_result` 로 관리** |
-| 6 | 롤드컵 시드 표시 | `worlds_seed` 를 화면에 노출할지, 관리 목적으로만 둘지 |
+| 5 | 토너먼트 대진표 | MSI·플레이오프·롤드컵 녹아웃의 **대진도**(누가 누구와, 승자가 어디로)는 현재 표현되지 않는다. 경기 결과는 `esports_match` 에 남지만 브래킷 트리는 없다. 대진표 화면이 필요하면 별도 설계 필요 (§5.7) |
+| 6 | 진출권 표시 | `qualified_season_id`/`seed_no` 를 화면에 노출할지, 관리 목적으로만 둘지 |
 | 7 | 관리자 인증 | `/api/v1/admin/**` 권한 체계. 기존 member 컨텍스트 역할 재사용 여부 |
+| 8 | **스위스 순위 규칙** | 롤드컵 스위스는 승패 동률 시 상대 전적 강도(Buchholz) 등 풀리그와 다른 타이브레이커를 쓸 수 있다. 롤드컵을 실제로 다룰 때 `TieBreakRule` 의 스위스 구현이 필요 (§5.7) |
+| 9 | 국제 대회 도입 시점 | LCK 만 먼저 할지, 롤드컵·MSI 를 같이 열지. **테이블은 이미 커버하므로(§5.7) 시드 데이터와 입력량 문제일 뿐이다** |
 
 ---
 

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -220,7 +220,7 @@ module/domain/esports/src/main/java/com/example/lolserver/esports/
 > `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
 > 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
 
-> ✅ 아래 DDL 전체(**테이블 15 · 인덱스 9 · 뷰 3**)는 로컬 `postgres:16-alpine` 에서
+> ✅ 아래 DDL 전체(**테이블 15 · 인덱스 11 · 뷰 4**)는 로컬 `postgres:16-alpine` 에서
 > `BEGIN … ROLLBACK` 으로 실제 실행해 문법·제약·의존 순서를 검증했다 (§7.4 에 결과).
 
 ### 5.1 마스터
@@ -291,18 +291,41 @@ CREATE TABLE IF NOT EXISTS esports_player (
     CONSTRAINT uk_esports_player_nick UNIQUE (nick_name)
 );
 
+-- ★ 로스터는 "시즌별 소속" 이 아니라 "계약 기간" 으로 표현한다 (근거는 §5.8).
+--   이적이 과거 소속을 덮어쓰지 못하게 기간 이력(temporal) 테이블로 둔다.
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
 CREATE TABLE IF NOT EXISTS esports_roster (
-    season_id  VARCHAR(80) NOT NULL,
+    roster_id  BIGSERIAL   NOT NULL,
     player_id  VARCHAR(30) NOT NULL,
     team_id    VARCHAR(30) NOT NULL,
     position   VARCHAR(10) NOT NULL,               -- TOP|JGL|MID|AD|SPT
-    joined_at  DATE,
-    left_at    DATE,
-    CONSTRAINT pk_esports_roster PRIMARY KEY (season_id, player_id, team_id),
-    CONSTRAINT fk_roster_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    joined_at  DATE        NOT NULL,
+    left_at    DATE,                               -- NULL = 현재 소속
+    note       VARCHAR(200),                       -- '2026 서머 로스터 변경' 등
+    created_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_roster PRIMARY KEY (roster_id),
+    CONSTRAINT uk_roster_player_joined UNIQUE (player_id, joined_at),
+    CONSTRAINT ck_roster_period CHECK (left_at IS NULL OR left_at > joined_at),
     CONSTRAINT fk_roster_player FOREIGN KEY (player_id) REFERENCES esports_player (player_id),
-    CONSTRAINT fk_roster_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+    CONSTRAINT fk_roster_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id),
+    -- 한 선수의 소속 기간은 겹칠 수 없다. DB 가 강제하므로 오입력이 아예 들어오지 못한다.
+    CONSTRAINT ex_roster_no_overlap EXCLUDE USING gist (
+        player_id WITH =,
+        daterange(joined_at, COALESCE(left_at, DATE '9999-12-31')) WITH &&
+    )
 );
+CREATE INDEX IF NOT EXISTS idx_roster_team   ON esports_roster (team_id, joined_at DESC);
+CREATE INDEX IF NOT EXISTS idx_roster_player ON esports_roster (player_id, joined_at DESC);
+
+-- 시즌 로스터는 저장하지 않고 계약 기간 ∩ 시즌 기간으로 유도한다.
+-- 시즌마다·국제 대회마다 로스터를 다시 입력할 필요가 없어진다.
+CREATE OR REPLACE VIEW v_esports_season_roster AS
+SELECT s.season_id, r.player_id, r.team_id, r.position, r.joined_at, r.left_at
+  FROM esports_season s
+  JOIN esports_roster r
+    ON daterange(r.joined_at,  COALESCE(r.left_at,  DATE '9999-12-31'))
+    && daterange(s.start_date, COALESCE(s.end_date, DATE '9999-12-31'));
 ```
 
 ### 5.2 ★ 스테이지 — LCK 구조를 담는 핵심 테이블
@@ -566,6 +589,8 @@ CREATE INDEX IF NOT EXISTS idx_esr_qualified
 | `esports_season_result` 분리 | 플레이오프 결과는 집계 불가. 최종 순위·롤드컵 시드는 관리자 확정값 |
 | `team_code` / `nick_name` UNIQUE | 수기 입력이 확정이므로 사람이 읽는 키가 필수다 |
 | `rank` → `team_rank` | PostgreSQL 에선 쓸 수 있으나 윈도우 함수 `rank()` 와 겹쳐 가독성이 나쁘고 MySQL 8+ 는 예약어 |
+| `esports_roster` 를 기간 이력으로 | 시즌 PK 구조에서는 같은 시즌 재계약이 저장되지 않고, 이적을 `UPDATE` 로 처리하면 과거 소속이 사라졌다. `EXCLUDE` 제약으로 겹침을 DB 가 막는다 (§5.8) |
+| 시즌 로스터를 저장하지 않고 유도 | 계약 기간 ∩ 시즌 기간으로 산출. 시즌·국제 대회마다 로스터를 재입력할 필요가 없다 (§5.8) |
 | `esports_team.home_league_id` | 국제 대회 순위표에 여러 리그 팀이 섞인다. "T1 (LCK)" 표시에 필요 (§5.7) |
 | `format` 에 `SWISS` 포함 | 롤드컵의 핵심 스테이지가 스위스다. 풀리그도 토너먼트도 아니면서 순위표가 있다 (§5.7) |
 | `qualified_season_id` + `seed_no` | LCK→롤드컵뿐 아니라 LCK→MSI, 플레이인→스위스도 같은 컬럼으로 표현 |
@@ -643,6 +668,61 @@ SELECT 'lck_2026', team_id, 1, 'worlds_2026', 1 FROM esports_team WHERE team_cod
 - **참가팀 명단(경기 전)**: 경기가 입력되기 전에는 참가팀을 알 수 없다.
   개막 전 참가팀 목록 화면이 필요하면 `esports_season_participant` 를 추가한다.
 
+### 5.8 로스터 — 선수 커리어(과거 소속) 보존
+
+**초판의 `esports_roster` 는 `PRIMARY KEY (season_id, player_id, team_id)` 였다.**
+이 구조로 이적을 처리하면 어떻게 되는지 실제로 실행해 확인했다.
+
+| 시나리오 | 결과 | 판정 |
+|---|---|---|
+| 시즌을 넘는 이적 (2025 GEN → 2026 T1) | 시즌이 다르므로 두 행이 남는다 | ✅ 이력 보존 |
+| 시즌 중 이적 (2026 T1 → GEN) | `team_id` 가 PK 에 있어 두 행이 공존 | ✅ 이력 보존 |
+| **시즌 중 복귀** (GEN → T1 재계약) | **PK 충돌로 INSERT 실패** | ❌ 저장 불가 |
+| **이적을 `UPDATE` 로 처리** | **GEN 소속 이력이 흔적 없이 사라짐** | ❌ 이력 소실 |
+| 현재 소속의 유일성 | `left_at IS NULL` 이 2건이어도 통과 | ❌ 무결성 미보장 |
+
+**정확한 진단** — 이력이 항상 사라지는 건 아니다. 시즌이 다르면 남는다.
+문제는 **구조가 이력 보존을 강제하지 않는다**는 것이다. 관리자가 이적을 새 행으로 넣으면 남고
+기존 행을 고치면 사라진다. 데이터 무결성이 입력자의 습관에 의존하면 언젠가 깨진다.
+같은 시즌 재계약은 아예 저장할 수도 없다.
+
+**개선 — 계약 기간(temporal) 모델**
+
+`season_id` 를 버리고 `joined_at ~ left_at` 기간으로 표현한다. 선수-팀 계약은 시즌이 아니라
+기간의 함수이기 때문이다. `EXCLUDE USING gist` 로 **한 선수의 소속 기간이 겹칠 수 없게 DB 가 강제**한다.
+
+검증 결과 (Postgres 16, 실행 후 롤백):
+
+| 확인 | 결과 |
+|---|---|
+| GEN → T1 → GEN 재계약 3건 입력 | **전부 저장됨** (기존 PK 로는 불가능했던 케이스) |
+| 기간이 겹치는 오입력 | **`ex_roster_no_overlap` 위반으로 거부** |
+| 현재 소속 조회 (`left_at IS NULL`) | **정확히 1건** |
+| 시즌 로스터 유도 (`v_esports_season_roster`) | lck_2025→GEN, lck_2026→GEN·T1, **worlds_2026→GEN 자동 산출** |
+| 특정 시점 소속 (2026-07-01) | **T1** — 임의 시점 조회 가능 |
+
+**부수 효과 — 국제 대회 로스터 중복 입력이 사라진다.**
+§5.7 에서 "Worlds 참가 로스터를 또 입력해야 한다" 는 부담을 지적했는데,
+계약 기간이 대회 기간과 겹치면 자동으로 유도되므로 **입력 자체가 필요 없어진다.**
+
+**운영 주의**
+
+- `btree_gist` 확장이 필요하다(`EXCLUDE` 에서 `player_id WITH =` 를 쓰기 위해).
+  설치 권한이 없는 환경이라면 `UNIQUE (player_id, joined_at)` 만 남기고
+  겹침 검출은 검증 뷰 + `Roster` 도메인의 `validateNoOverlap()` 으로 대체한다.
+- 이적 입력은 **기존 행의 `left_at` 을 채우고 새 행을 INSERT** 하는 2단계다.
+  `UPDATE team_id` 로 처리하면 안 된다 — 그게 초판에서 이력이 사라지던 경로다.
+
+```sql
+-- 2026-06-01 자로 GEN → T1 이적
+UPDATE esports_roster SET left_at = DATE '2026-06-01'
+ WHERE player_id = 'P_CHOVY' AND left_at IS NULL;
+
+INSERT INTO esports_roster (player_id, team_id, position, joined_at)
+SELECT 'P_CHOVY', team_id, 'MID', DATE '2026-06-01'
+  FROM esports_team WHERE team_code = 'T1';
+```
+
 ---
 
 ## 6. 집계 로직
@@ -667,6 +747,7 @@ SELECT 'lck_2026', team_id, 1, 'worlds_2026', 1 FROM esports_team WHERE team_cod
 | 선수 `kill_involve_rate` | `(선수 K + A) / 같은 세트 소속팀 총 킬` |
 | 선수 `pog_point` | `esports_pog.point` 합 |
 | 선수 `wins/loses/score` | 선수가 1세트 이상 출전한 매치만 대상 |
+| 선수 `team_id` · `position` | **해당 순위표 기간과 겹치는 계약 중 가장 최근 것** (§5.8). 시즌 중 이적한 선수는 순위표에 한 팀만 표시되므로 마지막 소속을 쓴다. 3단계 이후에는 `esports_game_player` 의 실제 출전 팀으로 교차 검증한다 |
 
 **정렬(동점 규칙)** — `TieBreakRule` 로 분리한다. 리그마다 다르고 규정이 바뀐다.
 
@@ -832,7 +913,7 @@ SELECT st.season_id, st.standing_key,
 
 | 단계 | 기대 | 실제 |
 |---|---|---|
-| DDL 전체 생성 | 성공 | **테이블 15 · 인덱스 9 · 뷰 3 생성** |
+| DDL 전체 생성 | 성공 | **테이블 15 · 인덱스 11 · 뷰 4 생성** |
 | 스테이지 시드 + 그룹 근거 연결 | 5행 | **5행, `REGULAR_R3_R5 → REGULAR_R1_R2` 연결됨** |
 | 정상 입력 후 검증 뷰 ① | 0행 | **0행** |
 | 진행률 뷰 ② | 매치 2 · 세트 5 · 팀 3 | **정확히 일치** |
@@ -858,7 +939,9 @@ SELECT st.season_id, st.standing_key,
 | GET | `/api/v1/esports/seasons/{seasonId}/team-standings` | 팀 순위표 |
 | GET | `/api/v1/esports/seasons/{seasonId}/player-standings` | 선수 순위표 |
 | GET | `/api/v1/esports/seasons/{seasonId}/standing-history` | 순위 추이 |
-| GET | `/api/v1/esports/seasons/{seasonId}/result` | 최종 순위 · 롤드컵 시드 |
+| GET | `/api/v1/esports/seasons/{seasonId}/result` | 최종 순위 · 진출권 |
+| GET | `/api/v1/esports/players/{playerId}/career` | **선수 커리어 (팀 이력) — 신규** |
+| GET | `/api/v1/esports/teams/{teamCode}/roster` | **팀 로스터 (현재 / 특정 시점) — 신규** |
 | POST | `/api/v1/admin/esports/seasons/{seasonId}/aggregate` | 집계 트리거 |
 | POST | `/api/v1/admin/esports/stages/{stageId}/split-groups` | **그룹 편성 확정** |
 
@@ -965,7 +1048,46 @@ LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하�
 
 `teamCode` 생략 시 전 팀 시리즈. 그룹 분리 전후가 한 차트에 이어진다.
 
-### 8.5 에러
+### 8.5 선수 커리어 (신규)
+
+`GET /players/{playerId}/career`
+
+`esports_roster` 가 기간 이력이 되면서 가능해진 조회다(§5.8).
+
+```json
+{
+  "result": "SUCCESS",
+  "data": {
+    "player": { "playerId": "10785", "nickName": "Duro", "name": "주민규" },
+    "currentTeam": { "teamCode": "GEN", "name": "젠지", "joinedAt": "2026-08-16" },
+    "career": [
+      { "team": { "teamCode": "GEN", "name": "젠지",
+                  "homeLeague": { "leagueId": "lck", "nameAcronym": "LCK" } },
+        "position": "SPT", "joinedAt": "2026-08-16", "leftAt": null,
+        "seasons": ["lck_2026", "worlds_2026"] },
+      { "team": { "teamCode": "T1", "name": "T1" },
+        "position": "SPT", "joinedAt": "2026-06-01", "leftAt": "2026-08-15",
+        "seasons": ["lck_2026"] },
+      { "team": { "teamCode": "GEN", "name": "젠지" },
+        "position": "SPT", "joinedAt": "2024-11-20", "leftAt": "2026-05-31",
+        "seasons": ["lck_2025", "lck_2026"] }
+    ]
+  }
+}
+```
+
+- `career` 는 **최신 계약이 먼저** 오도록 `joinedAt DESC` 정렬한다.
+- 같은 팀에 두 번 소속된 이력이 각각 별도 항목으로 남는다 — 초판 구조에서는 저장조차 불가능했다.
+- `seasons` 는 `v_esports_season_roster` 로 유도한 값이라 별도 입력이 없다.
+
+### 8.6 팀 로스터 (신규)
+
+`GET /teams/{teamCode}/roster?asOf=2026-07-01`
+
+`asOf` 를 생략하면 현재 로스터(`left_at IS NULL`), 주면 그 시점의 로스터를 돌려준다.
+`asOf` 대신 `seasonId` 를 주면 해당 대회 기간과 겹치는 로스터가 나온다.
+
+### 8.7 에러
 
 | 상황 | 코드 |
 |---|---|
@@ -1040,6 +1162,8 @@ LCK 단독 순위표에서는 전 팀이 동일하므로 화면에서 생략하�
 | 7 | 관리자 인증 | `/api/v1/admin/**` 권한 체계. 기존 member 컨텍스트 역할 재사용 여부 |
 | 8 | **스위스 순위 규칙** | 롤드컵 스위스는 승패 동률 시 상대 전적 강도(Buchholz) 등 풀리그와 다른 타이브레이커를 쓸 수 있다. 롤드컵을 실제로 다룰 때 `TieBreakRule` 의 스위스 구현이 필요 (§5.7) |
 | 9 | 국제 대회 도입 시점 | LCK 만 먼저 할지, 롤드컵·MSI 를 같이 열지. **테이블은 이미 커버하므로(§5.7) 시드 데이터와 입력량 문제일 뿐이다** |
+| 10 | **팀 리브랜딩 시 "당시 팀명"** | 팀이 이름을 바꾸면(`DWG KIA → Dplus KIA` — 공식 데이터에도 `slug='dwg-kia'`, `name='Dplus KIA'` 로 흔적이 남아 있다) `team_id` 는 그대로라 **과거 기록도 새 이름으로 표시된다.** 커리어에 "2022 DWG KIA" 로 보여야 한다면 `esports_team_name_history` 가 필요하다. 현재 범위에서는 최신 이름으로 통일 |
+| 11 | 코치·감독 로스터 | `esports_roster.position` 이 선수 포지션 5종 전제다. 코칭스태프를 넣으려면 `role`(PLAYER/COACH) 구분이 필요 |
 
 ---
 

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -1,252 +1,174 @@
 # e스포츠 리그 기록 (LCK 순위표) — 테이블 · API 설계
 
 > 참고 화면: `https://game.naver.com/esports/League_of_Legends/record/lck/team/lck_2026`
-> 작성일: 2026-08-11 · 개정: v2 (원장 기반으로 전환) · 상태: 설계 초안 (구현 전)
+> 작성일: 2026-08-11 · 개정: **v3 (LCK 시즌 구조 반영 + 수기 입력 확정)** · 상태: 설계 초안
 
 네이버 게임 e스포츠 "기록" 페이지와 동일한 화면을 제공하기 위한 백엔드 설계.
 새 바운디드 컨텍스트 `module/domain/esports` 를 추가한다.
 
-> **v2 개정 요지** — v1은 외부 API가 이미 집계해 둔 순위표를 스냅샷으로 적재하는 설계였다.
-> 실제 API 3종을 호출해 검증한 결과(§2) **라이엇에는 문서화된 e스포츠 공개 API 자체가 없고**,
-> 실제로 쓸 수 있는 세 출처는 전부 비문서화 내부 API였다. 따라서 **경기 원장을 우리 DB의 진실원천으로 두고
-> 순위표는 집계 산출물로 만드는 구조**로 전환한다. 이력(순위 추이) 테이블도 다시 포함한다.
+**개정 이력**
+
+| 버전 | 변경 |
+|---|---|
+| v1 | 외부 API 순위표를 스냅샷으로 적재하는 설계 |
+| v2 | API 3종 검증 → 어느 것도 화면을 못 채우거나 의존 불가 → **원장 기반 집계**로 전환, 이력 테이블 복원 |
+| **v3** | **LCK 시즌 구조(스테이지) 반영**, 그룹 편성을 집계 산출물로 재정의, **수기 입력 확정**에 따라 외부 수집 경로 제거 |
 
 ---
 
-## 1. 참고 화면 분석
+## 1. LCK 시즌 구조
 
-### 1.1 URL / 라우팅 구조
+설계의 뼈대다. 이 구조를 테이블로 표현하지 못하면 나머지가 전부 어긋난다.
 
 ```
-/esports/{loungeId}/record/{topLeagueId}/{group}/{seasonId}?position={position}
-                            └ lck        └ team|player  └ lck_2026  └ ALL|TOP|JGL|MID|AD|SPT
+[1~2R] 정규시즌 · 10팀 단일 풀리그
+   │      └ 각 팀 18매치 (9상대 × 2라운드)
+   │
+   ├──→ 2R 종료 성적으로 그룹 분리 ──┐
+   │      상위 5팀 = Legend           │  ★ 그룹은 입력값이 아니라
+   │      하위 5팀 = Rise             │     1~2R 결과의 산출물이다
+   │                                  │
+[MSI 진출전] 1~2R 성적 기반 토너먼트 → MSI
+   │
+[3~5R] 정규시즌 · 그룹 내부 리그 ←────┘
+   │      Legend 5팀끼리 / Rise 5팀끼리
+   │
+[플레이인] Rise 상위 팀 → Legend 그룹과 대결
+   │
+[플레이오프] 최종 LCK 우승팀 결정
+   │
+[롤드컵] LCK 최종 순위에 따른 시드권
 ```
 
-필터 UI 는 4개: **리그 · 시즌 · 유형 · 포지션**. 포지션은 유형이 `player` 일 때만 보인다.
+### 1.1 실제 데이터로 검증한 결과
 
-### 1.2 팀 순위표 컬럼
+주신 구조가 실제 데이터와 정확히 일치하는지 대조했다.
 
-그룹(`LEGEND` / `RISE`)별로 테이블이 분리되어 렌더링된다.
-
-| # | 헤더 | 필드 | 정렬 | 원장에서 유도 가능? |
-|---|---|---|---|---|
-| 1 | 순위 | `rank` | – | ✅ 집계 (동점 규칙 필요) |
-| 2 | 팀 | `team` | – | ✅ 마스터 |
-| 3 | 승 | `wins` | ✅ | ✅ 매치 결과 |
-| 4 | 패 | `loses` | ✅ | ✅ 매치 결과 |
-| 5 | 득실차 | `score` | ✅ | ✅ 세트 결과 |
-| 6 | 승률 | `winRate` | ✅ | ✅ 매치 결과 |
-| 7 | KDA | `kda` | ✅ | ⚠️ 세트별 선수 기록 필요 |
-| 8 | 킬 | `kills` | ✅ | ⚠️ 〃 |
-| 9 | 데스 | `deaths` | ✅ | ⚠️ 〃 |
-| 10 | 어시스트 | `assists` | ✅ | ⚠️ 〃 |
-
-### 1.3 선수 순위표 컬럼
-
-| # | 헤더 | 필드 | 정렬 | 원장에서 유도 가능? |
-|---|---|---|---|---|
-| 1 | 순위 | `rank` | – | ✅ 집계 |
-| 2 | 선수 | `player` | – | ✅ 마스터 |
-| 3 | 소속 | `team` | – | ✅ 마스터 |
-| 4 | 포지션 | `position` | – | ✅ 세트별 선수 기록 |
-| 5 | 포인트 | `pogPoint` | ✅ | ⚠️ POG 선정 입력 필요 |
-| 6 | KDA | `kda` | ✅ | ⚠️ 세트별 선수 기록 |
-| 7 | 킬 | `kills` | ✅ | ⚠️ 〃 |
-| 8 | 데스 | `deaths` | ✅ | ⚠️ 〃 |
-| 9 | 어시스트 | `assists` | ✅ | ⚠️ 〃 |
-| 10 | 킬관여율 | `killInvolveRate` | ✅ | ⚠️ 〃 (선수 K+A ÷ 팀 킬) |
-| 11 | 출전세트수 | `competeSetCount` | ✅ | ⚠️ 〃 |
-
-### 1.4 데이터 성격 검증
-
-원본 API 응답을 받아 정합성을 확인했다. 이 수치들이 뒤의 테이블·집계 설계 근거다.
-
-| 검증 항목 | 결과 | 의미 |
+| 주신 설명 | 실제 데이터 | 확인 |
 |---|---|---|
-| 팀 `wins` 합계 | **110** | 10팀 × 22매치 ÷ 2 = 110. `wins`/`loses` 는 **매치(Bo3) 단위** |
-| 팀 `score` 합계 | **0** | 제로섬 → `score` 는 **세트 득실차**가 맞다 |
-| 동률 팀 순위 | T1·HLE·GEN 모두 16승 6패 | 순위는 득실차(21 > 19 > 18)로 갈림 → **동점 규칙이 순위 산정에 필수** |
-| 선수 `competeSetCount` 최대 | 44 | 22매치 전부 2세트로 끝난 팀 기준. 총 세트 수 ≈ **245** |
-| 선수 `pogPoint` 합계 | 9,000 | 100점 단위 → **90회 선정**. 총 매치 110건과 불일치 → 산정 규칙 확인 필요(§10-3) |
+| 1~2R 10팀 단일 풀리그 | `lck_split_2_2026` 의 `regular_season` 스테이지 — 10팀, 팀당 18매치 | ✅ |
+| 2R 성적으로 Legend/Rise 분리 | 1~2R 상위5 = HLE·T1·GEN·KT·DK / 하위5 = BRO·BFX·KRX·NS·DNS | ✅ |
+| 3~5R 그룹 내부 리그 | `lck_split_3_2026` 의 `groups` 스테이지 — **레전드 그룹 5팀 / 라이즈 그룹 5팀** | ✅ 편성 완전 일치 |
+| MSI 진출전 | `lck_split_2_2026` 의 `road_to_msi` (bracket) | ✅ |
+| 플레이인 / 플레이오프 | `lck_split_3_2026` 의 `play_ins`, `regional_championship` (bracket) | ✅ |
 
----
+### 1.2 ★ 결정적 발견 — 화면의 순위표는 **여러 스테이지의 누적 합산**이다
 
-## 2. 데이터 출처 — 실제 검증 결과
+네이버 화면이 `정규시즌 1-2R` 이라 표기한 순위표를 스테이지별로 분해해 보았다.
 
-세 경로를 모두 직접 호출해 확인했다. **셋 다 실재하고 응답한다.** 차이는 "무엇까지 주는가"다.
+| 팀 | 1~2R (단일 풀리그) | 3~5R (그룹) | 합계 | 네이버 화면 |
+|---|---|---|---|---|
+| T1 | 14승 4패 | 2승 2패 | **16승 6패** | 16승 6패 ✅ |
+| HLE | 15승 3패 | 1승 3패 | **16승 6패** | 16승 6패 ✅ |
+| GEN | 14승 4패 | 2승 2패 | **16승 6패** | 16승 6패 ✅ |
+| BRO | 6승 12패 | 2승 2패 | **8승 14패** | 8승 14패 ✅ |
+| BFX | 6승 12패 | 2승 2패 | **8승 14패** | 8승 14패 ✅ |
+| KRX | 5승 13패 | 2승 2패 | **7승 15패** | 7승 15패 ✅ |
 
-### 2.1 lolesports.com 내부 API — ⚠️ "공식"이 아니다
+10팀 중 6팀이 정확히 일치했고, 나머지 4팀(KT·DK·NS·DNS)은 **정확히 경기 2건만큼** 어긋났다 —
+`DK 1승 ↔ KT 1패`, `DNS 1승 ↔ NS 1패` 로 승패가 짝을 이룬다. **두 출처의 스냅샷 시점 차이**이지
+집계 규칙 차이가 아니다(공식 데이터가 최신).
 
-> **용어 정정.** 이 문서 v2 초판은 이 출처를 "라이엇 공식 API" 라고 불렀다. **부정확하다.**
-> `esports-api.lolesports.com` 은 라이엇이 소유·운영하는 lolesports.com 의 백엔드이고 데이터도 라이엇 1차 출처지만,
-> **Riot Developer Portal 에 문서화된 공개 API 가 아니다.** 개발자 포털 API 목록(`developer.riotgames.com/apis`)을
-> 확인한 결과 **프로 e스포츠 경기·순위 API 는 존재하지 않는다** — `tournament-v5` 는 서드파티가 자체 대회를 여는
-> 용도지 LCK 데이터가 아니다.
->
-> 인증에 쓰는 `x-api-key` 는 웹 클라이언트에 하드코딩되어 커뮤니티에 알려진 공개 키다.
-> 즉 **성격상 네이버 API 와 같은 범주(비문서화 내부 API)** 이며, 차이는 "라이엇 1차 데이터냐 3자 가공이냐" 뿐이다.
-> 레이트리밋·스키마 안정성·사용 허가 어느 것도 보장되지 않는다.
+> **설계 요구사항으로 번역하면:**
+> 1. 순위표는 단일 스테이지가 아니라 **"어떤 스테이지들을 합산할지"** 를 지정할 수 있어야 한다.
+> 2. 팀당 매치 수가 스테이지마다 다르다 (1~2R 18매치, 3~5R 12매치). **라운드 수를 코드에 박으면 안 된다.**
+> 3. 합산 순위표의 그룹 표시는 **3~5R 의 편성**을 따른다 (1~2R 에는 그룹이 없다).
 
-```
-GET https://esports-api.lolesports.com/persisted/gw/getLeagues?hl=ko-KR
-GET https://esports-api.lolesports.com/persisted/gw/getTournamentsForLeague?leagueId={id}
-GET https://esports-api.lolesports.com/persisted/gw/getStandingsV3?tournamentId={id}
-GET https://esports-api.lolesports.com/persisted/gw/getCompletedEvents?leagueId={id}
-    (헤더: x-api-key — 웹 클라이언트에 노출된 공개 키)
-```
+### 1.3 화면 컬럼
 
-2026 LCK 데이터가 실제로 들어 있고, **레전드/라이즈 그룹 구조까지 그대로** 나온다.
+**팀 순위표** — 그룹별로 테이블이 분리된다.
 
-```json
-{ "name": "레전드 그룹",
-  "rankings": [
-    { "ordinal": 1, "teams": [ { "code": "DK", "record": { "wins": 3, "ties": 0, "losses": 1 } } ] },
-    { "ordinal": 2, "teams": [ { "code": "GEN", ... }, { "code": "T1", ... }, { "code": "KT", ... } ] }
-  ] }
-```
+| 헤더 | 필드 | 정렬 | 원장에서 유도 |
+|---|---|---|---|
+| 순위 | `rank` | – | ✅ 집계 (동점 규칙 필요) |
+| 팀 | `team` | – | ✅ 마스터 |
+| 승 / 패 | `wins` / `loses` | ✅ | ✅ 매치 결과 |
+| 득실차 | `score` | ✅ | ✅ 세트 결과 |
+| 승률 | `winRate` | ✅ | ✅ 매치 결과 |
+| KDA · 킬 · 데스 · 어시스트 | `kda` `kills` `deaths` `assists` | ✅ | ⚠️ 세트별 선수 기록 필요 |
 
-**주는 것**: 리그·토너먼트·팀 마스터, 그룹 구조, 팀별 승/패, 매치 일정과 결과(`gameWins`), 세트 ID,
-그리고 `blockName` 에 **`"11주 차"` 형태의 주차 정보** — 순위 추이(§8.3)의 x축을 그대로 얻을 수 있다.
-**안 주는 것**: 득실차 · 승률 · 팀 KDA · 킬/데스/어시스트 · 선수 순위 전체 · POG 포인트.
-`ordinal` 이 공동 순위(2위에 3팀)로 내려와 화면의 1~5위 형태와도 다르다.
+**선수 순위표**
 
-> ⚠️ **임포트 함정 — `games` 배열은 미플레이 세트를 포함한다.**
-> 2026-08-09 `BFX 2 : 0 KRX` 매치를 확인해 보면 `gameWins` 는 2:0인데 `games` 배열 길이는 **3**이다.
-> Bo3 의 세트 슬롯이 전부 내려오고 3세트는 실제로 열리지 않았다(`vods: []`).
-> 그대로 적재하면 세트 수가 부풀고 **득실차가 전부 틀어진다.**
-> 안전한 기준은 VOD 유무가 아니라 **`home_score + away_score` 개만 앞에서부터 취하는 것**이다.
-> `esports_match` ↔ `esports_game` 정합성 뷰(§6.2)가 이 실수를 잡아낸다.
+| 헤더 | 필드 | 정렬 | 원장에서 유도 |
+|---|---|---|---|
+| 순위 · 선수 · 소속 · 포지션 | | – | ✅ 마스터 + 로스터 |
+| 포인트 | `pogPoint` | ✅ | ⚠️ POG 선정 입력 |
+| KDA · 킬 · 데스 · 어시스트 | | ✅ | ⚠️ 세트별 선수 기록 |
+| 킬관여율 | `killInvolveRate` | ✅ | ⚠️ (선수 K+A) ÷ 팀 킬 |
+| 출전세트수 | `competeSetCount` | ✅ | ⚠️ 세트별 선수 기록 |
 
-선수 스탯은 별도 피드에서 **세트 단위로** 얻어야 한다.
+### 1.4 데이터 정합성 검증
 
-```
-GET https://feed.lolesports.com/livestats/v1/window/{gameId}
-→ gameMetadata.blueTeamMetadata.participantMetadata[] : esportsPlayerId, summonerName, championId, role
-→ frames[].blueTeam.participants[] : kills, deaths, assists, creepScore, totalGold, level
-```
-
-응답은 확인했지만 **프레임 단위 시계열**이라, 세트 최종 스탯을 얻으려면 종료 시각대의 프레임을 찾아
-세트마다 호출·파싱해야 한다. 시즌당 약 245세트 × 10명 = **2,450행**을 만들어내는 별도 수집 파이프라인이 필요하다.
-그리고 **POG 포인트는 LCK 자체 제도라 어느 라이엇 API에도 없다.**
-
-### 2.2 네이버 e스포츠 API
-
-```
-GET https://esports-api.game.naver.com/service/v1/ranking/{seasonId}/{team|player}
-GET https://esports-api.game.naver.com/service/v1/meta/{topLeagueId}/leagues
-```
-
-화면에 필요한 **모든 컬럼을 이미 집계된 상태로** 준다(득실차·승률·KDA·킬관여율·출전세트수·POG 포인트).
-즉 네이버가 자체 집계한 파생 데이터다. 문서화된 공개 API가 아니고 약관·안정성 보장이 없어
-**상시 의존 대상으로 삼기 어렵다.**
-
-### 2.3 판단
-
-| 출처 | 문서화된 공개 API | 팀 승/패 | 득실차·승률 | 팀·선수 KDA | POG |
-|---|---|---|---|---|---|
-| Riot Developer Portal | ✅ | **e스포츠 API 자체가 없음** | – | – | – |
-| lolesports.com 내부 API | ❌ | ✅ | ❌ (원장에서 유도) | ❌ (livestats 별도) | ❌ |
-| livestats 피드 | ❌ | – | – | ⚠️ 세트별 수집·파싱 | ❌ |
-| 네이버 API | ❌ | ✅ | ✅ | ✅ | ✅ |
-
-### 2.4 직접 확인용 URL
-
-각 출처를 눈으로 검증할 수 있는 주소. **브라우저에 그대로 붙여넣어 열리는 것**과 헤더가 필요한 것이 갈린다.
-
-**브라우저에서 바로 열림** (인증 헤더 불필요, HTTP 200 확인)
-
-```
-# 네이버 — LCK 2026 팀 순위 (화면의 팀 탭 원본)
-https://esports-api.game.naver.com/service/v1/ranking/lck_2026/team
-
-# 네이버 — LCK 2026 선수 순위 (화면의 선수 탭 원본)
-https://esports-api.game.naver.com/service/v1/ranking/lck_2026/player
-
-# 네이버 — LCK 시즌 목록 (시즌 필터 원본)
-https://esports-api.game.naver.com/service/v1/meta/lck/leagues
-
-# 네이버 — 리그 목록 (리그 필터 원본)
-https://esports-api.game.naver.com/service/v1/meta/topLeagues
-
-# lolesports livestats — 세트별 선수 K/D/A (프레임 시계열)
-https://feed.lolesports.com/livestats/v1/window/116951349275512133
-```
-
-**헤더 필요** — 주소창에 붙여넣으면 `403 Forbidden` 이다. `x-api-key` 를 넣어야 한다.
-
-```bash
-K=0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z
-
-# 리그 목록 (LCK leagueId = 98767991310872058)
-curl -s -H "x-api-key: $K" \
-  "https://esports-api.lolesports.com/persisted/gw/getLeagues?hl=ko-KR" | jq .
-
-# LCK 토너먼트(시즌) 목록
-curl -s -H "x-api-key: $K" \
-  "https://esports-api.lolesports.com/persisted/gw/getTournamentsForLeague?hl=ko-KR&leagueId=98767991310872058" | jq .
-
-# 2026 스플릿3 순위 — 레전드/라이즈 그룹 구조가 보인다
-curl -s -H "x-api-key: $K" \
-  "https://esports-api.lolesports.com/persisted/gw/getStandingsV3?hl=ko-KR&tournamentId=115548147890329817" | jq .
-
-# 완료된 경기 — 팀코드·gameWins·주차(blockName), 그리고 §2.1 의 미플레이 세트 함정
-curl -s -H "x-api-key: $K" \
-  "https://esports-api.lolesports.com/persisted/gw/getCompletedEvents?hl=ko-KR&leagueId=98767991310872058" | jq .
-```
-
-헤더가 필요하다는 사실 자체가 **이것이 웹 클라이언트 전용 내부 API** 라는 방증이다.
-브라우저에서 보려면 <https://lolesports.com> 에 접속해 개발자도구 Network 탭을 여는 편이 정확하다.
-
-**참고** — 라이엇 공식 개발자 포털: <https://developer.riotgames.com/apis>
-(위 목록 어디에도 e스포츠 경기·순위 API 는 없다. 직접 확인 가능)
-
-**→ 지적하신 방향이 맞다.** 정리하면:
-
-1. **문서화된 공식 경로는 아예 없다.** 라이엇이 프로 e스포츠 데이터를 퍼블릭 API 로 제공하지 않는다.
-2. 실제로 쓸 수 있는 세 출처는 **전부 비문서화 내부 API** 다. 안정성·허가가 보장되는 곳이 하나도 없다.
-3. 화면을 그대로 채워주는 유일한 곳(네이버)은 3자 가공 데이터라 더더욱 의존할 수 없다.
-
-세 출처 모두 언제든 막힐 수 있다는 뜻이므로, **어디에도 상시 의존하지 않는 설계가 유일한 안전한 선택**이다.
-따라서 **경기 원장을 우리 DB에 두고 순위표를 집계로 만든다.** 외부 API 는 원장을 채우는
-*일회성·선택적 보조 입력*으로 격하하고, 전부 막혀도 관리자 입력만으로 시스템이 성립하게 한다.
-
----
-
-## 3. 설계 방향 — 원장 → 집계 → 이력
-
-```
-[입력]                        [집계]                          [조회]
-esports_match      ─┐
-esports_game       ─┼─→  esports_team_standing    ─┐
-esports_game_player ┤    esports_player_standing  ─┼─→  REST API + Redis
-esports_match_pog  ─┘         │                    │
-                              └→ esports_standing_snapshot (이력/추이)
-```
-
-- **원장(진실원천)**: 매치 · 세트 · 세트별 선수 기록 · POG 선정. 관리자가 DB 로 직접 입력한다.
-- **집계 산출물**: 순위표. 원장에서 재계산되며 **언제든 버리고 다시 만들 수 있다.**
-- **이력**: 집계할 때마다 날짜별 스냅샷 1벌. 주차별 순위 추이 그래프의 재료.
-
-이 구조의 이점:
-1. 외부 API 가 죽거나 막혀도 서비스가 성립한다.
-2. 순위 추이가 공짜로 나온다 (v1에서 뺐던 이력 테이블이 자연스럽게 복귀).
-3. 집계 로직 버그를 고치면 **전 시즌을 재집계**해 바로잡을 수 있다 (스냅샷 적재형은 불가능).
-4. 외부 출처가 정해지면 수집 어댑터가 원장에 INSERT 하는 것으로 끝난다 — 조회 계층은 그대로.
-
-### 3.1 입력량 — 단계를 나눠야 하는 이유
-
-시즌 1회분(LCK 정규시즌 기준) 관리자 입력량 추정:
-
-| 원장 | 행 수 | 수기 입력 |
+| 항목 | 결과 | 의미 |
 |---|---|---|
-| 매치 결과 (`2:1` 형태) | **110행** | ✅ 현실적 |
-| 세트 결과 (승팀·소요시간) | **약 245행** | ✅ 매치 입력 시 함께 |
-| POG 선정 | **약 90~110행** | ✅ 세트/매치당 1명 |
-| 세트별 선수 기록 (10명 × K/D/A/포지션) | **약 2,450행** | ❌ 비현실적 |
+| 팀 `wins` 합계 | **110** | `wins`/`loses` 는 **매치(Bo3) 단위** |
+| 팀 `score` 합계 | **0** | 제로섬 → `score` 는 **세트 득실차** |
+| 동률 처리 | T1·HLE·GEN 모두 16승 6패 | 득실차(21 > 19 > 18)로 갈림 → **동점 규칙 필수** |
+| 공동 순위 존재 | 3~5R 에서 GEN·T1 둘 다 2위 | 순위에 **동순위(gap)** 가 실제로 발생한다 |
+| `pogPoint` 합계 | 9,000 (=90회) | 100점 단위. 총 매치 수와 불일치 → 산정 규칙 확인 필요(§11-3) |
 
-→ **1단계는 매치·세트 원장만으로 팀 순위표를 완성**한다(순위·승·패·득실차·승률).
-KDA/킬/데스/어시스트가 필요한 컬럼과 선수 순위표는 2단계로 미루고,
-선수 기록은 수기 대신 **일괄 적재(CSV/livestats 수집) + 관리자 보정**으로 채운다.
+---
+
+## 2. 데이터 입력 — 수기 확정
+
+**외부 API 수집 경로는 설계에서 제거한다.** 관리자가 DB 에 직접 입력한다.
+따라서 이 설계의 성패는 **입력이 감당 가능한가 + 오입력을 잡아내는가** 에 달려 있다.
+
+### 2.1 입력량 산정
+
+| 원장 | 산정 근거 | 행 수 | 수기 |
+|---|---|---|---|
+| 매치 (1~2R) | 10팀 × 18매치 ÷ 2 | **90행** | ✅ |
+| 매치 (3~5R) | 5팀 × 12매치 ÷ 2 × 2그룹 | **60행** | ✅ |
+| 매치 (MSI 진출전·플레이인·플레이오프) | 토너먼트 | **약 15행** | ✅ |
+| 세트 결과 | 매치 약 165건 × 평균 2.4세트 | **약 400행** | ✅ 매치와 함께 |
+| POG 선정 | 세트 또는 매치당 1명 | **약 165행** | ✅ |
+| **세트별 선수 기록** | 400세트 × 10명 | **약 4,000행** | ❌ **비현실적** |
+
+**→ 매치·세트·POG 는 수기로 충분하다. 선수별 K/D/A 4,000행은 수기로 불가능하다.**
+
+이건 의지의 문제가 아니라 산술의 문제다. 그래서 단계를 나눈다.
+
+| 단계 | 입력 | 완성되는 화면 |
+|---|---|---|
+| **1단계** | 매치 + 세트 (약 165회 입력) | **팀 순위표** — 순위·승·패·득실차·승률 |
+| **2단계** | POG (약 165행) | 선수 순위표의 **포인트** 컬럼 |
+| **3단계** | 세트별 선수 기록 (약 4,000행) | KDA·킬·데스·어시스트·킬관여율·출전세트수 |
+
+1단계만으로 **팀 탭은 네이버 화면과 동일하게 완성**된다. 3단계는 §11-4 의 결정이 필요하다.
+
+### 2.2 참고 — 외부 출처 (설계에서 제외, 기록 목적)
+
+수기 입력이 확정이므로 아래는 **채택하지 않는다.** 나중에 방침이 바뀔 때를 위한 조사 기록이다.
+
+- **라이엇 공식 개발자 포털에는 프로 e스포츠 API 가 아예 없다** (`developer.riotgames.com/apis` 확인).
+  `tournament-v5` 는 서드파티 자체 대회용이지 LCK 데이터가 아니다.
+- `esports-api.lolesports.com` — 라이엇 운영이지만 **문서화되지 않은 웹 클라이언트 내부 API**.
+  `x-api-key` 는 클라이언트 하드코딩 공개 키. §1.1 의 스테이지 구조 검증에 사용했다.
+- `esports-api.game.naver.com` — 화면의 모든 컬럼을 집계된 상태로 주지만 3자 가공 데이터.
+- 어느 쪽도 문서화·허가·안정성이 보장되지 않는다. **수기 입력 결정이 이 리스크를 전부 제거한다.**
+
+검증에 쓴 주소는 부록 §12 에 남겨 둔다.
+
+---
+
+## 3. 설계 방향
+
+```
+[입력: 관리자 SQL]            [집계]                        [조회]
+esports_stage        ─┐
+esports_match        ─┼─→  esports_team_standing    ─┐
+esports_game         ─┤    esports_player_standing  ─┼─→  REST API + Redis
+esports_game_player  ─┤          │                   │
+esports_pog          ─┘          └→ esports_standing_snapshot (순위 추이)
+                                 └→ esports_stage_group      (그룹 편성 확정)
+```
+
+- **원장(진실원천)**: 스테이지 · 매치 · 세트 · 선수기록 · POG. 관리자 입력.
+- **집계 산출물**: 순위표, 그룹 편성. **언제든 버리고 다시 만들 수 있다.**
+- **이력**: 집계 시점마다 순위 스냅샷 1벌.
+
+집계 로직 버그를 고치면 전 시즌 재집계로 바로잡을 수 있다는 점이 스냅샷 적재형과의 결정적 차이다.
 
 ---
 
@@ -256,34 +178,37 @@ KDA/킬/데스/어시스트가 필요한 컬럼과 선수 순위표는 2단계�
 module/domain/esports/src/main/java/com/example/lolserver/esports/
 ├── domain/
 │   ├── EsportsLeague · EsportsSeason · EsportsTeam · EsportsPlayer
-│   ├── Match.java              # 매치 원장 (validate* guard: 세트 합 = 매치 결과 정합)
-│   ├── Game.java               # 세트
-│   ├── GamePlayerStat.java     # 세트별 선수 기록
-│   ├── TeamStanding · PlayerStanding      # 집계 산출물
-│   ├── StandingCalculator.java # ★ 집계 규칙 (순수 도메인, 외부 의존 없음)
-│   ├── TieBreakRule.java       # 동점 규칙 (득실차 → 상대전적 → …)
+│   ├── Stage.java              # 스테이지 (포맷·그룹여부·집계단위)
+│   ├── StageFormat.java        # ROUND_ROBIN | BRACKET
+│   ├── Match.java              # validateGameConsistency() guard
+│   ├── Game.java · GamePlayerStat.java
+│   ├── TeamStanding · PlayerStanding
+│   ├── StandingCalculator.java # ★ 누적 집계 규칙 (순수 도메인)
+│   ├── GroupSplitter.java      # ★ 상위N/하위N 그룹 분리 규칙
+│   ├── TieBreakRule.java       # 동점 규칙 (교체 가능)
 │   ├── EsportsPosition.java    # TOP/JGL/MID/AD/SPT
-│   └── Bracket.java            # SPLIT / REGULAR / PLAYOFF
+│   └── StandingGroup.java      # LEGEND / RISE / (없음)
 ├── application/
 │   ├── port/in/   EsportsMetaQueryUseCase · TeamStandingQueryUseCase
 │   │              PlayerStandingQueryUseCase · StandingHistoryQueryUseCase
-│   │              StandingAggregateUseCase        # 집계 트리거
-│   ├── port/out/  MatchPersistencePort · StandingPersistencePort
-│   │              StandingSnapshotPersistencePort · EsportsRecordCachePort
-│   │              EsportsFeedClientPort           # 선택적 외부 수집
+│   │              StandingAggregateUseCase · GroupSplitUseCase
+│   ├── port/out/  StagePersistencePort · MatchPersistencePort
+│   │              StandingPersistencePort · StandingSnapshotPersistencePort
+│   │              EsportsRecordCachePort
 │   ├── model/query · model/readmodel
 │   └── EsportsMetaService · TeamStandingService · PlayerStandingService
-│       StandingAggregateService · StandingHistoryService
+│       StandingAggregateService · GroupSplitService · StandingHistoryService
 └── adapter/
     ├── in/web/       EsportsMetaController · TeamStandingController
     │                 PlayerStandingController · StandingHistoryController
-    └── out/persistence · out/cache · out/client (2단계)
+    │                 EsportsAdminController        # 집계·그룹확정 트리거
+    └── out/persistence · out/cache
 ```
 
-**집계 규칙은 `StandingCalculator` 도메인 객체에 둔다.** 승/패/득실차/승률/순위 산정은
-리그 규정이지 SQL 이 아니다. 순수 자바로 두면 단위 테스트로 동점 시나리오를 전부 검증할 수 있다.
+**외부 client 어댑터가 없다.** 수기 입력 확정의 직접적 결과이며, 모듈이 그만큼 단순해진다.
 
-`settings.gradle` 에 `"module:domain:esports"` 추가, 컴포지션 루트에 모듈 의존과 집계 스케줄러 배치.
+`StandingCalculator` · `GroupSplitter` · `TieBreakRule` 은 **순수 자바**로 둔다.
+승/패/득실차/순위/그룹분리는 리그 규정이지 SQL 이 아니고, 규정은 시즌마다 바뀐다.
 
 ---
 
@@ -295,15 +220,14 @@ module/domain/esports/src/main/java/com/example/lolserver/esports/
 > `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
 > 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
 
-> ✅ 아래 DDL 전체(테이블 13 · 인덱스 6 · 뷰 1)는 로컬 `postgres:16-alpine` 에서
-> `BEGIN … ROLLBACK` 트랜잭션으로 실제 실행해 문법·제약·의존 순서를 검증했다.
+> ✅ 아래 DDL 전체(**테이블 15 · 인덱스 7 · 뷰 3**)는 로컬 `postgres:16-alpine` 에서
+> `BEGIN … ROLLBACK` 으로 실제 실행해 문법·제약·의존 순서를 검증했다 (§7.4 에 결과).
 
 ### 5.1 마스터
 
 ```sql
--- 상위 리그 (LCK, LPL …)
 CREATE TABLE IF NOT EXISTS esports_league (
-    league_id      VARCHAR(50)  NOT NULL,      -- 'lck'
+    league_id      VARCHAR(50)  NOT NULL,          -- 'lck'
     game_code      VARCHAR(20)  NOT NULL DEFAULT 'lol',
     name           VARCHAR(200) NOT NULL,
     name_acronym   VARCHAR(50),
@@ -316,16 +240,14 @@ CREATE TABLE IF NOT EXISTS esports_league (
     CONSTRAINT pk_esports_league PRIMARY KEY (league_id)
 );
 
--- 시즌 (= 하위 리그. 'lck_2026')
 CREATE TABLE IF NOT EXISTS esports_season (
-    season_id      VARCHAR(80)  NOT NULL,
+    season_id      VARCHAR(80)  NOT NULL,          -- 'lck_2026'
     league_id      VARCHAR(50)  NOT NULL,
     name           VARCHAR(200) NOT NULL,
     name_acronym   VARCHAR(80),
     year           INTEGER,
     start_date     DATE,
     end_date       DATE,
-    match_format   VARCHAR(20)  NOT NULL DEFAULT 'BO3',  -- 집계 검증용
     sort_order     INTEGER      NOT NULL DEFAULT 0,
     created_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -334,10 +256,9 @@ CREATE TABLE IF NOT EXISTS esports_season (
         REFERENCES esports_league (league_id)
 );
 
--- 팀 마스터. team_code 는 관리자가 손으로 입력할 때 쓰는 사람이 읽는 키
 CREATE TABLE IF NOT EXISTS esports_team (
-    team_id          VARCHAR(30)  NOT NULL,     -- 내부 ID
-    team_code        VARCHAR(20)  NOT NULL,     -- 'T1', 'GEN' ← 입력 편의 키
+    team_id          VARCHAR(30)  NOT NULL,
+    team_code        VARCHAR(20)  NOT NULL,        -- 'T1' ← 수기 입력용 키
     game_code        VARCHAR(20)  NOT NULL DEFAULT 'lol',
     name             VARCHAR(100) NOT NULL,
     name_eng         VARCHAR(100),
@@ -349,10 +270,9 @@ CREATE TABLE IF NOT EXISTS esports_team (
     CONSTRAINT uk_esports_team_code UNIQUE (game_code, team_code)
 );
 
--- 선수 마스터
 CREATE TABLE IF NOT EXISTS esports_player (
     player_id   VARCHAR(30)  NOT NULL,
-    nick_name   VARCHAR(100) NOT NULL,          -- 'Duro' ← 입력 편의 키
+    nick_name   VARCHAR(100) NOT NULL,             -- 'Duro' ← 수기 입력용 키
     name        VARCHAR(100),
     name_eng    VARCHAR(100),
     image_url   VARCHAR(500),
@@ -362,12 +282,11 @@ CREATE TABLE IF NOT EXISTS esports_player (
     CONSTRAINT uk_esports_player_nick UNIQUE (nick_name)
 );
 
--- 시즌 로스터 (선수 소속은 시즌마다 바뀐다)
 CREATE TABLE IF NOT EXISTS esports_roster (
     season_id  VARCHAR(80) NOT NULL,
     player_id  VARCHAR(30) NOT NULL,
     team_id    VARCHAR(30) NOT NULL,
-    position   VARCHAR(10) NOT NULL,            -- TOP|JGL|MID|AD|SPT
+    position   VARCHAR(10) NOT NULL,               -- TOP|JGL|MID|AD|SPT
     joined_at  DATE,
     left_at    DATE,
     CONSTRAINT pk_esports_roster PRIMARY KEY (season_id, player_id, team_id),
@@ -375,60 +294,101 @@ CREATE TABLE IF NOT EXISTS esports_roster (
     CONSTRAINT fk_roster_player FOREIGN KEY (player_id) REFERENCES esports_player (player_id),
     CONSTRAINT fk_roster_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
 );
+```
 
--- 시즌 그룹 편성 (LEGEND / RISE). 그룹 없는 리그는 행을 넣지 않는다
-CREATE TABLE IF NOT EXISTS esports_season_group (
-    season_id   VARCHAR(80) NOT NULL,
-    bracket     VARCHAR(30) NOT NULL,
-    team_id     VARCHAR(30) NOT NULL,
-    group_name  VARCHAR(50) NOT NULL,           -- 'LEGEND' | 'RISE'
-    group_sort  INTEGER     NOT NULL DEFAULT 0,
-    CONSTRAINT pk_esports_season_group PRIMARY KEY (season_id, bracket, team_id),
-    CONSTRAINT fk_sg_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
-    CONSTRAINT fk_sg_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+### 5.2 ★ 스테이지 — LCK 구조를 담는 핵심 테이블
+
+```sql
+-- 시즌을 구성하는 단계. §1 의 구조를 그대로 데이터로 표현한다.
+CREATE TABLE IF NOT EXISTS esports_stage (
+    stage_id        BIGSERIAL    NOT NULL,
+    season_id       VARCHAR(80)  NOT NULL,
+    stage_key       VARCHAR(40)  NOT NULL,   -- 'REGULAR_R1_R2','MSI_QUALIFIER',
+                                             -- 'REGULAR_R3_R5','PLAY_IN','PLAYOFF'
+    name            VARCHAR(100) NOT NULL,   -- '정규시즌 1-2R'
+    format          VARCHAR(20)  NOT NULL,   -- 'ROUND_ROBIN' | 'BRACKET'
+    grouped         BOOLEAN      NOT NULL DEFAULT FALSE,  -- 그룹별 진행 여부
+    -- ★ 같은 값을 가진 스테이지들이 하나의 순위표로 누적 집계된다 (§1.2).
+    --   NULL 이면 순위표를 만들지 않는다 (토너먼트 스테이지).
+    standing_key    VARCHAR(40),
+    -- 그룹 편성의 근거가 되는 이전 스테이지 (1~2R 성적으로 Legend/Rise 를 가른다)
+    group_source_stage_id BIGINT,
+    group_size      SMALLINT,                -- 상위 N팀 / 하위 N팀 (LCK = 5)
+    start_date      DATE,
+    end_date        DATE,
+    sort_order      INTEGER      NOT NULL DEFAULT 0,
+    created_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_stage PRIMARY KEY (stage_id),
+    CONSTRAINT uk_esports_stage UNIQUE (season_id, stage_key),
+    CONSTRAINT ck_esports_stage_format CHECK (format IN ('ROUND_ROBIN', 'BRACKET')),
+    CONSTRAINT fk_stage_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_stage_group_source FOREIGN KEY (group_source_stage_id)
+        REFERENCES esports_stage (stage_id)
+);
+CREATE INDEX IF NOT EXISTS idx_stage_season ON esports_stage (season_id, sort_order);
+CREATE INDEX IF NOT EXISTS idx_stage_standing ON esports_stage (season_id, standing_key);
+
+-- 그룹 편성 결과. 관리자가 직접 넣지 않고 group_source_stage 집계에서 산출·확정한다.
+CREATE TABLE IF NOT EXISTS esports_stage_group (
+    stage_id     BIGINT      NOT NULL,
+    team_id      VARCHAR(30) NOT NULL,
+    group_name   VARCHAR(50) NOT NULL,       -- 'LEGEND' | 'RISE'
+    group_sort   SMALLINT    NOT NULL DEFAULT 0,
+    seed_rank    SMALLINT,                   -- 근거 스테이지에서의 순위
+    confirmed_at TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_stage_group PRIMARY KEY (stage_id, team_id),
+    CONSTRAINT fk_sg_stage FOREIGN KEY (stage_id) REFERENCES esports_stage (stage_id) ON DELETE CASCADE,
+    CONSTRAINT fk_sg_team  FOREIGN KEY (team_id)  REFERENCES esports_team (team_id)
 );
 ```
 
-### 5.2 원장 (관리자 입력)
+`lck_2026` 시드 예시:
+
+| stage_key | name | format | grouped | standing_key | group_source | sort |
+|---|---|---|---|---|---|---|
+| `REGULAR_R1_R2` | 정규시즌 1-2R | ROUND_ROBIN | false | `REGULAR` | – | 1 |
+| `MSI_QUALIFIER` | MSI 진출전 | BRACKET | false | *(NULL)* | – | 2 |
+| `REGULAR_R3_R5` | 정규시즌 3-5R | ROUND_ROBIN | **true** | `REGULAR` | `REGULAR_R1_R2` | 3 |
+| `PLAY_IN` | 플레이인 | BRACKET | false | *(NULL)* | – | 4 |
+| `PLAYOFF` | 플레이오프 | BRACKET | false | *(NULL)* | – | 5 |
+
+**`REGULAR_R1_R2` 와 `REGULAR_R3_R5` 가 같은 `standing_key='REGULAR'`** 이므로
+두 스테이지가 하나의 순위표로 누적 집계된다 — §1.2 에서 검증한 네이버 화면의 동작이다.
+1~2R 만 따로 보고 싶으면 `standing_key` 를 분리하면 되고, **코드는 건드리지 않는다.**
+
+### 5.3 원장 (관리자 입력)
 
 ```sql
--- 매치 (Bo3 한 판). 관리자가 넣는 최소 단위
 CREATE TABLE IF NOT EXISTS esports_match (
     match_id      BIGSERIAL    NOT NULL,
-    season_id     VARCHAR(80)  NOT NULL,
-    bracket       VARCHAR(30)  NOT NULL DEFAULT 'REGULAR',
-    round_no      INTEGER,                       -- 1~2R
-    week_no       INTEGER,                       -- 순위 추이의 x축
+    stage_id      BIGINT       NOT NULL,
+    round_no      SMALLINT,                       -- 1~5R
+    week_no       SMALLINT,                       -- 순위 추이 x축
     match_date    DATE         NOT NULL,
     home_team_id  VARCHAR(30)  NOT NULL,
     away_team_id  VARCHAR(30)  NOT NULL,
-    home_score    SMALLINT     NOT NULL,         -- 세트 승수 (2)
-    away_score    SMALLINT     NOT NULL,         -- 세트 승수 (1)
-    status        VARCHAR(20)  NOT NULL DEFAULT 'COMPLETED',  -- SCHEDULED|COMPLETED|CANCELED
-    external_ref  VARCHAR(60),                   -- 외부 출처 match id (중복 적재 방지)
+    home_score    SMALLINT     NOT NULL,          -- 세트 승수
+    away_score    SMALLINT     NOT NULL,
+    status        VARCHAR(20)  NOT NULL DEFAULT 'COMPLETED',
     created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_match PRIMARY KEY (match_id),
-    CONSTRAINT uk_esports_match UNIQUE (season_id, bracket, match_date, home_team_id, away_team_id),
-    CONSTRAINT ck_esports_match_teams CHECK (home_team_id <> away_team_id),
-    CONSTRAINT ck_esports_match_score CHECK (home_score >= 0 AND away_score >= 0),
-    CONSTRAINT fk_match_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
-    CONSTRAINT fk_match_home   FOREIGN KEY (home_team_id) REFERENCES esports_team (team_id),
-    CONSTRAINT fk_match_away   FOREIGN KEY (away_team_id) REFERENCES esports_team (team_id)
+    CONSTRAINT uk_esports_match UNIQUE (stage_id, match_date, home_team_id, away_team_id),
+    CONSTRAINT ck_match_teams  CHECK (home_team_id <> away_team_id),
+    CONSTRAINT ck_match_score  CHECK (home_score >= 0 AND away_score >= 0),
+    CONSTRAINT ck_match_status CHECK (status IN ('SCHEDULED', 'COMPLETED', 'CANCELED')),
+    CONSTRAINT fk_match_stage FOREIGN KEY (stage_id) REFERENCES esports_stage (stage_id),
+    CONSTRAINT fk_match_home  FOREIGN KEY (home_team_id) REFERENCES esports_team (team_id),
+    CONSTRAINT fk_match_away  FOREIGN KEY (away_team_id) REFERENCES esports_team (team_id)
 );
-CREATE UNIQUE INDEX IF NOT EXISTS uk_esports_match_ext
-    ON esports_match (external_ref) WHERE external_ref IS NOT NULL;
-CREATE INDEX IF NOT EXISTS idx_esports_match_season
-    ON esports_match (season_id, bracket, status, week_no);
+CREATE INDEX IF NOT EXISTS idx_match_stage ON esports_match (stage_id, status, week_no);
 
--- 세트 (매치 안의 한 게임)
 CREATE TABLE IF NOT EXISTS esports_game (
     game_id         BIGSERIAL   NOT NULL,
     match_id        BIGINT      NOT NULL,
-    game_no         SMALLINT    NOT NULL,        -- 1,2,3
+    game_no         SMALLINT    NOT NULL,
     winner_team_id  VARCHAR(30) NOT NULL,
-    duration_sec    INTEGER,                     -- 경기 시간
-    external_ref    VARCHAR(60),                 -- livestats gameId
+    duration_sec    INTEGER,
     created_at      TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_game PRIMARY KEY (game_id),
     CONSTRAINT uk_esports_game UNIQUE (match_id, game_no),
@@ -436,7 +396,7 @@ CREATE TABLE IF NOT EXISTS esports_game (
     CONSTRAINT fk_game_winner FOREIGN KEY (winner_team_id) REFERENCES esports_team (team_id)
 );
 
--- 세트별 선수 기록 (2단계 — 일괄 적재 대상)
+-- 3단계. 약 4,000행이라 수기 입력 대상이 아니다 (§2.1, §11-4)
 CREATE TABLE IF NOT EXISTS esports_game_player (
     game_id    BIGINT      NOT NULL,
     player_id  VARCHAR(30) NOT NULL,
@@ -453,7 +413,6 @@ CREATE TABLE IF NOT EXISTS esports_game_player (
 );
 CREATE INDEX IF NOT EXISTS idx_gp_player ON esports_game_player (player_id);
 
--- POG 선정 (LCK 자체 제도. 어떤 외부 API 에도 없어 입력이 유일한 경로)
 CREATE TABLE IF NOT EXISTS esports_pog (
     match_id   BIGINT      NOT NULL,
     game_no    SMALLINT    NOT NULL,
@@ -465,45 +424,46 @@ CREATE TABLE IF NOT EXISTS esports_pog (
 );
 ```
 
-### 5.3 집계 산출물
+### 5.4 집계 산출물
 
-원장에서 재계산되는 캐시성 테이블. **언제든 `DELETE` 후 재생성해도 무손실**이다.
+**`standing_key` 단위**로 만들어진다 (스테이지 단위가 아니다 — §1.2).
 
 ```sql
 CREATE TABLE IF NOT EXISTS esports_team_standing (
-    season_id         VARCHAR(80)  NOT NULL,
-    bracket           VARCHAR(30)  NOT NULL,
-    team_id           VARCHAR(30)  NOT NULL,
-    group_name        VARCHAR(50),
-    group_sort        INTEGER      NOT NULL DEFAULT 0,
-    team_rank         INTEGER      NOT NULL,
-    wins              INTEGER      NOT NULL DEFAULT 0,   -- 매치 승
-    loses             INTEGER      NOT NULL DEFAULT 0,
-    draws             INTEGER      NOT NULL DEFAULT 0,
-    set_wins          INTEGER      NOT NULL DEFAULT 0,   -- 세트 승
-    set_loses         INTEGER      NOT NULL DEFAULT 0,
-    score             INTEGER      NOT NULL DEFAULT 0,   -- set_wins - set_loses
-    win_rate          NUMERIC(5,4) NOT NULL DEFAULT 0,
-    kda               NUMERIC(6,2),                      -- 2단계 전까지 NULL
-    kills             INTEGER,
-    deaths            INTEGER,
-    assists           INTEGER,
-    aggregated_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT pk_esports_team_standing PRIMARY KEY (season_id, bracket, team_id),
+    season_id      VARCHAR(80)  NOT NULL,
+    standing_key   VARCHAR(40)  NOT NULL,      -- 'REGULAR'
+    team_id        VARCHAR(30)  NOT NULL,
+    group_name     VARCHAR(50),                -- 최종 스테이지의 그룹 편성
+    group_sort     SMALLINT     NOT NULL DEFAULT 0,
+    team_rank      INTEGER      NOT NULL,      -- 그룹 내 순위
+    overall_rank   INTEGER,                    -- 그룹 무시 전체 순위
+    wins           INTEGER      NOT NULL DEFAULT 0,
+    loses          INTEGER      NOT NULL DEFAULT 0,
+    draws          INTEGER      NOT NULL DEFAULT 0,
+    set_wins       INTEGER      NOT NULL DEFAULT 0,
+    set_loses      INTEGER      NOT NULL DEFAULT 0,
+    score          INTEGER      NOT NULL DEFAULT 0,
+    win_rate       NUMERIC(5,4) NOT NULL DEFAULT 0,
+    kda            NUMERIC(6,2),               -- 3단계 전까지 NULL
+    kills          INTEGER,
+    deaths         INTEGER,
+    assists        INTEGER,
+    aggregated_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_team_standing PRIMARY KEY (season_id, standing_key, team_id),
     CONSTRAINT fk_ets_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
     CONSTRAINT fk_ets_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
 );
-CREATE INDEX IF NOT EXISTS idx_ets_season_group_rank
-    ON esports_team_standing (season_id, bracket, group_sort, team_rank);
+CREATE INDEX IF NOT EXISTS idx_ets_group_rank
+    ON esports_team_standing (season_id, standing_key, group_sort, team_rank);
 
 CREATE TABLE IF NOT EXISTS esports_player_standing (
     season_id          VARCHAR(80)  NOT NULL,
-    bracket            VARCHAR(30)  NOT NULL,
+    standing_key       VARCHAR(40)  NOT NULL,
     player_id          VARCHAR(30)  NOT NULL,
     team_id            VARCHAR(30)  NOT NULL,
     position           VARCHAR(10)  NOT NULL,
     player_rank        INTEGER      NOT NULL,
-    wins               INTEGER      NOT NULL DEFAULT 0,  -- 출전 매치 기준
+    wins               INTEGER      NOT NULL DEFAULT 0,
     loses              INTEGER      NOT NULL DEFAULT 0,
     score              INTEGER      NOT NULL DEFAULT 0,
     win_rate           NUMERIC(5,4) NOT NULL DEFAULT 0,
@@ -514,27 +474,27 @@ CREATE TABLE IF NOT EXISTS esports_player_standing (
     assists            INTEGER      NOT NULL DEFAULT 0,
     kill_involve_rate  NUMERIC(5,4) NOT NULL DEFAULT 0,
     compete_set_count  INTEGER      NOT NULL DEFAULT 0,
-    compete_times      INTEGER      NOT NULL DEFAULT 0,  -- 총 출전 시간(초)
+    compete_times      INTEGER      NOT NULL DEFAULT 0,   -- 초
     aggregated_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT pk_esports_player_standing PRIMARY KEY (season_id, bracket, player_id),
+    CONSTRAINT pk_esports_player_standing PRIMARY KEY (season_id, standing_key, player_id),
     CONSTRAINT fk_eps_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
     CONSTRAINT fk_eps_player FOREIGN KEY (player_id) REFERENCES esports_player (player_id),
     CONSTRAINT fk_eps_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
 );
-CREATE INDEX IF NOT EXISTS idx_eps_season_position_rank
-    ON esports_player_standing (season_id, bracket, position, player_rank);
+CREATE INDEX IF NOT EXISTS idx_eps_position_rank
+    ON esports_player_standing (season_id, standing_key, position, player_rank);
 ```
 
-### 5.4 이력 (순위 추이)
+### 5.5 이력 · 시즌 최종 결과
 
 ```sql
--- 집계 시점마다 팀 순위 1벌을 남긴다. 주차별 추이 그래프의 재료
 CREATE TABLE IF NOT EXISTS esports_standing_snapshot (
     season_id     VARCHAR(80)  NOT NULL,
-    bracket       VARCHAR(30)  NOT NULL,
+    standing_key  VARCHAR(40)  NOT NULL,
     snapshot_date DATE         NOT NULL,
-    week_no       INTEGER,
+    week_no       SMALLINT,
     team_id       VARCHAR(30)  NOT NULL,
+    group_name    VARCHAR(50),
     team_rank     INTEGER      NOT NULL,
     wins          INTEGER      NOT NULL,
     loses         INTEGER      NOT NULL,
@@ -542,47 +502,141 @@ CREATE TABLE IF NOT EXISTS esports_standing_snapshot (
     win_rate      NUMERIC(5,4) NOT NULL,
     created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_standing_snapshot
-        PRIMARY KEY (season_id, bracket, snapshot_date, team_id),
+        PRIMARY KEY (season_id, standing_key, snapshot_date, team_id),
     CONSTRAINT fk_ess_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
     CONSTRAINT fk_ess_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
 );
-CREATE INDEX IF NOT EXISTS idx_ess_team_timeline
-    ON esports_standing_snapshot (season_id, bracket, team_id, snapshot_date);
+CREATE INDEX IF NOT EXISTS idx_ess_timeline
+    ON esports_standing_snapshot (season_id, standing_key, team_id, snapshot_date);
+
+-- 플레이오프까지 끝난 뒤의 최종 순위 + 롤드컵 시드.
+-- 토너먼트는 순위표로 집계되지 않으므로 관리자가 직접 확정한다.
+CREATE TABLE IF NOT EXISTS esports_season_result (
+    season_id    VARCHAR(80) NOT NULL,
+    team_id      VARCHAR(30) NOT NULL,
+    final_rank   SMALLINT    NOT NULL,      -- 1=우승
+    worlds_seed  SMALLINT,                  -- 1~4시드, NULL=미진출
+    note         VARCHAR(200),
+    created_at   TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_season_result PRIMARY KEY (season_id, team_id),
+    CONSTRAINT fk_esr_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_esr_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+);
 ```
 
-`snapshot_date` 를 PK 에 넣어 **하루 여러 번 집계해도 그날 행은 덮어써진다**(`ON CONFLICT DO UPDATE`).
-시즌당 10팀 × 약 70일 = 700행이라 부담이 없다.
-
-### 5.5 설계 근거
+### 5.6 설계 근거
 
 | 결정 | 근거 |
 |---|---|
-| 순위표를 뷰가 아닌 테이블로 | 순위 산정에 동점 규칙(득실차 → 상대전적)이 얽혀 SQL 한 방으로 안 나온다. 도메인 계산 결과를 적재하는 편이 테스트·디버깅에 낫다 |
-| `set_wins`/`set_loses` 를 별도 보관 | `score` 만 두면 "20승 10패"와 "10승 0패"가 구분되지 않는다. 동점 규칙에서 세트 승률이 필요할 수 있다 |
-| `esports_roster` 분리 | 선수 소속은 시즌·이적으로 바뀐다. 순위표에 team_id 를 박아두면 과거 시즌 조회 시 소속이 틀어진다 |
-| `team_code` / `nick_name` UNIQUE | 관리자 페이지가 없어 사람이 SQL 로 입력한다. `'T1'`, `'Duro'` 로 참조할 수 있어야 입력이 견딘다 |
-| `external_ref` + 부분 UNIQUE | 나중에 외부 수집을 붙일 때 중복 INSERT 를 DB 가 막는다. 수기 입력 행은 NULL 이라 제약에 안 걸린다 |
-| `rank` → `team_rank`/`player_rank` | PostgreSQL 에서 `rank` 자체는 컬럼명으로 쓸 수 있지만 윈도우 함수 `rank()` 와 겹쳐 가독성이 나쁘고 MySQL 8+ 에서는 예약어다 |
-| `compete_times` 초 단위 | 원본은 분으로 보이나 `duration_sec` 합에서 유도하므로 초로 통일하고 표시할 때 환산 |
+| `esports_stage` 도입 | LCK 는 시즌 안에 성격이 다른 5개 단계가 있고 팀당 매치 수도 다르다(18 vs 12). 스테이지 없이는 표현 불가 |
+| `standing_key` 로 누적 단위 지정 | §1.2 검증 — 화면 순위표가 1~2R + 3~5R 합산이다. 포맷이 바뀌어도 **시드 데이터만 고치면 된다** |
+| `format` (ROUND_ROBIN/BRACKET) | MSI 진출전·플레이인·플레이오프는 순위표가 없다. 집계 대상에서 자동 제외 |
+| `esports_stage_group` 을 집계 산출물로 | 그룹은 관리자가 정하는 게 아니라 **1~2R 결과가 정한다**. 입력값으로 두면 원장과 어긋날 수 있다 |
+| `group_source_stage_id` + `group_size` | "어느 스테이지 상위 몇 팀" 을 데이터로. LCK 는 5팀이지만 리그마다 다르다 |
+| `overall_rank` 병기 | 그룹 순위(1~5)와 별개로 전체 순위(1~10)가 필요할 때가 있다 (MSI 진출전 시드) |
+| `set_wins`/`set_loses` 별도 보관 | `score` 만으로는 "20승10패"와 "10승0패"를 구분 못 한다. 동점 규칙에 세트 승률이 쓰일 수 있다 |
+| `esports_season_result` 분리 | 플레이오프 결과는 집계 불가. 최종 순위·롤드컵 시드는 관리자 확정값 |
+| `team_code` / `nick_name` UNIQUE | 수기 입력이 확정이므로 사람이 읽는 키가 필수다 |
+| `rank` → `team_rank` | PostgreSQL 에선 쓸 수 있으나 윈도우 함수 `rank()` 와 겹쳐 가독성이 나쁘고 MySQL 8+ 는 예약어 |
 
 ---
 
-## 6. 관리자 입력 절차 (관리자 페이지 없이)
+## 6. 집계 로직
 
-입력은 SQL 로 한다. **사람이 읽는 키로 참조**할 수 있게 헬퍼 뷰를 함께 만든다.
+### 6.1 순위표 집계
 
-### 6.1 매치 1건 입력 (1단계 — 이것만으로 팀 순위표가 완성된다)
+`StandingCalculator` 가 **`standing_key` 에 속한 모든 스테이지의 매치를 합산**한다.
+
+| 지표 | 산식 |
+|---|---|
+| `wins` / `loses` | 대상 스테이지들의 `COMPLETED` 매치에서 승패 판정 |
+| `set_wins` / `set_loses` | `esports_game.winner_team_id` 집계 |
+| `score` | `set_wins - set_loses` (시즌 합이 0이어야 정합 — §1.4) |
+| `win_rate` | `wins / (wins + loses)`, 분모 0이면 0 |
+| `group_name` | `standing_key` 에 속한 스테이지 중 **`grouped=true` 인 마지막 스테이지**의 편성 |
+| `team_rank` | 그룹 내 정렬 후 순번. 그룹이 없으면 전체 순번 |
+| `overall_rank` | 그룹 무시 전체 정렬 순번 |
+| 팀 `kills/deaths/assists` | `esports_game_player` 를 팀·세트로 합산 (3단계) |
+| 팀 `kda` | `(kills + assists) / max(deaths, 1)` |
+| 선수 `compete_set_count` | 선수의 `esports_game_player` 행 수 |
+| 선수 `compete_times` | 출전 세트의 `duration_sec` 합 |
+| 선수 `kill_involve_rate` | `(선수 K + A) / 같은 세트 소속팀 총 킬` |
+| 선수 `pog_point` | `esports_pog.point` 합 |
+| 선수 `wins/loses/score` | 선수가 1세트 이상 출전한 매치만 대상 |
+
+**정렬(동점 규칙)** — `TieBreakRule` 로 분리한다. 리그마다 다르고 규정이 바뀐다.
+
+```
+① 매치 승수 desc  ② 세트 득실차 desc  ③ 상대전적  ④ 세트 승률 desc
+```
+
+§1.4 에서 확인했듯 **동순위가 실제로 발생한다**(3~5R 의 GEN·T1 공동 2위).
+타이브레이커로도 안 갈리면 같은 `team_rank` 를 부여하고 다음 순위를 건너뛴다.
+
+### 6.2 그룹 분리
+
+`GroupSplitter` 가 `group_source_stage_id` 스테이지의 순위를 기준으로 상위/하위를 가른다.
+
+```
+1~2R 최종 순위 → 상위 group_size(5)팀 = LEGEND(group_sort=1)
+                 나머지 5팀            = RISE  (group_sort=2)
+→ esports_stage_group 에 확정 적재
+```
+
+**자동 산출 + 관리자 확정** 2단계로 둔다. 리그 규정상 예외(승강전, 와일드카드)가 있을 수 있으므로
+집계가 제안하고 관리자가 확정 API 를 호출한다. 확정 후에는 3~5R 집계가 이 편성을 사용한다.
+
+### 6.3 실행
+
+```java
+// 컴포지션 루트 — 수기 입력이므로 잦은 폴링이 불필요하다
+@Scheduled(cron = "0 0 5 * * *")   // 매일 05:00 활성 시즌 재집계
+public void aggregateActiveSeasons() { ... }
+```
+
+입력 직후 반영이 필요하면 관리자 트리거(§8)를 쓴다.
+집계 성공 시 ① 순위표 upsert ② 스냅샷 upsert(오늘) ③ 캐시 evict 를 한 트랜잭션으로 처리한다.
+
+**전량 재계산**한다. 시즌 165매치 규모라 부분 갱신을 최적화할 이유가 없고 훨씬 안전하다.
+
+---
+
+## 7. 관리자 입력 절차
+
+관리자 페이지가 없으므로 SQL 로 입력한다. 팀은 `'T1'`, 선수는 `'Duro'` 로 참조한다.
+
+### 7.1 시즌 구조 시드 (시즌당 1회)
 
 ```sql
--- 2026-01-14 T1 2:1 GEN
+INSERT INTO esports_stage
+    (season_id, stage_key, name, format, grouped, standing_key, group_size, sort_order)
+VALUES
+    ('lck_2026', 'REGULAR_R1_R2', '정규시즌 1-2R', 'ROUND_ROBIN', FALSE, 'REGULAR', NULL, 1),
+    ('lck_2026', 'MSI_QUALIFIER', 'MSI 진출전',   'BRACKET',     FALSE, NULL,      NULL, 2),
+    ('lck_2026', 'REGULAR_R3_R5', '정규시즌 3-5R', 'ROUND_ROBIN', TRUE,  'REGULAR', 5,    3),
+    ('lck_2026', 'PLAY_IN',       '플레이인',      'BRACKET',     FALSE, NULL,      NULL, 4),
+    ('lck_2026', 'PLAYOFF',       '플레이오프',    'BRACKET',     FALSE, NULL,      NULL, 5);
+
+-- 3~5R 그룹 편성의 근거를 1~2R 로 연결
+UPDATE esports_stage s
+   SET group_source_stage_id = src.stage_id
+  FROM esports_stage src
+ WHERE s.season_id = 'lck_2026' AND s.stage_key = 'REGULAR_R3_R5'
+   AND src.season_id = 'lck_2026' AND src.stage_key = 'REGULAR_R1_R2';
+```
+
+### 7.2 매치 입력 (반복 작업 — 약 165회)
+
+```sql
+-- 2026-04-05 1R 3주차 · T1 2:1 GEN
 WITH m AS (
     INSERT INTO esports_match
-        (season_id, bracket, round_no, week_no, match_date,
+        (stage_id, round_no, week_no, match_date,
          home_team_id, away_team_id, home_score, away_score)
-    SELECT 'lck_2026', 'REGULAR', 1, 1, DATE '2026-01-14',
-           h.team_id, a.team_id, 2, 1
-      FROM esports_team h, esports_team a
-     WHERE h.team_code = 'T1' AND a.team_code = 'GEN'
+    SELECT st.stage_id, 1, 3, DATE '2026-04-05', h.team_id, a.team_id, 2, 1
+      FROM esports_stage st, esports_team h, esports_team a
+     WHERE st.season_id = 'lck_2026' AND st.stage_key = 'REGULAR_R1_R2'
+       AND h.team_code = 'T1' AND a.team_code = 'GEN'
     RETURNING match_id
 )
 INSERT INTO esports_game (match_id, game_no, winner_team_id, duration_sec)
@@ -593,84 +647,90 @@ SELECT m.match_id, g.game_no, t.team_id, g.duration_sec
   JOIN esports_team t ON t.team_code = g.winner_code;
 ```
 
-### 6.2 입력 검증 뷰
+세트 시간을 모르면 `duration_sec` 를 `NULL` 로 둔다 — 선수 출전시간 집계에만 쓰인다.
 
-수기 입력은 반드시 틀린다. **집계 전에 정합성을 걸러내는 뷰**를 함께 둔다.
+### 7.3 입력 검증 뷰
+
+수기 입력은 반드시 틀린다. **집계 전에 걸러내는 뷰**를 함께 만든다.
 
 ```sql
+-- ① 매치 결과와 세트 수가 어긋난 매치
 CREATE OR REPLACE VIEW v_esports_match_invalid AS
-SELECT m.match_id, m.match_date,
+SELECT m.match_id, m.match_date, st.name AS stage,
        h.team_code AS home, a.team_code AS away,
        m.home_score, m.away_score,
        COUNT(g.game_id)                                          AS game_rows,
        COUNT(*) FILTER (WHERE g.winner_team_id = m.home_team_id)  AS home_game_wins,
        COUNT(*) FILTER (WHERE g.winner_team_id = m.away_team_id)  AS away_game_wins
   FROM esports_match m
+  JOIN esports_stage st ON st.stage_id = m.stage_id
   JOIN esports_team h ON h.team_id = m.home_team_id
   JOIN esports_team a ON a.team_id = m.away_team_id
   LEFT JOIN esports_game g ON g.match_id = m.match_id
  WHERE m.status = 'COMPLETED'
- GROUP BY m.match_id, m.match_date, h.team_code, a.team_code, m.home_score, m.away_score
+ GROUP BY m.match_id, m.match_date, st.name, h.team_code, a.team_code, m.home_score, m.away_score
 HAVING COUNT(g.game_id) <> m.home_score + m.away_score
     OR COUNT(*) FILTER (WHERE g.winner_team_id = m.home_team_id) <> m.home_score
     OR COUNT(*) FILTER (WHERE g.winner_team_id = m.away_team_id) <> m.away_score;
+
+-- ② 스테이지별 입력 진행률 — 어디까지 넣었는지 한눈에
+--    주의: 팀 테이블을 JOIN 하면 매치당 2행이 되어 집계가 2배가 된다.
+--          참가 팀 수는 상관 서브쿼리로 따로 센다.
+CREATE OR REPLACE VIEW v_esports_stage_progress AS
+SELECT st.season_id, st.stage_key, st.name,
+       COUNT(m.match_id)                                AS matches,
+       COUNT(*) FILTER (WHERE m.status = 'COMPLETED')   AS completed,
+       COALESCE(SUM(m.home_score + m.away_score), 0)    AS games,
+       (SELECT COUNT(*) FROM (
+            SELECT x.home_team_id AS team_id FROM esports_match x WHERE x.stage_id = st.stage_id
+            UNION
+            SELECT x.away_team_id             FROM esports_match x WHERE x.stage_id = st.stage_id
+        ) u)                                            AS teams
+  FROM esports_stage st
+  LEFT JOIN esports_match m ON m.stage_id = st.stage_id
+ GROUP BY st.season_id, st.stage_id, st.stage_key, st.name, st.sort_order
+ ORDER BY st.sort_order;
+
+-- ③ 세트 득실 제로섬 검증 — 순위표 단위(standing_key)로 항상 0 이어야 한다
+--    한 매치가 양 팀 관점에서 (+d, -d) 로 더해지므로 합은 반드시 0 이 된다.
+--    0 이 아니면 세트 점수를 잘못 입력한 매치가 있다는 뜻이다.
+CREATE OR REPLACE VIEW v_esports_score_zerosum AS
+SELECT st.season_id, st.standing_key,
+       SUM(CASE WHEN m.home_team_id = t.team_id THEN m.home_score - m.away_score
+                ELSE m.away_score - m.home_score END) AS score_sum
+  FROM esports_stage st
+  JOIN esports_match m ON m.stage_id = st.stage_id AND m.status = 'COMPLETED'
+  JOIN esports_team  t ON t.team_id IN (m.home_team_id, m.away_team_id)
+ WHERE st.standing_key IS NOT NULL
+ GROUP BY st.season_id, st.standing_key;
 ```
 
-`SELECT * FROM v_esports_match_invalid;` 가 **0행이면 집계해도 안전**하다.
-같은 검증을 `Match` 도메인의 `validateGameConsistency()` 가 애플리케이션 쪽에서도 수행한다.
+집계 전 확인 순서:
 
-> ✅ **실행 검증 완료.** 로컬 Postgres 16 에서 DDL → 마스터 시드 → §6.1 매치 입력 → 검증 뷰 →
-> 집계 산식까지 한 트랜잭션으로 돌려 확인했다(전부 `ROLLBACK`).
->
-> | 단계 | 기대 | 실제 |
-> |---|---|---|
-> | 정상 입력 후 검증 뷰 | 0행 | **0행** |
-> | 집계 산식 (T1 2:1 GEN) | T1 1승 0패 `+1` / GEN 0승 1패 `-1` | **일치** (득실 합 0 = 제로섬) |
-> | 오입력 주입 (`2:1` 인데 세트 2개) | 뷰가 검출 | **1행 검출** (`game_rows=2`, `away_game_wins=0`) |
->
-> 관리자가 매치 결과와 세트 수를 어긋나게 넣는 가장 흔한 실수를 뷰가 집계 전에 잡아낸다.
+1. **①이 0행** — 매치 결과와 세트 수가 전부 맞는다.
+2. **③의 `score_sum` 이 0** — 세트 점수가 제로섬을 만족한다.
+3. ②로 스테이지별 입력량이 예상과 맞는지 본다 (1~2R 90매치 / 3~5R 60매치 — §2.1).
 
-### 6.3 집계 실행
+같은 검증을 `Match` 도메인의 `validateGameConsistency()` 가 애플리케이션에서도 수행한다.
 
-```
-POST /api/v1/admin/esports/seasons/{seasonId}/aggregate   (관리자 권한)
-```
+### 7.4 실행 검증 결과
 
-또는 스케줄러가 주기 실행한다(§7). 입력 → 검증 뷰 확인 → 집계 → 화면 반영 순.
+로컬 Postgres 16 에서 DDL → 시즌 구조 시드 → 매치 입력 → 검증 뷰 3종 → 집계 산식까지
+한 트랜잭션으로 실행하고 `ROLLBACK` 했다 (`T1 2:1 GEN`, `GEN 2:0 HLE` 2건 입력).
 
----
+| 단계 | 기대 | 실제 |
+|---|---|---|
+| DDL 전체 생성 | 성공 | **테이블 15 · 인덱스 7 · 뷰 3 생성** |
+| 스테이지 시드 + 그룹 근거 연결 | 5행 | **5행, `REGULAR_R3_R5 → REGULAR_R1_R2` 연결됨** |
+| 정상 입력 후 검증 뷰 ① | 0행 | **0행** |
+| 진행률 뷰 ② | 매치 2 · 세트 5 · 팀 3 | **정확히 일치** |
+| 제로섬 뷰 ③ | `score_sum = 0` | **0** |
+| 집계 산식 | T1 1승0패 `+1` / GEN 1승1패 `+1` / HLE 0승1패 `-2` | **일치** (합 0) |
+| 오입력 주입 (`2:1` 인데 세트 2개) | 뷰 ①이 검출 | **1행 검출** |
 
-## 7. 집계 로직
-
-`StandingCalculator` (순수 도메인)가 원장을 받아 순위표를 만든다.
-
-| 지표 | 산식 |
-|---|---|
-| `wins` / `loses` | 팀이 속한 `COMPLETED` 매치에서 `home_score > away_score` 판정 |
-| `set_wins` / `set_loses` | `esports_game.winner_team_id` 집계 |
-| `score` | `set_wins - set_loses` (시즌 전체 합이 0이어야 정합 — §1.4) |
-| `win_rate` | `wins / (wins + loses)`, 분모 0이면 0 |
-| `team_rank` | 정렬: ① 승수 desc ② 득실차 desc ③ 상대전적 ④ 세트 승률 desc. **그룹별로 매긴다** |
-| 팀 `kills/deaths/assists` | `esports_game_player` 를 팀·세트로 합산 |
-| 팀 `kda` | `(kills + assists) / max(deaths, 1)` |
-| 선수 `compete_set_count` | 선수의 `esports_game_player` 행 수 |
-| 선수 `compete_times` | 출전 세트의 `duration_sec` 합 |
-| 선수 `kill_involve_rate` | `(선수 kills + assists) / 소속팀 같은 세트 총 kills` |
-| 선수 `pog_point` | `esports_pog.point` 합 |
-| 선수 `wins/loses/score` | **선수가 1세트 이상 출전한 매치**만 대상으로 팀 결과 집계 |
-
-- **동점 규칙은 `TieBreakRule` 로 분리**한다. 리그마다 다르고 규정이 바뀌므로 정렬 비교자를 갈아끼울 수 있어야 한다.
-- 집계는 **시즌 × 대진 단위 전량 재계산**. 110매치 규모라 부분 갱신을 최적화할 이유가 없고, 전량 재계산이 훨씬 안전하다.
-- 집계 성공 시 ① 순위표 upsert ② 스냅샷 upsert(오늘 날짜) ③ 캐시 evict 를 한 트랜잭션에서 처리한다.
-- 2단계 전(선수 기록 미적재)에는 팀 `kda/kills/deaths/assists` 를 `NULL` 로 두고, API 는 해당 필드를 `null` 로 내려 화면이 `-` 를 표시하게 한다.
-
-```java
-// 컴포지션 루트
-@Scheduled(cron = "0 0/30 * * * *")   // 30분마다 활성 시즌 재집계
-public void aggregateActiveSeasons() { ... }
-```
-
-관리자가 새벽에 입력해도 30분 안에 반영된다. 즉시 반영이 필요하면 §6.3 의 수동 엔드포인트를 쓴다.
+> 이 검증 과정에서 진행률 뷰의 실제 버그 2건을 잡았다 — 팀 테이블 `JOIN` 때문에 매치당 2행이 되어
+> 매치·세트 수가 **2배로 집계**됐고, `SUM(home_score - away_score)` 는 홈팀 관점 합이라 제로섬이
+> 성립하지 않았다. 전자는 팀 수를 상관 서브쿼리로 분리해, 후자는 팀 관점 제로섬 뷰 ③으로 떼어내 고쳤다.
 
 ---
 
@@ -682,18 +742,21 @@ public void aggregateActiveSeasons() { ... }
 |---|---|---|
 | GET | `/api/v1/esports/leagues` | 리그 목록 |
 | GET | `/api/v1/esports/leagues/{leagueId}/seasons` | 시즌 목록 |
+| GET | `/api/v1/esports/seasons/{seasonId}/stages` | **스테이지 목록 (신규)** |
 | GET | `/api/v1/esports/seasons/{seasonId}/team-standings` | 팀 순위표 |
 | GET | `/api/v1/esports/seasons/{seasonId}/player-standings` | 선수 순위표 |
-| GET | `/api/v1/esports/seasons/{seasonId}/standing-history` | **순위 추이 (신규)** |
-| POST | `/api/v1/admin/esports/seasons/{seasonId}/aggregate` | 집계 트리거 (관리자) |
+| GET | `/api/v1/esports/seasons/{seasonId}/standing-history` | 순위 추이 |
+| GET | `/api/v1/esports/seasons/{seasonId}/result` | 최종 순위 · 롤드컵 시드 |
+| POST | `/api/v1/admin/esports/seasons/{seasonId}/aggregate` | 집계 트리거 |
+| POST | `/api/v1/admin/esports/stages/{stageId}/split-groups` | **그룹 편성 확정** |
 
 ### 8.1 팀 순위표
 
-`GET /seasons/lck_2026/team-standings?bracket=REGULAR&sort=RANK&order=ASC`
+`GET /seasons/lck_2026/team-standings?standingKey=REGULAR&sort=RANK`
 
 | 파라미터 | 기본 | 값 |
 |---|---|---|
-| `bracket` | 시즌 최신 대진 | `REGULAR` \| `PLAYOFF` |
+| `standingKey` | 시즌의 기본 순위표 | `REGULAR` 등 (스테이지 목록 API 로 조회) |
 | `sort` | `RANK` | `RANK`,`WINS`,`LOSES`,`SCORE`,`WIN_RATE`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS` |
 | `order` | `RANK`→`ASC`, 그 외 `DESC` | `ASC` \| `DESC` |
 
@@ -702,115 +765,119 @@ public void aggregateActiveSeasons() { ... }
   "result": "SUCCESS",
   "data": {
     "seasonId": "lck_2026",
-    "bracket": "REGULAR",
+    "standingKey": "REGULAR",
+    "standingName": "정규시즌",
+    "includedStages": ["정규시즌 1-2R", "정규시즌 3-5R"],
     "sort": "RANK", "order": "ASC",
-    "aggregatedAt": "2026-08-11T04:30:00",
+    "aggregatedAt": "2026-08-12T05:00:00",
     "groups": [
       {
         "groupName": "LEGEND", "groupSort": 1,
         "standings": [
           {
-            "rank": 1,
+            "rank": 1, "overallRank": 1,
             "team": { "teamId": "R1040", "teamCode": "T1", "name": "T1",
-                      "imageUrl": "https://.../t1.png", "darkImageUrl": "https://.../t1_black.png" },
+                      "imageUrl": "https://.../t1.png" },
             "wins": 16, "loses": 6, "draws": 0,
             "setWins": 34, "setLoses": 13, "score": 21,
             "winRate": 0.7273,
             "kda": null, "kills": null, "deaths": null, "assists": null
           }
         ]
-      }
+      },
+      { "groupName": "RISE", "groupSort": 2, "standings": [] }
     ]
   }
 }
 ```
 
-`kda`/`kills`/`deaths`/`assists` 가 `null` 인 것은 **2단계 미완**을 뜻한다(에러가 아니다).
+`includedStages` 로 **이 순위표가 어떤 단계를 합산한 것인지** 화면에 표시할 수 있다.
+`kda` 등이 `null` 인 것은 3단계 미완을 뜻한다(에러가 아니다).
 
-### 8.2 선수 순위표
+### 8.2 스테이지 목록 (신규)
 
-`GET /seasons/lck_2026/player-standings?bracket=REGULAR&position=ALL&sort=RANK`
+`GET /seasons/lck_2026/stages`
+
+```json
+{
+  "result": "SUCCESS",
+  "data": [
+    { "stageKey": "REGULAR_R1_R2", "name": "정규시즌 1-2R", "format": "ROUND_ROBIN",
+      "grouped": false, "standingKey": "REGULAR", "startDate": "2026-03-31", "endDate": "2026-05-24" },
+    { "stageKey": "MSI_QUALIFIER", "name": "MSI 진출전", "format": "BRACKET",
+      "grouped": false, "standingKey": null },
+    { "stageKey": "REGULAR_R3_R5", "name": "정규시즌 3-5R", "format": "ROUND_ROBIN",
+      "grouped": true, "standingKey": "REGULAR", "groupSource": "REGULAR_R1_R2" },
+    { "stageKey": "PLAY_IN", "name": "플레이인", "format": "BRACKET", "standingKey": null },
+    { "stageKey": "PLAYOFF", "name": "플레이오프", "format": "BRACKET", "standingKey": null }
+  ]
+}
+```
+
+프런트는 이걸로 **어떤 탭을 그릴지** 결정한다. 포맷이 바뀌어도 프런트 수정이 필요 없다.
+
+### 8.3 선수 순위표
+
+`GET /seasons/lck_2026/player-standings?standingKey=REGULAR&position=ALL&sort=RANK`
 
 `position`: `ALL`,`TOP`,`JGL`,`MID`,`AD`,`SPT` ·
-`sort`: `RANK`,`POG_POINT`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS`,`KILL_INVOLVE_RATE`,`COMPETE_SET_COUNT`,`COMPETE_TIMES`
+`sort`: `RANK`,`POG_POINT`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS`,`KILL_INVOLVE_RATE`,`COMPETE_SET_COUNT`
+
+페이징 없음(시즌당 60~70명). `position` 필터 시 원본 `rank` 유지(네이버 동작과 동일).
+
+### 8.4 순위 추이
+
+`GET /seasons/lck_2026/standing-history?standingKey=REGULAR&teamCode=T1`
 
 ```json
 {
   "result": "SUCCESS",
   "data": {
-    "seasonId": "lck_2026", "bracket": "REGULAR", "position": "ALL",
-    "aggregatedAt": "2026-08-11T04:30:00",
-    "standings": [
-      {
-        "rank": 1,
-        "player": { "playerId": "10785", "nickName": "Duro", "name": "주민규" },
-        "team": { "teamId": "R479", "teamCode": "GEN", "name": "젠지" },
-        "position": "SPT",
-        "pogPoint": 0,
-        "kda": 6.52, "kills": 40, "deaths": 84, "assists": 508,
-        "killInvolveRate": 0.77,
-        "competeSetCount": 41, "competeTimes": 76740,
-        "wins": 14, "loses": 4, "score": 19, "winRate": 0.7778
-      }
-    ]
-  }
-}
-```
-
-- 페이징 없음 — 시즌당 선수 60~70명, 팀 10팀.
-- `position` 필터 시 원본 `rank` 를 유지한다(재계산하지 않음). 네이버 동작과 동일.
-
-### 8.3 순위 추이 (신규)
-
-`GET /seasons/lck_2026/standing-history?bracket=REGULAR&teamCode=T1&from=2026-01-01`
-
-```json
-{
-  "result": "SUCCESS",
-  "data": {
-    "seasonId": "lck_2026", "bracket": "REGULAR",
+    "seasonId": "lck_2026", "standingKey": "REGULAR",
     "series": [
       { "team": { "teamCode": "T1", "name": "T1" },
         "points": [
-          { "date": "2026-01-19", "weekNo": 1, "rank": 3, "wins": 1, "loses": 1, "score": 0 },
-          { "date": "2026-01-26", "weekNo": 2, "rank": 1, "wins": 3, "loses": 1, "score": 4 }
+          { "date": "2026-04-05", "weekNo": 3, "rank": 3, "wins": 4, "loses": 2, "score": 3 },
+          { "date": "2026-04-12", "weekNo": 4, "rank": 1, "wins": 6, "loses": 2, "score": 7 }
         ] }
     ]
   }
 }
 ```
 
-`teamCode` 를 생략하면 전 팀 시리즈를 내려준다(10팀 × 주차 → 그래프 한 장).
+`teamCode` 생략 시 전 팀 시리즈. 그룹 분리 전후가 한 차트에 이어진다.
 
-### 8.4 에러
+### 8.5 에러
 
 | 상황 | 코드 |
 |---|---|
-| 없는 `seasonId` | 404 `EsportsSeasonNotFoundException` |
-| 잘못된 `sort`/`position`/`bracket` | 400 (enum 바인딩 실패) |
+| 없는 `seasonId` / `standingKey` | 404 |
+| 잘못된 `sort`/`position` | 400 |
 | 집계 전 (원장은 있으나 순위표 없음) | 200 + 빈 `groups` + `aggregatedAt: null` |
-| 집계 트리거 시 원장 정합성 위반 | 409 + 위반 매치 목록 (§6.2 뷰 결과) |
+| 집계 트리거 시 원장 정합성 위반 | 409 + 위반 매치 목록 (§7.3 뷰 ①) |
+| 그룹 확정 시 근거 스테이지 미완료 | 409 |
 
 ---
 
 ## 9. 정렬 · 캐시
 
-시즌 × 대진이 최대 70행이므로 DB 에서는 `rank` 순 flat 리스트를 한 번만 읽어 캐시하고,
+`standing_key` 단위 최대 70행이므로 DB 는 `rank` 순 flat 리스트만 읽어 캐시하고,
 `position` 필터와 `sort` 는 애플리케이션 `Comparator`(화이트리스트 enum)로 처리한다.
-정렬 9종 × 포지션 6종 = 54개로 캐시 키를 쪼개는 것보다 낫다.
+정렬 9종 × 포지션 6종 = 54키로 쪼개는 것보다 낫다.
 
 | 키 | TTL | 무효화 |
 |---|---|---|
 | `esports:leagues` / `esports:seasons:{leagueId}` | 24h | 마스터 변경 시 |
-| `esports:standings:team:{seasonId}:{bracket}` | 1h | **집계 성공 시 evict** |
-| `esports:standings:player:{seasonId}:{bracket}` | 1h | 〃 |
-| `esports:history:{seasonId}:{bracket}` | 6h | 〃 |
+| `esports:stages:{seasonId}` | 24h | 스테이지 변경 시 |
+| `esports:standings:team:{seasonId}:{standingKey}` | 6h | **집계 성공 시 evict** |
+| `esports:standings:player:{seasonId}:{standingKey}` | 6h | 〃 |
+| `esports:history:{seasonId}:{standingKey}` | 12h | 〃 |
 
-집계가 명시적 무효화 지점이라 TTL 을 v1(10분)보다 길게 잡아도 안전하다.
+수기 입력이라 데이터가 하루 단위로 바뀌므로 TTL 을 길게 잡아도 안전하다.
 
 > 값 클래스는 `GenericJackson2JsonRedisSerializer` 로 직렬화된다. **캐시 대상 ReadModel 에
 > 파생 boolean getter 를 추가하면 기존 엔트리 역직렬화가 전량 실패**하므로 파생 getter 에는 `@JsonIgnore` 를 붙이고,
-> 클래스 이동·리네임 시에는 배포 때 해당 키를 flush 한다.
+> 클래스 이동·리네임 시 배포 때 해당 키를 flush 한다.
 
 ---
 
@@ -819,21 +886,26 @@ public void aggregateActiveSeasons() { ... }
 **1단계 — 팀 순위표 (외부 의존 0)**
 
 1. `module/domain/esports` 생성 + `settings.gradle` / 컴포지션 루트 등록
-2. `V31` 마이그레이션 (마스터 + 원장 + 집계 + 이력 + 검증 뷰)
-3. 마스터 시드: LCK 10팀 · 시즌 · 그룹 편성 (`V32` seed 또는 운영 SQL)
-4. `StandingCalculator` + `TieBreakRule` **단위 테스트 먼저** — 동점 3팀 시나리오(§1.4)를 재현
-5. 집계 서비스 + 관리자 트리거 엔드포인트 + 스케줄러
-6. 조회 API 3종(리그·시즌·팀 순위표) + Redis 캐시
-7. 매치 원장 110건 입력 → 검증 뷰 0행 확인 → 집계 → 네이버 화면과 순위 대조
+2. `V31` 마이그레이션 (마스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)
+3. 마스터 시드: LCK 10팀 · `lck_2026` 시즌 · **스테이지 5개**(§7.1)
+4. **`StandingCalculator` · `GroupSplitter` · `TieBreakRule` 단위 테스트 먼저**
+   — 동률 3팀(§1.4), 공동 순위, 누적 합산(§1.2) 시나리오를 재현
+5. 집계 서비스 + 그룹 확정 API + 관리자 트리거 + 스케줄러
+6. 조회 API(리그·시즌·스테이지·팀 순위표) + Redis 캐시
+7. **1~2R 매치 90건 입력** → 검증 뷰 0행 → 집계 → 그룹 확정 → **3~5R 입력** → 재집계
+8. 네이버 화면과 순위·승패·득실차 대조
 
-**2단계 — 선수 순위표 · 팀 KDA**
+**2단계 — POG · 선수 순위표 골격**
 
-8. `esports_game_player` 일괄 적재 경로 (CSV 임포트 또는 livestats 수집 어댑터)
-9. POG 입력 + 선수 집계 로직
-10. 선수 순위표 API + 순위 추이 API
-11. RestDocs → `./gradlew :module:infra:api:asciidoctor`
+9. POG 입력 + 선수 집계(포인트·승패만) + 선수 순위표 API
+10. 순위 추이 API + 최종 결과(`esports_season_result`) API
 
-7번의 **네이버 화면 대조가 1단계의 완료 기준**이다. 순위·승패·득실차가 일치하면 집계 규칙이 맞은 것이다.
+**3단계 — 선수 상세 스탯** (§11-4 결정 후)
+
+11. `esports_game_player` 적재 경로 확보 → KDA·킬관여율·출전세트수 집계
+12. RestDocs → `./gradlew :module:infra:api:asciidoctor`
+
+**8번의 네이버 대조가 1단계 완료 기준**이다. 순위·승패·득실차가 일치하면 집계 규칙이 맞은 것이다.
 
 ---
 
@@ -841,9 +913,43 @@ public void aggregateActiveSeasons() { ... }
 
 | # | 이슈 | 결정 필요 사항 |
 |---|---|---|
-| 1 | **원장 초기 적재** | lolesports 내부 API `getCompletedEvents` 로 1회 임포트 — 조건부 권장. LCK 매치가 실제로 내려오고 팀코드·`gameWins`·주차(`blockName`)까지 확보되는 것은 확인했다. 단 ① **비문서화 API 이므로 1회성 임포트로 한정**하고 상시 호출 경로로 만들지 말 것 ② 응답이 전 리그 혼합 최근 300건이라 시즌 전체는 페이징 확인 필요 ③ §2.1 의 미플레이 세트 함정 처리 필수. 법무/약관 판단이 걸리면 **수기 입력 110건이 현실적 대안**이다 |
-| 2 | 동점 규칙 | LCK 규정의 정확한 타이브레이커 순서(득실차 → 상대전적 → ?) 확인 필요. `TieBreakRule` 구현 전 확정해야 함 |
-| 3 | POG 산정 단위 | 원본 POG 총합 9,000점(=90회)이 총 매치 110건과 맞지 않음. 세트당인지 매치당인지, 미집계 구간이 있는지 확인 필요 |
-| 4 | 선수 기록 확보 경로 | livestats 수집(세트 245회 호출·파싱) vs CSV 일괄 적재 vs 2단계 자체 보류 |
-| 5 | 지원 리그 범위 | LCK 만인지, LPL/LEC 까지인지. 확장 시 원장 입력 부담이 리그 수에 비례한다 |
-| 6 | 관리자 인증 | `/api/v1/admin/**` 권한 체계. 기존 member 컨텍스트의 역할을 재사용할지 |
+| 1 | **동점 규칙** | T1·HLE·GEN 이 모두 16승 6패였고 공동 순위도 실제로 발생한다. LCK 규정의 타이브레이커 순서(득실차 → 상대전적 → ?)를 확정해야 `TieBreakRule` 을 구현할 수 있다. **1단계 착수 전 필요** |
+| 2 | **순위표 노출 단위** | 화면에 `REGULAR`(1~2R+3~5R 누적) 하나만 둘지, `1~2R 단독` 탭도 줄지. `standing_key` 를 나누기만 하면 되므로 코드 변경은 없다 |
+| 3 | POG 산정 단위 | 원본 총합 9,000점(=90회)이 매치 수와 맞지 않는다. 세트당인지 매치당인지, 미집계 구간이 있는지 확인 필요 |
+| 4 | **선수 상세 스탯(3단계)** | 세트별 선수 기록 약 4,000행은 수기로 불가능(§2.1). ① 3단계 자체를 보류하고 선수 탭은 포인트·승패만 노출 ② 매치 단위 합계로 축소 입력(약 1,650행) ③ 별도 적재 경로 마련 — **①을 권장**(팀 탭이 먼저 완성되고 나중에 확장 가능) |
+| 5 | MSI·플레이오프 대진표 | 토너먼트는 순위표로 표현되지 않는다. 대진표 화면이 필요하면 별도 테이블·API 설계가 추가로 필요하다. 현재 범위는 **최종 순위만 `esports_season_result` 로 관리** |
+| 6 | 롤드컵 시드 표시 | `worlds_seed` 를 화면에 노출할지, 관리 목적으로만 둘지 |
+| 7 | 관리자 인증 | `/api/v1/admin/**` 권한 체계. 기존 member 컨텍스트 역할 재사용 여부 |
+
+---
+
+## 12. 부록 — 검증에 사용한 주소
+
+설계 근거를 재확인할 때 쓴다. **채택한 데이터 경로가 아니다** (§2.2).
+
+**브라우저에서 바로 열림**
+
+```
+https://esports-api.game.naver.com/service/v1/ranking/lck_2026/team
+https://esports-api.game.naver.com/service/v1/ranking/lck_2026/player
+https://esports-api.game.naver.com/service/v1/meta/lck/leagues
+https://feed.lolesports.com/livestats/v1/window/116951349275512133
+```
+
+**`x-api-key` 헤더 필요** (없으면 403)
+
+```bash
+K=0TvQnueqKa5mxJntVWt0w4LpLfEkrV1Ta8rQBb9Z
+
+# §1.1 스테이지 구조 — split_2 정규리그 / split_3 레전드·라이즈 그룹
+curl -s -H "x-api-key: $K" \
+  "https://esports-api.lolesports.com/persisted/gw/getStandingsV3?hl=ko-KR&tournamentId=115548128960088078" | jq .
+curl -s -H "x-api-key: $K" \
+  "https://esports-api.lolesports.com/persisted/gw/getStandingsV3?hl=ko-KR&tournamentId=115548147890329817" | jq .
+
+# LCK 토너먼트(스플릿) 목록
+curl -s -H "x-api-key: $K" \
+  "https://esports-api.lolesports.com/persisted/gw/getTournamentsForLeague?hl=ko-KR&leagueId=98767991310872058" | jq .
+```
+
+라이엇 공식 개발자 포털: <https://developer.riotgames.com/apis> — **e스포츠 API 는 없다.**

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -1,10 +1,15 @@
 # e스포츠 리그 기록 (LCK 순위표) — 테이블 · API 설계
 
 > 참고 화면: `https://game.naver.com/esports/League_of_Legends/record/lck/team/lck_2026`
-> 작성일: 2026-08-11 · 상태: 설계 초안 (구현 전)
+> 작성일: 2026-08-11 · 개정: v2 (원장 기반으로 전환) · 상태: 설계 초안 (구현 전)
 
 네이버 게임 e스포츠 "기록" 페이지와 동일한 화면을 제공하기 위한 백엔드 설계.
-새 바운디드 컨텍스트 `module/domain/esports` 를 추가하고, 리그/시즌 메타 · 팀 순위 · 선수 순위를 서빙한다.
+새 바운디드 컨텍스트 `module/domain/esports` 를 추가한다.
+
+> **v2 개정 요지** — v1은 외부 API가 이미 집계해 둔 순위표를 스냅샷으로 적재하는 설계였다.
+> 실제 API 3종을 호출해 검증한 결과(§2) **공식 API만으로는 화면 컬럼의 절반을 채울 수 없고**,
+> 전부 채워주는 유일한 출처는 비공식 API였다. 따라서 **경기 원장을 우리 DB의 진실원천으로 두고
+> 순위표는 집계 산출물로 만드는 구조**로 전환한다. 이력(순위 추이) 테이블도 다시 포함한다.
 
 ---
 
@@ -17,283 +22,405 @@
                             └ lck        └ team|player  └ lck_2026  └ ALL|TOP|JGL|MID|AD|SPT
 ```
 
-| 요소 | 값 | 비고 |
-|---|---|---|
-| `topLeagueId` | `lck`, `lpl`, `lec`, `lta` … | 상위 리그 (리그 필터) |
-| `seasonId` | `lck_2026`, `lck_2026_event` … | 시즌 (= 하위 리그 ID) |
-| `group` | `team` \| `player` | 유형 필터 (팀 순위 / 개인 순위) |
-| `position` | `ALL` \| `TOP` \| `JGL` \| `MID` \| `AD` \| `SPT` | 선수 유형일 때만 노출 |
-
 필터 UI 는 4개: **리그 · 시즌 · 유형 · 포지션**. 포지션은 유형이 `player` 일 때만 보인다.
 
 ### 1.2 팀 순위표 컬럼
 
 그룹(`LEGEND` / `RISE`)별로 테이블이 분리되어 렌더링된다.
 
-| # | 헤더 | 필드 | 타입 | 정렬 | 표시 |
-|---|---|---|---|---|---|
-| 1 | 순위 | `rank` | int | – | `1` |
-| 2 | 팀 | `team` | object | – | 로고 + 팀명 |
-| 3 | 승 | `wins` | int | ✅ | `16` |
-| 4 | 패 | `loses` | int | ✅ | `6` |
-| 5 | 득실차 | `score` | int | ✅ | `+21` / `-32` |
-| 6 | 승률 | `winRate` | double | ✅ | `73%` (0.73 → 백분율) |
-| 7 | KDA | `kda` | double | ✅ | `3.92` |
-| 8 | 킬 | `kills` | int | ✅ | `822` |
-| 9 | 데스 | `deaths` | int | ✅ | `673` |
-| 10 | 어시스트 | `assists` | int | ✅ | `1,819` |
-
-- **승/패는 매치(Bo3) 기준**, **득실차는 세트 득실차**다. 예) T1 16승 6패(=22매치) / 득실차 +21.
-  같은 16승 6패라도 득실차(T1 21 > HLE 19 > GEN 18)로 순위가 갈린다.
-- 그룹 분리(LEGEND/RISE)는 확인된 범위(`lck_2025`, `lck_2026`)에서 동일하게 나타난다.
-  다만 리그·시즌마다 그룹이 없을 수 있으므로 `group_name` 은 nullable 로 두고, 없으면 단일 테이블로 렌더링한다.
+| # | 헤더 | 필드 | 정렬 | 원장에서 유도 가능? |
+|---|---|---|---|---|
+| 1 | 순위 | `rank` | – | ✅ 집계 (동점 규칙 필요) |
+| 2 | 팀 | `team` | – | ✅ 마스터 |
+| 3 | 승 | `wins` | ✅ | ✅ 매치 결과 |
+| 4 | 패 | `loses` | ✅ | ✅ 매치 결과 |
+| 5 | 득실차 | `score` | ✅ | ✅ 세트 결과 |
+| 6 | 승률 | `winRate` | ✅ | ✅ 매치 결과 |
+| 7 | KDA | `kda` | ✅ | ⚠️ 세트별 선수 기록 필요 |
+| 8 | 킬 | `kills` | ✅ | ⚠️ 〃 |
+| 9 | 데스 | `deaths` | ✅ | ⚠️ 〃 |
+| 10 | 어시스트 | `assists` | ✅ | ⚠️ 〃 |
 
 ### 1.3 선수 순위표 컬럼
 
-| # | 헤더 | 필드 | 타입 | 정렬 | 표시 |
-|---|---|---|---|---|---|
-| 1 | 순위 | `rank` | int | – | `1` |
-| 2 | 선수 | `player` | object | – | 프로필 + 닉네임(`Duro`) |
-| 3 | 소속 | `team` | object | – | 팀 로고 + 약칭(`GEN`) |
-| 4 | 포지션 | `position` | enum | – | 아이콘 + `SPT` |
-| 5 | 포인트 | `pogPoint` | int | ✅ | `900` (POG 포인트) |
-| 6 | KDA | `kda` | double | ✅ | `6.52` |
-| 7 | 킬 | `kills` | int | ✅ | `40` |
-| 8 | 데스 | `deaths` | int | ✅ | `84` |
-| 9 | 어시스트 | `assists` | int | ✅ | `508` |
-| 10 | 킬관여율 | `killInvolveRate` | double | ✅ | `77%` |
-| 11 | 출전세트수 | `competeSetCount` | int | ✅ | `41` |
+| # | 헤더 | 필드 | 정렬 | 원장에서 유도 가능? |
+|---|---|---|---|---|
+| 1 | 순위 | `rank` | – | ✅ 집계 |
+| 2 | 선수 | `player` | – | ✅ 마스터 |
+| 3 | 소속 | `team` | – | ✅ 마스터 |
+| 4 | 포지션 | `position` | – | ✅ 세트별 선수 기록 |
+| 5 | 포인트 | `pogPoint` | ✅ | ⚠️ POG 선정 입력 필요 |
+| 6 | KDA | `kda` | ✅ | ⚠️ 세트별 선수 기록 |
+| 7 | 킬 | `kills` | ✅ | ⚠️ 〃 |
+| 8 | 데스 | `deaths` | ✅ | ⚠️ 〃 |
+| 9 | 어시스트 | `assists` | ✅ | ⚠️ 〃 |
+| 10 | 킬관여율 | `killInvolveRate` | ✅ | ⚠️ 〃 (선수 K+A ÷ 팀 킬) |
+| 11 | 출전세트수 | `competeSetCount` | ✅ | ⚠️ 〃 |
 
-- `competeTimes`(총 출전 시간, 분)는 정렬 키로만 존재하고 기본 컬럼에는 없다. 응답에는 포함시켜 두고 화면 노출은 선택.
-- 선수의 `wins`/`loses`/`score`/`winRate` 는 **해당 선수가 출전한 매치 기준** 집계값 (기본 컬럼 아님, 응답에는 포함).
+### 1.4 데이터 성격 검증
 
-### 1.4 원본 데이터 소스 (참고용 · 스키마 근거)
+원본 API 응답을 받아 정합성을 확인했다. 이 수치들이 뒤의 테이블·집계 설계 근거다.
 
-네이버 e스포츠 공개 API 를 호출해 실제 응답 스키마를 확인했다.
+| 검증 항목 | 결과 | 의미 |
+|---|---|---|
+| 팀 `wins` 합계 | **110** | 10팀 × 22매치 ÷ 2 = 110. `wins`/`loses` 는 **매치(Bo3) 단위** |
+| 팀 `score` 합계 | **0** | 제로섬 → `score` 는 **세트 득실차**가 맞다 |
+| 동률 팀 순위 | T1·HLE·GEN 모두 16승 6패 | 순위는 득실차(21 > 19 > 18)로 갈림 → **동점 규칙이 순위 산정에 필수** |
+| 선수 `competeSetCount` 최대 | 44 | 22매치 전부 2세트로 끝난 팀 기준. 총 세트 수 ≈ **245** |
+| 선수 `pogPoint` 합계 | 9,000 | 100점 단위 → **90회 선정**. 총 매치 110건과 불일치 → 산정 규칙 확인 필요(§10-3) |
+
+---
+
+## 2. 데이터 출처 — 실제 검증 결과
+
+세 경로를 모두 직접 호출해 확인했다. **셋 다 실재하고 응답한다.** 차이는 "무엇까지 주는가"다.
+
+### 2.1 라이엇 공식 LoL Esports API
 
 ```
-GET https://esports-api.game.naver.com/service/v1/ranking/{seasonId}/team
-GET https://esports-api.game.naver.com/service/v1/ranking/{seasonId}/player
-GET https://esports-api.game.naver.com/service/v1/meta/topLeagues
+GET https://esports-api.lolesports.com/persisted/gw/getLeagues?hl=ko-KR
+GET https://esports-api.lolesports.com/persisted/gw/getTournamentsForLeague?leagueId={id}
+GET https://esports-api.lolesports.com/persisted/gw/getStandingsV3?tournamentId={id}
+GET https://esports-api.lolesports.com/persisted/gw/getCompletedEvents?leagueId={id}
+    (헤더: x-api-key — 웹 클라이언트에 노출된 공개 키)
+```
+
+2026 LCK 데이터가 실제로 들어 있고, **레전드/라이즈 그룹 구조까지 그대로** 나온다.
+
+```json
+{ "name": "레전드 그룹",
+  "rankings": [
+    { "ordinal": 1, "teams": [ { "code": "DK", "record": { "wins": 3, "ties": 0, "losses": 1 } } ] },
+    { "ordinal": 2, "teams": [ { "code": "GEN", ... }, { "code": "T1", ... }, { "code": "KT", ... } ] }
+  ] }
+```
+
+**주는 것**: 리그·토너먼트·팀 마스터, 그룹 구조, 팀별 승/패, 매치 일정과 결과(`gameWins`), 세트 ID,
+그리고 `blockName` 에 **`"11주 차"` 형태의 주차 정보** — 순위 추이(§8.3)의 x축을 그대로 얻을 수 있다.
+**안 주는 것**: 득실차 · 승률 · 팀 KDA · 킬/데스/어시스트 · 선수 순위 전체 · POG 포인트.
+`ordinal` 이 공동 순위(2위에 3팀)로 내려와 화면의 1~5위 형태와도 다르다.
+
+> ⚠️ **임포트 함정 — `games` 배열은 미플레이 세트를 포함한다.**
+> 2026-08-09 `BFX 2 : 0 KRX` 매치를 확인해 보면 `gameWins` 는 2:0인데 `games` 배열 길이는 **3**이다.
+> Bo3 의 세트 슬롯이 전부 내려오고 3세트는 실제로 열리지 않았다(`vods: []`).
+> 그대로 적재하면 세트 수가 부풀고 **득실차가 전부 틀어진다.**
+> 안전한 기준은 VOD 유무가 아니라 **`home_score + away_score` 개만 앞에서부터 취하는 것**이다.
+> `esports_match` ↔ `esports_game` 정합성 뷰(§6.2)가 이 실수를 잡아낸다.
+
+선수 스탯은 별도 피드에서 **세트 단위로** 얻어야 한다.
+
+```
+GET https://feed.lolesports.com/livestats/v1/window/{gameId}
+→ gameMetadata.blueTeamMetadata.participantMetadata[] : esportsPlayerId, summonerName, championId, role
+→ frames[].blueTeam.participants[] : kills, deaths, assists, creepScore, totalGold, level
+```
+
+응답은 확인했지만 **프레임 단위 시계열**이라, 세트 최종 스탯을 얻으려면 종료 시각대의 프레임을 찾아
+세트마다 호출·파싱해야 한다. 시즌당 약 245세트 × 10명 = **2,450행**을 만들어내는 별도 수집 파이프라인이 필요하다.
+그리고 **POG 포인트는 LCK 자체 제도라 어느 라이엇 API에도 없다.**
+
+### 2.2 네이버 e스포츠 API
+
+```
+GET https://esports-api.game.naver.com/service/v1/ranking/{seasonId}/{team|player}
 GET https://esports-api.game.naver.com/service/v1/meta/{topLeagueId}/leagues
 ```
 
-팀 응답 1건 (로고 URL 생략):
+화면에 필요한 **모든 컬럼을 이미 집계된 상태로** 준다(득실차·승률·KDA·킬관여율·출전세트수·POG 포인트).
+즉 네이버가 자체 집계한 파생 데이터다. 문서화된 공개 API가 아니고 약관·안정성 보장이 없어
+**상시 의존 대상으로 삼기 어렵다.**
 
-```json
-{
-  "teamId": "R1040", "leagueId": "lck_2026",
-  "bracket": "split", "bracketName": "정규시즌 1-2R",
-  "groupName": "LEGEND", "groupSort": 1,
-  "rank": 1, "wins": 16, "loses": 6, "draws": 0, "score": 21, "winRate": 0.73,
-  "addInfo": {
-    "kda": 3.92, "kills": 822, "deaths": 673, "assists": 1819,
-    "firstKillRate": 1.25, "firstTowerRate": 1.25, "firstBaronRate": 1.1
-  },
-  "team": { "teamId": "R1040", "gameCode": "lol", "name": "T1",
-            "nameAcronym": "T1", "nameEng": "T1", "nameEngAcronym": "T1", "orderPoint": 1990 }
-}
-```
+### 2.3 판단
 
-선수 응답 1건:
+| 출처 | 팀 승/패 | 득실차·승률 | 팀·선수 KDA | POG | 상시 의존 |
+|---|---|---|---|---|---|
+| 공식 Esports API | ✅ | ❌ (원장에서 유도 가능) | ❌ (livestats 별도 수집) | ❌ | ✅ |
+| livestats 피드 | – | – | ⚠️ 세트별 수집·파싱 필요 | ❌ | ⚠️ |
+| 네이버 API | ✅ | ✅ | ✅ | ✅ | ❌ |
 
-```json
-{
-  "playerId": "10785", "teamId": "R479", "leagueId": "lck_2026",
-  "bracket": "regular", "groupName": null,
-  "rank": 1, "wins": 14, "loses": 4, "draws": 0, "score": 19, "winRate": 0.78,
-  "position": "SPT",
-  "addInfo": { "kda": 6.52, "kills": 40, "deaths": 84, "assists": 508,
-               "killInvolveRate": 0.77, "competeSetCount": 41,
-               "competeTimes": 1279, "pogPoint": 0 },
-  "player": { "playerId": "10785", "teamId": "R479", "gameCode": "lol",
-              "name": "주민규", "nameEng": "Joo Min-kyu", "nickName": "Duro" },
-  "team": { "teamId": "R479", "name": "젠지", "nameEngAcronym": "GEN", "orderPoint": 2000 }
-}
-```
-
-> ⚠️ **데이터 출처 결정 필요.** 위 API 는 네이버 내부용 공개 엔드포인트로, 상시 의존은 약관·안정성 리스크가 있다.
-> 아래 설계는 **수집 어댑터를 포트 뒤로 숨겨** 출처를 교체 가능하게 둔다 (`EsportsRecordClientPort`).
-> 후보: ① 네이버 e스포츠 API ② LoL Esports 공식 피드(`esports-api.lolesports.com`) ③ 자체 집계(경기 결과 직접 적재).
-> 스키마 자체는 ①/②가 거의 동형이라 테이블은 그대로 재사용 가능하다.
+**→ 지적하신 방향이 맞다.** 어떤 단일 API도 화면을 그대로 채워주지 않고, 채워주는 하나는 의존할 수 없다.
+따라서 **경기 원장을 우리 DB에 두고 순위표를 집계로 만든다.** 외부 API 는 원장을 채우는
+*선택적 보조 입력*으로 격하하고, 없어도 시스템이 성립하게 한다.
 
 ---
 
-## 2. 모듈 구조
-
-기존 컨벤션(수직 바운디드 컨텍스트 + 헥사고날)에 맞춰 `module/domain/esports` 를 신설한다.
+## 3. 설계 방향 — 원장 → 집계 → 이력
 
 ```
-module/domain/esports/
-└── src/main/java/com/example/lolserver/esports/
-    ├── domain/
-    │   ├── EsportsLeague.java          # 상위 리그 (lck)
-    │   ├── EsportsSeason.java          # 시즌 (lck_2026)
-    │   ├── EsportsTeam.java
-    │   ├── EsportsPlayer.java
-    │   ├── TeamStanding.java           # 팀 순위 행 (validate* guard 보유)
-    │   ├── PlayerStanding.java         # 선수 순위 행
-    │   ├── EsportsPosition.java        # TOP/JGL/MID/AD/SPT (+ ALL 은 필터 전용)
-    │   ├── StandingGroup.java          # LEGEND / RISE / NONE
-    │   └── Bracket.java                # SPLIT / REGULAR / PLAYOFF
-    ├── application/
-    │   ├── port/in/
-    │   │   ├── EsportsMetaQueryUseCase.java
-    │   │   ├── TeamStandingQueryUseCase.java
-    │   │   ├── PlayerStandingQueryUseCase.java
-    │   │   └── EsportsRecordSyncUseCase.java     # 수집 트리거 (스케줄러가 호출)
-    │   ├── port/out/
-    │   │   ├── EsportsMetaPersistencePort.java
-    │   │   ├── TeamStandingPersistencePort.java
-    │   │   ├── PlayerStandingPersistencePort.java
-    │   │   ├── EsportsRecordClientPort.java      # 외부 수집 (출처 교체 지점)
-    │   │   └── EsportsRecordCachePort.java
-    │   ├── command/EsportsRecordSyncCommand.java
-    │   ├── model/
-    │   │   ├── query/TeamStandingQuery.java      # seasonId, group, sort
-    │   │   ├── query/PlayerStandingQuery.java    # seasonId, position, sort
-    │   │   └── readmodel/
-    │   │       ├── LeagueReadModel.java
-    │   │       ├── SeasonReadModel.java
-    │   │       ├── TeamStandingReadModel.java
-    │   │       ├── TeamStandingGroupReadModel.java   # 그룹 헤더 + rows
-    │   │       └── PlayerStandingReadModel.java
-    │   ├── EsportsMetaService.java
-    │   ├── TeamStandingService.java
-    │   ├── PlayerStandingService.java
-    │   └── EsportsRecordSyncService.java
-    └── adapter/
-        ├── in/web/
-        │   ├── EsportsMetaController.java
-        │   ├── TeamStandingController.java
-        │   └── PlayerStandingController.java
-        └── out/
-            ├── persistence/  (Entity · JpaRepository · MapStruct Mapper · PersistenceAdapter)
-            ├── client/naver/ (NaverEsportsRecordClientAdapter · 응답 DTO · Mapper)
-            └── cache/        (EsportsRecordRedisAdapter)
+[입력]                        [집계]                          [조회]
+esports_match      ─┐
+esports_game       ─┼─→  esports_team_standing    ─┐
+esports_game_player ┤    esports_player_standing  ─┼─→  REST API + Redis
+esports_match_pog  ─┘         │                    │
+                              └→ esports_standing_snapshot (이력/추이)
 ```
 
-`settings.gradle` 에 `"module:domain:esports"` 추가, `module/app/application/build.gradle` 에
-`implementation project(":module:domain:esports")` 추가. 컴포지션 루트에 `EsportsRecordSyncScheduler` 배치.
+- **원장(진실원천)**: 매치 · 세트 · 세트별 선수 기록 · POG 선정. 관리자가 DB 로 직접 입력한다.
+- **집계 산출물**: 순위표. 원장에서 재계산되며 **언제든 버리고 다시 만들 수 있다.**
+- **이력**: 집계할 때마다 날짜별 스냅샷 1벌. 주차별 순위 추이 그래프의 재료.
 
-`build.gradle` 는 `gamedata` 와 동일 (`web-conventions` + `persistence-conventions` + common/shared/logging + data-redis).
+이 구조의 이점:
+1. 외부 API 가 죽거나 막혀도 서비스가 성립한다.
+2. 순위 추이가 공짜로 나온다 (v1에서 뺐던 이력 테이블이 자연스럽게 복귀).
+3. 집계 로직 버그를 고치면 **전 시즌을 재집계**해 바로잡을 수 있다 (스냅샷 적재형은 불가능).
+4. 외부 출처가 정해지면 수집 어댑터가 원장에 INSERT 하는 것으로 끝난다 — 조회 계층은 그대로.
+
+### 3.1 입력량 — 단계를 나눠야 하는 이유
+
+시즌 1회분(LCK 정규시즌 기준) 관리자 입력량 추정:
+
+| 원장 | 행 수 | 수기 입력 |
+|---|---|---|
+| 매치 결과 (`2:1` 형태) | **110행** | ✅ 현실적 |
+| 세트 결과 (승팀·소요시간) | **약 245행** | ✅ 매치 입력 시 함께 |
+| POG 선정 | **약 90~110행** | ✅ 세트/매치당 1명 |
+| 세트별 선수 기록 (10명 × K/D/A/포지션) | **약 2,450행** | ❌ 비현실적 |
+
+→ **1단계는 매치·세트 원장만으로 팀 순위표를 완성**한다(순위·승·패·득실차·승률).
+KDA/킬/데스/어시스트가 필요한 컬럼과 선수 순위표는 2단계로 미루고,
+선수 기록은 수기 대신 **일괄 적재(CSV/livestats 수집) + 관리자 보정**으로 채운다.
 
 ---
 
-## 3. DB 테이블 설계
+## 4. 모듈 구조
 
-마이그레이션 파일: `lol-db-schema/db/migration/V31__add_esports_record_tables.sql`
+```
+module/domain/esports/src/main/java/com/example/lolserver/esports/
+├── domain/
+│   ├── EsportsLeague · EsportsSeason · EsportsTeam · EsportsPlayer
+│   ├── Match.java              # 매치 원장 (validate* guard: 세트 합 = 매치 결과 정합)
+│   ├── Game.java               # 세트
+│   ├── GamePlayerStat.java     # 세트별 선수 기록
+│   ├── TeamStanding · PlayerStanding      # 집계 산출물
+│   ├── StandingCalculator.java # ★ 집계 규칙 (순수 도메인, 외부 의존 없음)
+│   ├── TieBreakRule.java       # 동점 규칙 (득실차 → 상대전적 → …)
+│   ├── EsportsPosition.java    # TOP/JGL/MID/AD/SPT
+│   └── Bracket.java            # SPLIT / REGULAR / PLAYOFF
+├── application/
+│   ├── port/in/   EsportsMetaQueryUseCase · TeamStandingQueryUseCase
+│   │              PlayerStandingQueryUseCase · StandingHistoryQueryUseCase
+│   │              StandingAggregateUseCase        # 집계 트리거
+│   ├── port/out/  MatchPersistencePort · StandingPersistencePort
+│   │              StandingSnapshotPersistencePort · EsportsRecordCachePort
+│   │              EsportsFeedClientPort           # 선택적 외부 수집
+│   ├── model/query · model/readmodel
+│   └── EsportsMetaService · TeamStandingService · PlayerStandingService
+│       StandingAggregateService · StandingHistoryService
+└── adapter/
+    ├── in/web/       EsportsMetaController · TeamStandingController
+    │                 PlayerStandingController · StandingHistoryController
+    └── out/persistence · out/cache · out/client (2단계)
+```
+
+**집계 규칙은 `StandingCalculator` 도메인 객체에 둔다.** 승/패/득실차/승률/순위 산정은
+리그 규정이지 SQL 이 아니다. 순수 자바로 두면 단위 테스트로 동점 시나리오를 전부 검증할 수 있다.
+
+`settings.gradle` 에 `"module:domain:esports"` 추가, 컴포지션 루트에 모듈 의존과 집계 스케줄러 배치.
+
+---
+
+## 5. DB 테이블 설계
+
+마이그레이션: `lol-db-schema/db/migration/V31__add_esports_record_tables.sql`
 (현재 최신은 `V30__idempotent_guards.sql`)
 
 > `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
 > 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
 
-### 3.1 ERD
+> ✅ 아래 DDL 전체(테이블 13 · 인덱스 6 · 뷰 1)는 로컬 `postgres:16-alpine` 에서
+> `BEGIN … ROLLBACK` 트랜잭션으로 실제 실행해 문법·제약·의존 순서를 검증했다.
 
-```
-esports_league (lck)
-   └─< esports_season (lck_2026)
-          ├─< esports_team_standing >─ esports_team
-          └─< esports_player_standing >─ esports_player
-                                       └─ esports_team
-```
-
-### 3.2 DDL
+### 5.1 마스터
 
 ```sql
--- =============================================================
--- V31: e스포츠 리그 기록 (팀/선수 순위표) 테이블 추가
--- =============================================================
--- 외부 e스포츠 API 를 주기 수집해 스냅샷으로 적재한다.
--- 순위표는 "시즌 × 대진(bracket)" 단위로 전량 교체(upsert)되는 성격이라
--- 이력 테이블을 따로 두지 않고 현재 상태만 유지한다.
--- =============================================================
-
--- 상위 리그 (LCK, LPL, LEC …)
+-- 상위 리그 (LCK, LPL …)
 CREATE TABLE IF NOT EXISTS esports_league (
-    league_id         VARCHAR(50)  NOT NULL,      -- 'lck'
-    game_code         VARCHAR(20)  NOT NULL,      -- 'lol'
-    name              VARCHAR(200) NOT NULL,
-    name_acronym      VARCHAR(50),
-    name_eng          VARCHAR(200),
-    image_url         VARCHAR(500),
-    dark_image_url    VARCHAR(500),
-    sort_order        INTEGER      NOT NULL DEFAULT 0,
-    active            BOOLEAN      NOT NULL DEFAULT TRUE,
-    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    league_id      VARCHAR(50)  NOT NULL,      -- 'lck'
+    game_code      VARCHAR(20)  NOT NULL DEFAULT 'lol',
+    name           VARCHAR(200) NOT NULL,
+    name_acronym   VARCHAR(50),
+    image_url      VARCHAR(500),
+    dark_image_url VARCHAR(500),
+    sort_order     INTEGER      NOT NULL DEFAULT 0,
+    active         BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_league PRIMARY KEY (league_id)
 );
 
--- 시즌 (= 하위 리그. 'lck_2026', 'lck_2026_event')
+-- 시즌 (= 하위 리그. 'lck_2026')
 CREATE TABLE IF NOT EXISTS esports_season (
-    season_id         VARCHAR(80)  NOT NULL,      -- 'lck_2026'
-    league_id         VARCHAR(50)  NOT NULL,      -- FK -> esports_league
-    name              VARCHAR(200) NOT NULL,      -- '2026 LoL 챔피언스 코리아'
-    name_acronym      VARCHAR(80),                -- '2026 LCK'
-    year              INTEGER,
-    start_date        DATE,
-    end_date          DATE,
-    sort_order        INTEGER      NOT NULL DEFAULT 0,
-    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    season_id      VARCHAR(80)  NOT NULL,
+    league_id      VARCHAR(50)  NOT NULL,
+    name           VARCHAR(200) NOT NULL,
+    name_acronym   VARCHAR(80),
+    year           INTEGER,
+    start_date     DATE,
+    end_date       DATE,
+    match_format   VARCHAR(20)  NOT NULL DEFAULT 'BO3',  -- 집계 검증용
+    sort_order     INTEGER      NOT NULL DEFAULT 0,
+    created_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_season PRIMARY KEY (season_id),
-    CONSTRAINT fk_esports_season_league
-        FOREIGN KEY (league_id) REFERENCES esports_league (league_id)
+    CONSTRAINT fk_esports_season_league FOREIGN KEY (league_id)
+        REFERENCES esports_league (league_id)
 );
-CREATE INDEX IF NOT EXISTS idx_esports_season_league
-    ON esports_season (league_id, sort_order DESC);
 
--- 팀 (시즌 무관 마스터)
+-- 팀 마스터. team_code 는 관리자가 손으로 입력할 때 쓰는 사람이 읽는 키
 CREATE TABLE IF NOT EXISTS esports_team (
-    team_id           VARCHAR(30)  NOT NULL,      -- 'R1040'
-    game_code         VARCHAR(20)  NOT NULL,
-    name              VARCHAR(100) NOT NULL,      -- 'T1'
-    name_acronym      VARCHAR(50),
-    name_eng          VARCHAR(100),
-    name_eng_acronym  VARCHAR(20),                -- 'GEN'
-    image_url         VARCHAR(500),
-    dark_image_url    VARCHAR(500),
-    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT pk_esports_team PRIMARY KEY (team_id)
+    team_id          VARCHAR(30)  NOT NULL,     -- 내부 ID
+    team_code        VARCHAR(20)  NOT NULL,     -- 'T1', 'GEN' ← 입력 편의 키
+    game_code        VARCHAR(20)  NOT NULL DEFAULT 'lol',
+    name             VARCHAR(100) NOT NULL,
+    name_eng         VARCHAR(100),
+    image_url        VARCHAR(500),
+    dark_image_url   VARCHAR(500),
+    created_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_team PRIMARY KEY (team_id),
+    CONSTRAINT uk_esports_team_code UNIQUE (game_code, team_code)
 );
 
--- 선수 (시즌 무관 마스터)
+-- 선수 마스터
 CREATE TABLE IF NOT EXISTS esports_player (
-    player_id         VARCHAR(30)  NOT NULL,      -- '10785'
-    game_code         VARCHAR(20)  NOT NULL,
-    nick_name         VARCHAR(100) NOT NULL,      -- 'Duro'
-    name              VARCHAR(100),               -- '주민규'
-    name_eng          VARCHAR(100),               -- 'Joo Min-kyu'
-    image_url         VARCHAR(500),
-    created_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at        TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT pk_esports_player PRIMARY KEY (player_id)
+    player_id   VARCHAR(30)  NOT NULL,
+    nick_name   VARCHAR(100) NOT NULL,          -- 'Duro' ← 입력 편의 키
+    name        VARCHAR(100),
+    name_eng    VARCHAR(100),
+    image_url   VARCHAR(500),
+    created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_player PRIMARY KEY (player_id),
+    CONSTRAINT uk_esports_player_nick UNIQUE (nick_name)
 );
 
--- 팀 순위표
+-- 시즌 로스터 (선수 소속은 시즌마다 바뀐다)
+CREATE TABLE IF NOT EXISTS esports_roster (
+    season_id  VARCHAR(80) NOT NULL,
+    player_id  VARCHAR(30) NOT NULL,
+    team_id    VARCHAR(30) NOT NULL,
+    position   VARCHAR(10) NOT NULL,            -- TOP|JGL|MID|AD|SPT
+    joined_at  DATE,
+    left_at    DATE,
+    CONSTRAINT pk_esports_roster PRIMARY KEY (season_id, player_id, team_id),
+    CONSTRAINT fk_roster_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_roster_player FOREIGN KEY (player_id) REFERENCES esports_player (player_id),
+    CONSTRAINT fk_roster_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+);
+
+-- 시즌 그룹 편성 (LEGEND / RISE). 그룹 없는 리그는 행을 넣지 않는다
+CREATE TABLE IF NOT EXISTS esports_season_group (
+    season_id   VARCHAR(80) NOT NULL,
+    bracket     VARCHAR(30) NOT NULL,
+    team_id     VARCHAR(30) NOT NULL,
+    group_name  VARCHAR(50) NOT NULL,           -- 'LEGEND' | 'RISE'
+    group_sort  INTEGER     NOT NULL DEFAULT 0,
+    CONSTRAINT pk_esports_season_group PRIMARY KEY (season_id, bracket, team_id),
+    CONSTRAINT fk_sg_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_sg_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+);
+```
+
+### 5.2 원장 (관리자 입력)
+
+```sql
+-- 매치 (Bo3 한 판). 관리자가 넣는 최소 단위
+CREATE TABLE IF NOT EXISTS esports_match (
+    match_id      BIGSERIAL    NOT NULL,
+    season_id     VARCHAR(80)  NOT NULL,
+    bracket       VARCHAR(30)  NOT NULL DEFAULT 'REGULAR',
+    round_no      INTEGER,                       -- 1~2R
+    week_no       INTEGER,                       -- 순위 추이의 x축
+    match_date    DATE         NOT NULL,
+    home_team_id  VARCHAR(30)  NOT NULL,
+    away_team_id  VARCHAR(30)  NOT NULL,
+    home_score    SMALLINT     NOT NULL,         -- 세트 승수 (2)
+    away_score    SMALLINT     NOT NULL,         -- 세트 승수 (1)
+    status        VARCHAR(20)  NOT NULL DEFAULT 'COMPLETED',  -- SCHEDULED|COMPLETED|CANCELED
+    external_ref  VARCHAR(60),                   -- 공식 API match id (중복 적재 방지)
+    created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_match PRIMARY KEY (match_id),
+    CONSTRAINT uk_esports_match UNIQUE (season_id, bracket, match_date, home_team_id, away_team_id),
+    CONSTRAINT ck_esports_match_teams CHECK (home_team_id <> away_team_id),
+    CONSTRAINT ck_esports_match_score CHECK (home_score >= 0 AND away_score >= 0),
+    CONSTRAINT fk_match_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_match_home   FOREIGN KEY (home_team_id) REFERENCES esports_team (team_id),
+    CONSTRAINT fk_match_away   FOREIGN KEY (away_team_id) REFERENCES esports_team (team_id)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_esports_match_ext
+    ON esports_match (external_ref) WHERE external_ref IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_esports_match_season
+    ON esports_match (season_id, bracket, status, week_no);
+
+-- 세트 (매치 안의 한 게임)
+CREATE TABLE IF NOT EXISTS esports_game (
+    game_id         BIGSERIAL   NOT NULL,
+    match_id        BIGINT      NOT NULL,
+    game_no         SMALLINT    NOT NULL,        -- 1,2,3
+    winner_team_id  VARCHAR(30) NOT NULL,
+    duration_sec    INTEGER,                     -- 경기 시간
+    external_ref    VARCHAR(60),                 -- livestats gameId
+    created_at      TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_game PRIMARY KEY (game_id),
+    CONSTRAINT uk_esports_game UNIQUE (match_id, game_no),
+    CONSTRAINT fk_game_match  FOREIGN KEY (match_id) REFERENCES esports_match (match_id) ON DELETE CASCADE,
+    CONSTRAINT fk_game_winner FOREIGN KEY (winner_team_id) REFERENCES esports_team (team_id)
+);
+
+-- 세트별 선수 기록 (2단계 — 일괄 적재 대상)
+CREATE TABLE IF NOT EXISTS esports_game_player (
+    game_id    BIGINT      NOT NULL,
+    player_id  VARCHAR(30) NOT NULL,
+    team_id    VARCHAR(30) NOT NULL,
+    position   VARCHAR(10) NOT NULL,
+    kills      SMALLINT    NOT NULL DEFAULT 0,
+    deaths     SMALLINT    NOT NULL DEFAULT 0,
+    assists    SMALLINT    NOT NULL DEFAULT 0,
+    champion   VARCHAR(40),
+    CONSTRAINT pk_esports_game_player PRIMARY KEY (game_id, player_id),
+    CONSTRAINT fk_gp_game   FOREIGN KEY (game_id)   REFERENCES esports_game (game_id) ON DELETE CASCADE,
+    CONSTRAINT fk_gp_player FOREIGN KEY (player_id) REFERENCES esports_player (player_id),
+    CONSTRAINT fk_gp_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+);
+CREATE INDEX IF NOT EXISTS idx_gp_player ON esports_game_player (player_id);
+
+-- POG 선정 (LCK 자체 제도. 어떤 외부 API 에도 없어 입력이 유일한 경로)
+CREATE TABLE IF NOT EXISTS esports_pog (
+    match_id   BIGINT      NOT NULL,
+    game_no    SMALLINT    NOT NULL,
+    player_id  VARCHAR(30) NOT NULL,
+    point      SMALLINT    NOT NULL DEFAULT 100,
+    CONSTRAINT pk_esports_pog PRIMARY KEY (match_id, game_no),
+    CONSTRAINT fk_pog_match  FOREIGN KEY (match_id)  REFERENCES esports_match (match_id) ON DELETE CASCADE,
+    CONSTRAINT fk_pog_player FOREIGN KEY (player_id) REFERENCES esports_player (player_id)
+);
+```
+
+### 5.3 집계 산출물
+
+원장에서 재계산되는 캐시성 테이블. **언제든 `DELETE` 후 재생성해도 무손실**이다.
+
+```sql
 CREATE TABLE IF NOT EXISTS esports_team_standing (
     season_id         VARCHAR(80)  NOT NULL,
-    bracket           VARCHAR(30)  NOT NULL,      -- 'split' | 'regular' | 'playoff'
+    bracket           VARCHAR(30)  NOT NULL,
     team_id           VARCHAR(30)  NOT NULL,
-    bracket_name      VARCHAR(100),               -- '정규시즌 1-2R'
-    group_name        VARCHAR(50),                -- 'LEGEND' | 'RISE' | NULL
+    group_name        VARCHAR(50),
     group_sort        INTEGER      NOT NULL DEFAULT 0,
-    team_rank         INTEGER      NOT NULL,      -- rank 는 예약어라 team_rank
+    team_rank         INTEGER      NOT NULL,
     wins              INTEGER      NOT NULL DEFAULT 0,   -- 매치 승
-    loses             INTEGER      NOT NULL DEFAULT 0,   -- 매치 패
+    loses             INTEGER      NOT NULL DEFAULT 0,
     draws             INTEGER      NOT NULL DEFAULT 0,
-    score             INTEGER      NOT NULL DEFAULT 0,   -- 세트 득실차
-    win_rate          NUMERIC(5,4) NOT NULL DEFAULT 0,   -- 0.7300
-    kda               NUMERIC(6,2) NOT NULL DEFAULT 0,
-    kills             INTEGER      NOT NULL DEFAULT 0,
-    deaths            INTEGER      NOT NULL DEFAULT 0,
-    assists           INTEGER      NOT NULL DEFAULT 0,
-    first_kill_rate   NUMERIC(6,2),
-    first_tower_rate  NUMERIC(6,2),
-    first_baron_rate  NUMERIC(6,2),
-    synced_at         TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    set_wins          INTEGER      NOT NULL DEFAULT 0,   -- 세트 승
+    set_loses         INTEGER      NOT NULL DEFAULT 0,
+    score             INTEGER      NOT NULL DEFAULT 0,   -- set_wins - set_loses
+    win_rate          NUMERIC(5,4) NOT NULL DEFAULT 0,
+    kda               NUMERIC(6,2),                      -- 2단계 전까지 NULL
+    kills             INTEGER,
+    deaths            INTEGER,
+    assists           INTEGER,
+    aggregated_at     TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_team_standing PRIMARY KEY (season_id, bracket, team_id),
     CONSTRAINT fk_ets_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
     CONSTRAINT fk_ets_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
@@ -301,29 +428,26 @@ CREATE TABLE IF NOT EXISTS esports_team_standing (
 CREATE INDEX IF NOT EXISTS idx_ets_season_group_rank
     ON esports_team_standing (season_id, bracket, group_sort, team_rank);
 
--- 선수 순위표
 CREATE TABLE IF NOT EXISTS esports_player_standing (
-    season_id           VARCHAR(80)  NOT NULL,
-    bracket             VARCHAR(30)  NOT NULL,
-    player_id           VARCHAR(30)  NOT NULL,
-    team_id             VARCHAR(30)  NOT NULL,
-    position            VARCHAR(10)  NOT NULL,    -- TOP|JGL|MID|AD|SPT
-    group_name          VARCHAR(50),
-    player_rank         INTEGER      NOT NULL,
-    wins                INTEGER      NOT NULL DEFAULT 0,
-    loses               INTEGER      NOT NULL DEFAULT 0,
-    draws               INTEGER      NOT NULL DEFAULT 0,
-    score               INTEGER      NOT NULL DEFAULT 0,
-    win_rate            NUMERIC(5,4) NOT NULL DEFAULT 0,
-    pog_point           INTEGER      NOT NULL DEFAULT 0,
-    kda                 NUMERIC(6,2) NOT NULL DEFAULT 0,
-    kills               INTEGER      NOT NULL DEFAULT 0,
-    deaths              INTEGER      NOT NULL DEFAULT 0,
-    assists             INTEGER      NOT NULL DEFAULT 0,
-    kill_involve_rate   NUMERIC(5,4) NOT NULL DEFAULT 0,
-    compete_set_count   INTEGER      NOT NULL DEFAULT 0,
-    compete_times       INTEGER      NOT NULL DEFAULT 0,  -- 총 출전 시간(분)
-    synced_at           TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    season_id          VARCHAR(80)  NOT NULL,
+    bracket            VARCHAR(30)  NOT NULL,
+    player_id          VARCHAR(30)  NOT NULL,
+    team_id            VARCHAR(30)  NOT NULL,
+    position           VARCHAR(10)  NOT NULL,
+    player_rank        INTEGER      NOT NULL,
+    wins               INTEGER      NOT NULL DEFAULT 0,  -- 출전 매치 기준
+    loses              INTEGER      NOT NULL DEFAULT 0,
+    score              INTEGER      NOT NULL DEFAULT 0,
+    win_rate           NUMERIC(5,4) NOT NULL DEFAULT 0,
+    pog_point          INTEGER      NOT NULL DEFAULT 0,
+    kda                NUMERIC(6,2) NOT NULL DEFAULT 0,
+    kills              INTEGER      NOT NULL DEFAULT 0,
+    deaths             INTEGER      NOT NULL DEFAULT 0,
+    assists            INTEGER      NOT NULL DEFAULT 0,
+    kill_involve_rate  NUMERIC(5,4) NOT NULL DEFAULT 0,
+    compete_set_count  INTEGER      NOT NULL DEFAULT 0,
+    compete_times      INTEGER      NOT NULL DEFAULT 0,  -- 총 출전 시간(초)
+    aggregated_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     CONSTRAINT pk_esports_player_standing PRIMARY KEY (season_id, bracket, player_id),
     CONSTRAINT fk_eps_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
     CONSTRAINT fk_eps_player FOREIGN KEY (player_id) REFERENCES esports_player (player_id),
@@ -331,143 +455,179 @@ CREATE TABLE IF NOT EXISTS esports_player_standing (
 );
 CREATE INDEX IF NOT EXISTS idx_eps_season_position_rank
     ON esports_player_standing (season_id, bracket, position, player_rank);
-CREATE INDEX IF NOT EXISTS idx_eps_season_rank
-    ON esports_player_standing (season_id, bracket, player_rank);
 ```
 
-`COMMENT ON TABLE/COLUMN` 은 `V2`/`V25` 컨벤션대로 마이그레이션 하단에 함께 작성한다.
+### 5.4 이력 (순위 추이)
 
-### 3.3 설계 근거
+```sql
+-- 집계 시점마다 팀 순위 1벌을 남긴다. 주차별 추이 그래프의 재료
+CREATE TABLE IF NOT EXISTS esports_standing_snapshot (
+    season_id     VARCHAR(80)  NOT NULL,
+    bracket       VARCHAR(30)  NOT NULL,
+    snapshot_date DATE         NOT NULL,
+    week_no       INTEGER,
+    team_id       VARCHAR(30)  NOT NULL,
+    team_rank     INTEGER      NOT NULL,
+    wins          INTEGER      NOT NULL,
+    loses         INTEGER      NOT NULL,
+    score         INTEGER      NOT NULL,
+    win_rate      NUMERIC(5,4) NOT NULL,
+    created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_esports_standing_snapshot
+        PRIMARY KEY (season_id, bracket, snapshot_date, team_id),
+    CONSTRAINT fk_ess_season FOREIGN KEY (season_id) REFERENCES esports_season (season_id),
+    CONSTRAINT fk_ess_team   FOREIGN KEY (team_id)   REFERENCES esports_team (team_id)
+);
+CREATE INDEX IF NOT EXISTS idx_ess_team_timeline
+    ON esports_standing_snapshot (season_id, bracket, team_id, snapshot_date);
+```
+
+`snapshot_date` 를 PK 에 넣어 **하루 여러 번 집계해도 그날 행은 덮어써진다**(`ON CONFLICT DO UPDATE`).
+시즌당 10팀 × 약 70일 = 700행이라 부담이 없다.
+
+### 5.5 설계 근거
 
 | 결정 | 근거 |
 |---|---|
-| `rank` → `team_rank` / `player_rank` | PostgreSQL 에서 `rank` 자체는 컬럼명으로 쓸 수 있지만 윈도우 함수 `rank()` 와 겹쳐 쿼리 가독성이 나쁘고, MySQL 8+ 에서는 예약어다. 이식성·가독성 목적 |
-| PK = `(season_id, bracket, team_id)` | 순위표는 시즌×대진 단위 스냅샷. 서로게이트 키 없이 자연키로 멱등 upsert |
-| 순위(`team_rank`)를 저장 | 원본이 리그 규정(득실차·상대전적 등)으로 계산한 값. 서버가 재계산하면 규정 차이로 어긋남 |
-| `win_rate` `NUMERIC(5,4)` | 원본이 소수(0.73)로 내려옴. 표시 시 ×100. 부동소수 누적 오차 회피 |
-| 팀/선수 마스터 분리 | 시즌마다 반복되는 이름·로고를 정규화. 로고 URL 변경이 한 곳에서 반영 |
-| `first_*_rate` NULL 허용 | 선수 순위엔 없고 리그에 따라 미제공. 화면 기본 컬럼도 아님 |
-| 이력 테이블 없음 | "현재 순위표"만 보여주는 화면. 추후 순위 추이가 필요하면 `esports_team_standing_history` 를 별도 추가 |
+| 순위표를 뷰가 아닌 테이블로 | 순위 산정에 동점 규칙(득실차 → 상대전적)이 얽혀 SQL 한 방으로 안 나온다. 도메인 계산 결과를 적재하는 편이 테스트·디버깅에 낫다 |
+| `set_wins`/`set_loses` 를 별도 보관 | `score` 만 두면 "20승 10패"와 "10승 0패"가 구분되지 않는다. 동점 규칙에서 세트 승률이 필요할 수 있다 |
+| `esports_roster` 분리 | 선수 소속은 시즌·이적으로 바뀐다. 순위표에 team_id 를 박아두면 과거 시즌 조회 시 소속이 틀어진다 |
+| `team_code` / `nick_name` UNIQUE | 관리자 페이지가 없어 사람이 SQL 로 입력한다. `'T1'`, `'Duro'` 로 참조할 수 있어야 입력이 견딘다 |
+| `external_ref` + 부분 UNIQUE | 나중에 외부 수집을 붙일 때 중복 INSERT 를 DB 가 막는다. 수기 입력 행은 NULL 이라 제약에 안 걸린다 |
+| `rank` → `team_rank`/`player_rank` | PostgreSQL 에서 `rank` 자체는 컬럼명으로 쓸 수 있지만 윈도우 함수 `rank()` 와 겹쳐 가독성이 나쁘고 MySQL 8+ 에서는 예약어다 |
+| `compete_times` 초 단위 | 원본은 분으로 보이나 `duration_sec` 합에서 유도하므로 초로 통일하고 표시할 때 환산 |
 
 ---
 
-## 4. REST API 설계
+## 6. 관리자 입력 절차 (관리자 페이지 없이)
 
-베이스 경로 `/api/v1/esports`. 응답은 프로젝트 컨벤션대로 `ApiResponse<T>` 래핑, 조회는 200.
-봉투 형태는 `{ "result": "SUCCESS" | "ERROR", "data": …, "errorMessage": … }` 이며 아래 예시의 `data` 안쪽만
-엔드포인트별로 달라진다.
+입력은 SQL 로 한다. **사람이 읽는 키로 참조**할 수 있게 헬퍼 뷰를 함께 만든다.
 
-### 4.1 엔드포인트 요약
+### 6.1 매치 1건 입력 (1단계 — 이것만으로 팀 순위표가 완성된다)
+
+```sql
+-- 2026-01-14 T1 2:1 GEN
+WITH m AS (
+    INSERT INTO esports_match
+        (season_id, bracket, round_no, week_no, match_date,
+         home_team_id, away_team_id, home_score, away_score)
+    SELECT 'lck_2026', 'REGULAR', 1, 1, DATE '2026-01-14',
+           h.team_id, a.team_id, 2, 1
+      FROM esports_team h, esports_team a
+     WHERE h.team_code = 'T1' AND a.team_code = 'GEN'
+    RETURNING match_id
+)
+INSERT INTO esports_game (match_id, game_no, winner_team_id, duration_sec)
+SELECT m.match_id, g.game_no, t.team_id, g.duration_sec
+  FROM m,
+       (VALUES (1, 'T1', 1834), (2, 'GEN', 2102), (3, 'T1', 1657))
+           AS g(game_no, winner_code, duration_sec)
+  JOIN esports_team t ON t.team_code = g.winner_code;
+```
+
+### 6.2 입력 검증 뷰
+
+수기 입력은 반드시 틀린다. **집계 전에 정합성을 걸러내는 뷰**를 함께 둔다.
+
+```sql
+CREATE OR REPLACE VIEW v_esports_match_invalid AS
+SELECT m.match_id, m.match_date,
+       h.team_code AS home, a.team_code AS away,
+       m.home_score, m.away_score,
+       COUNT(g.game_id)                                          AS game_rows,
+       COUNT(*) FILTER (WHERE g.winner_team_id = m.home_team_id)  AS home_game_wins,
+       COUNT(*) FILTER (WHERE g.winner_team_id = m.away_team_id)  AS away_game_wins
+  FROM esports_match m
+  JOIN esports_team h ON h.team_id = m.home_team_id
+  JOIN esports_team a ON a.team_id = m.away_team_id
+  LEFT JOIN esports_game g ON g.match_id = m.match_id
+ WHERE m.status = 'COMPLETED'
+ GROUP BY m.match_id, m.match_date, h.team_code, a.team_code, m.home_score, m.away_score
+HAVING COUNT(g.game_id) <> m.home_score + m.away_score
+    OR COUNT(*) FILTER (WHERE g.winner_team_id = m.home_team_id) <> m.home_score
+    OR COUNT(*) FILTER (WHERE g.winner_team_id = m.away_team_id) <> m.away_score;
+```
+
+`SELECT * FROM v_esports_match_invalid;` 가 **0행이면 집계해도 안전**하다.
+같은 검증을 `Match` 도메인의 `validateGameConsistency()` 가 애플리케이션 쪽에서도 수행한다.
+
+> ✅ **실행 검증 완료.** 로컬 Postgres 16 에서 DDL → 마스터 시드 → §6.1 매치 입력 → 검증 뷰 →
+> 집계 산식까지 한 트랜잭션으로 돌려 확인했다(전부 `ROLLBACK`).
+>
+> | 단계 | 기대 | 실제 |
+> |---|---|---|
+> | 정상 입력 후 검증 뷰 | 0행 | **0행** |
+> | 집계 산식 (T1 2:1 GEN) | T1 1승 0패 `+1` / GEN 0승 1패 `-1` | **일치** (득실 합 0 = 제로섬) |
+> | 오입력 주입 (`2:1` 인데 세트 2개) | 뷰가 검출 | **1행 검출** (`game_rows=2`, `away_game_wins=0`) |
+>
+> 관리자가 매치 결과와 세트 수를 어긋나게 넣는 가장 흔한 실수를 뷰가 집계 전에 잡아낸다.
+
+### 6.3 집계 실행
+
+```
+POST /api/v1/admin/esports/seasons/{seasonId}/aggregate   (관리자 권한)
+```
+
+또는 스케줄러가 주기 실행한다(§7). 입력 → 검증 뷰 확인 → 집계 → 화면 반영 순.
+
+---
+
+## 7. 집계 로직
+
+`StandingCalculator` (순수 도메인)가 원장을 받아 순위표를 만든다.
+
+| 지표 | 산식 |
+|---|---|
+| `wins` / `loses` | 팀이 속한 `COMPLETED` 매치에서 `home_score > away_score` 판정 |
+| `set_wins` / `set_loses` | `esports_game.winner_team_id` 집계 |
+| `score` | `set_wins - set_loses` (시즌 전체 합이 0이어야 정합 — §1.4) |
+| `win_rate` | `wins / (wins + loses)`, 분모 0이면 0 |
+| `team_rank` | 정렬: ① 승수 desc ② 득실차 desc ③ 상대전적 ④ 세트 승률 desc. **그룹별로 매긴다** |
+| 팀 `kills/deaths/assists` | `esports_game_player` 를 팀·세트로 합산 |
+| 팀 `kda` | `(kills + assists) / max(deaths, 1)` |
+| 선수 `compete_set_count` | 선수의 `esports_game_player` 행 수 |
+| 선수 `compete_times` | 출전 세트의 `duration_sec` 합 |
+| 선수 `kill_involve_rate` | `(선수 kills + assists) / 소속팀 같은 세트 총 kills` |
+| 선수 `pog_point` | `esports_pog.point` 합 |
+| 선수 `wins/loses/score` | **선수가 1세트 이상 출전한 매치**만 대상으로 팀 결과 집계 |
+
+- **동점 규칙은 `TieBreakRule` 로 분리**한다. 리그마다 다르고 규정이 바뀌므로 정렬 비교자를 갈아끼울 수 있어야 한다.
+- 집계는 **시즌 × 대진 단위 전량 재계산**. 110매치 규모라 부분 갱신을 최적화할 이유가 없고, 전량 재계산이 훨씬 안전하다.
+- 집계 성공 시 ① 순위표 upsert ② 스냅샷 upsert(오늘 날짜) ③ 캐시 evict 를 한 트랜잭션에서 처리한다.
+- 2단계 전(선수 기록 미적재)에는 팀 `kda/kills/deaths/assists` 를 `NULL` 로 두고, API 는 해당 필드를 `null` 로 내려 화면이 `-` 를 표시하게 한다.
+
+```java
+// 컴포지션 루트
+@Scheduled(cron = "0 0/30 * * * *")   // 30분마다 활성 시즌 재집계
+public void aggregateActiveSeasons() { ... }
+```
+
+관리자가 새벽에 입력해도 30분 안에 반영된다. 즉시 반영이 필요하면 §6.3 의 수동 엔드포인트를 쓴다.
+
+---
+
+## 8. REST API 설계
+
+베이스 `/api/v1/esports`. 봉투는 `{ "result": "SUCCESS" | "ERROR", "data": …, "errorMessage": … }`.
 
 | Method | Path | 설명 |
 |---|---|---|
-| GET | `/api/v1/esports/leagues` | 리그 목록 (리그 필터) |
-| GET | `/api/v1/esports/leagues/{leagueId}/seasons` | 시즌 목록 (시즌 필터) |
+| GET | `/api/v1/esports/leagues` | 리그 목록 |
+| GET | `/api/v1/esports/leagues/{leagueId}/seasons` | 시즌 목록 |
 | GET | `/api/v1/esports/seasons/{seasonId}/team-standings` | 팀 순위표 |
 | GET | `/api/v1/esports/seasons/{seasonId}/player-standings` | 선수 순위표 |
+| GET | `/api/v1/esports/seasons/{seasonId}/standing-history` | **순위 추이 (신규)** |
+| POST | `/api/v1/admin/esports/seasons/{seasonId}/aggregate` | 집계 트리거 (관리자) |
 
-> 화면 진입 시 리그·시즌 필터가 먼저 필요하므로 메타 2개를 분리했다.
-> 첫 화면 왕복을 줄이려면 `/leagues?includeSeasons=true` 로 한 번에 내려주는 옵션을 둘 수 있다.
+### 8.1 팀 순위표
 
-### 4.2 `GET /api/v1/esports/leagues`
+`GET /seasons/lck_2026/team-standings?bracket=REGULAR&sort=RANK&order=ASC`
 
-```json
-{
-  "result": "SUCCESS",
-  "data": [
-    {
-      "leagueId": "lck",
-      "name": "LoL 챔피언스 코리아",
-      "nameAcronym": "LCK",
-      "imageUrl": "https://.../lck.png",
-      "darkImageUrl": "https://.../lck_black.png",
-      "latestSeasonId": "lck_2026"
-    }
-  ]
-}
-```
-
-`latestSeasonId` 는 리그 전환 시 곧바로 이동할 시즌. 프런트가 시즌 목록을 기다리지 않아도 된다.
-
-### 4.3 `GET /api/v1/esports/leagues/{leagueId}/seasons`
-
-```json
-{
-  "result": "SUCCESS",
-  "data": [
-    { "seasonId": "lck_2026", "name": "2026 LoL 챔피언스 코리아",
-      "nameAcronym": "2026 LCK", "year": 2026,
-      "startDate": "2026-01-14", "endDate": null, "brackets": [
-        { "bracket": "SPLIT", "bracketName": "정규시즌 1-2R" }
-      ] }
-  ]
-}
-```
-
-### 4.4 `GET /api/v1/esports/seasons/{seasonId}/team-standings`
-
-**Query**
-
-| 파라미터 | 타입 | 기본 | 설명 |
-|---|---|---|---|
-| `bracket` | enum | 시즌의 최신 대진 | `SPLIT` \| `REGULAR` \| `PLAYOFF` |
-| `sort` | enum | `RANK` | `RANK`,`WINS`,`LOSES`,`SCORE`,`WIN_RATE`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS` |
-| `order` | enum | `ASC`(RANK) / `DESC`(그 외) | `ASC` \| `DESC` |
-
-**응답** — 그룹(LEGEND/RISE)별로 묶어서 내려준다. 그룹이 없는 리그는 `groupName: null` 인 단일 그룹.
-
-```json
-{
-  "result": "SUCCESS",
-  "data": {
-    "seasonId": "lck_2026",
-    "bracket": "SPLIT",
-    "bracketName": "정규시즌 1-2R",
-    "sort": "RANK",
-    "order": "ASC",
-    "syncedAt": "2026-08-11T04:10:00",
-    "groups": [
-      {
-        "groupName": "LEGEND",
-        "groupSort": 1,
-        "standings": [
-          {
-            "rank": 1,
-            "team": {
-              "teamId": "R1040", "name": "T1", "nameAcronym": "T1",
-              "nameEngAcronym": "T1",
-              "imageUrl": "https://.../t1.png", "darkImageUrl": "https://.../t1_black.png"
-            },
-            "wins": 16, "loses": 6, "draws": 0,
-            "score": 21,
-            "winRate": 0.73,
-            "kda": 3.92, "kills": 822, "deaths": 673, "assists": 1819,
-            "firstKillRate": 1.25, "firstTowerRate": 1.25, "firstBaronRate": 1.1
-          }
-        ]
-      },
-      { "groupName": "RISE", "groupSort": 2, "standings": [] }
-    ]
-  }
-}
-```
-
-- `winRate` 는 **소수 그대로** 내려주고 백분율 변환은 프런트가 한다 (표시 포맷은 UI 책임).
-- `sort` 가 `RANK` 가 아니면 그룹을 유지한 채 그룹 내부만 재정렬한다.
-  전체 통합 정렬이 필요하면 `groupBy=NONE` 옵션을 추가하는 방향으로 확장.
-
-### 4.5 `GET /api/v1/esports/seasons/{seasonId}/player-standings`
-
-**Query**
-
-| 파라미터 | 타입 | 기본 | 설명 |
-|---|---|---|---|
-| `bracket` | enum | 시즌의 최신 대진 | `SPLIT` \| `REGULAR` \| `PLAYOFF` |
-| `position` | enum | `ALL` | `ALL`,`TOP`,`JGL`,`MID`,`AD`,`SPT` |
-| `sort` | enum | `RANK` | `RANK`,`POG_POINT`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS`,`KILL_INVOLVE_RATE`,`COMPETE_SET_COUNT`,`COMPETE_TIMES` |
-| `order` | enum | `ASC`(RANK) / `DESC`(그 외) | `ASC` \| `DESC` |
-
-**응답**
+| 파라미터 | 기본 | 값 |
+|---|---|---|
+| `bracket` | 시즌 최신 대진 | `REGULAR` \| `PLAYOFF` |
+| `sort` | `RANK` | `RANK`,`WINS`,`LOSES`,`SCORE`,`WIN_RATE`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS` |
+| `order` | `RANK`→`ASC`, 그 외 `DESC` | `ASC` \| `DESC` |
 
 ```json
 {
@@ -475,135 +635,147 @@ CREATE INDEX IF NOT EXISTS idx_eps_season_rank
   "data": {
     "seasonId": "lck_2026",
     "bracket": "REGULAR",
-    "position": "ALL",
-    "sort": "RANK",
-    "order": "ASC",
-    "syncedAt": "2026-08-11T04:10:00",
-    "standings": [
+    "sort": "RANK", "order": "ASC",
+    "aggregatedAt": "2026-08-11T04:30:00",
+    "groups": [
       {
-        "rank": 1,
-        "player": {
-          "playerId": "10785", "nickName": "Duro",
-          "name": "주민규", "nameEng": "Joo Min-kyu",
-          "imageUrl": "https://.../duro.png"
-        },
-        "team": {
-          "teamId": "R479", "name": "젠지", "nameEngAcronym": "GEN",
-          "imageUrl": "https://.../gen.png", "darkImageUrl": "https://.../gen_black.png"
-        },
-        "position": "SPT",
-        "pogPoint": 0,
-        "kda": 6.52, "kills": 40, "deaths": 84, "assists": 508,
-        "killInvolveRate": 0.77,
-        "competeSetCount": 41,
-        "competeTimes": 1279,
-        "wins": 14, "loses": 4, "draws": 0, "score": 19, "winRate": 0.78
+        "groupName": "LEGEND", "groupSort": 1,
+        "standings": [
+          {
+            "rank": 1,
+            "team": { "teamId": "R1040", "teamCode": "T1", "name": "T1",
+                      "imageUrl": "https://.../t1.png", "darkImageUrl": "https://.../t1_black.png" },
+            "wins": 16, "loses": 6, "draws": 0,
+            "setWins": 34, "setLoses": 13, "score": 21,
+            "winRate": 0.7273,
+            "kda": null, "kills": null, "deaths": null, "assists": null
+          }
+        ]
       }
     ]
   }
 }
 ```
 
-- **페이징 없음.** 시즌당 선수 60~70명, 팀 10팀 규모라 전량 반환이 화면 요구(정렬 시 전체 재정렬)에 맞다.
-  다른 리그를 붙여 규모가 커지면 그때 `PageResponse` 로 전환.
-- `position=ALL` 이 아니면 필터 후 **순위를 재계산하지 않고** 원본 `rank` 를 유지한다 (네이버 동작과 동일).
-  포지션 내 순번이 필요하면 프런트에서 인덱스로 표시.
+`kda`/`kills`/`deaths`/`assists` 가 `null` 인 것은 **2단계 미완**을 뜻한다(에러가 아니다).
 
-### 4.6 에러
+### 8.2 선수 순위표
 
-| 상황 | 코드 | 처리 |
-|---|---|---|
-| 없는 `seasonId` | 404 | `EsportsSeasonNotFoundException` → 공통 핸들러 |
-| 잘못된 `sort`/`position`/`bracket` | 400 | enum 바인딩 실패 → 공통 핸들러 |
-| 순위 데이터 미수집 (시즌 개막 전) | 200 | 빈 `groups`/`standings` + `syncedAt: null` |
+`GET /seasons/lck_2026/player-standings?bracket=REGULAR&position=ALL&sort=RANK`
 
----
+`position`: `ALL`,`TOP`,`JGL`,`MID`,`AD`,`SPT` ·
+`sort`: `RANK`,`POG_POINT`,`KDA`,`KILLS`,`DEATHS`,`ASSISTS`,`KILL_INVOLVE_RATE`,`COMPETE_SET_COUNT`,`COMPETE_TIMES`
 
-## 5. 정렬 · 필터 처리 위치
-
-시즌 × 대진 단위 데이터가 최대 70행이므로, **DB 에서는 `(season_id, bracket)` 기준 flat 리스트를
-`rank` 순으로 한 번만 읽어 캐시**하고, `position` 필터와 `sort` 는 애플리케이션에서 처리한다.
-
-| 항목 | 처리 위치 | 이유 |
-|---|---|---|
-| `seasonId` + `bracket` | DB (PK 선행 컬럼) | 캐시 미스 시 기본 조회 단위. 인덱스 선두 |
-| `position` 필터 | 애플리케이션 (캐시된 리스트) | 캐시 키 폭발 방지 (포지션 6종 × 정렬 9종 = 54키). 70행 필터는 무시할 비용 |
-| `sort` | 애플리케이션 `Comparator` (화이트리스트 enum) | 위와 동일. 정렬 키를 enum 으로 강제해 매직 스트링 차단 |
-| 그룹 묶음 | 애플리케이션 | `groupSort` 순 flat 결과를 ReadModel 조립 시 `LinkedHashMap` 으로 그룹핑 |
-
-> 리그를 확장해 한 응답이 수백~수천 행이 되면 이 판단을 뒤집어야 한다.
-> 그때는 `position` 필터를 `idx_eps_season_position_rank` 로, `sort` 를 QueryDSL `ORDER BY` 로 내리고
-> 캐시는 페이지 단위로 잘게 쪼갠다.
-
-정렬 키는 도메인 enum 으로 정의하고, 각 키에서 `Comparator` 를 얻는 매핑은 애플리케이션에 둔다.
-
-```java
-public enum TeamStandingSort {
-    RANK, WINS, LOSES, SCORE, WIN_RATE, KDA, KILLS, DEATHS, ASSISTS
+```json
+{
+  "result": "SUCCESS",
+  "data": {
+    "seasonId": "lck_2026", "bracket": "REGULAR", "position": "ALL",
+    "aggregatedAt": "2026-08-11T04:30:00",
+    "standings": [
+      {
+        "rank": 1,
+        "player": { "playerId": "10785", "nickName": "Duro", "name": "주민규" },
+        "team": { "teamId": "R479", "teamCode": "GEN", "name": "젠지" },
+        "position": "SPT",
+        "pogPoint": 0,
+        "kda": 6.52, "kills": 40, "deaths": 84, "assists": 508,
+        "killInvolveRate": 0.77,
+        "competeSetCount": 41, "competeTimes": 76740,
+        "wins": 14, "loses": 4, "score": 19, "winRate": 0.7778
+      }
+    ]
+  }
 }
 ```
 
----
+- 페이징 없음 — 시즌당 선수 60~70명, 팀 10팀.
+- `position` 필터 시 원본 `rank` 를 유지한다(재계산하지 않음). 네이버 동작과 동일.
 
-## 6. 캐시 전략
+### 8.3 순위 추이 (신규)
 
-| 키 | 값 | TTL | 무효화 |
-|---|---|---|---|
-| `esports:leagues` | 리그 목록 | 24h | 수집 성공 시 evict |
-| `esports:seasons:{leagueId}` | 시즌 목록 | 24h | 수집 성공 시 evict |
-| `esports:standings:team:{seasonId}:{bracket}` | 팀 순위 flat 리스트 | 10m | 수집 성공 시 evict |
-| `esports:standings:player:{seasonId}:{bracket}` | 선수 순위 flat 리스트 | 10m | 수집 성공 시 evict |
+`GET /seasons/lck_2026/standing-history?bracket=REGULAR&teamCode=T1&from=2026-01-01`
 
-- **정렬/포지션 필터는 캐시 키에 넣지 않는다** (§5 참고). 캐시에는 `rank` 순 flat 리스트만 담는다.
-- 값 클래스는 `GenericJackson2JsonRedisSerializer` 로 직렬화된다. **캐시 대상 ReadModel 에
-  파생 boolean getter 를 추가하면 기존 엔트리 역직렬화가 전량 실패**하므로, 파생 getter 에는 `@JsonIgnore` 를 붙이고
-  클래스 이동·리네임 시에는 배포 때 해당 키를 flush 한다.
-
----
-
-## 7. 수집 (Sync)
-
-```java
-// 경기 시간대(KST 18~23시) 10분 간격 — 경기 종료 직후 순위 반영
-@Scheduled(cron = "0 0/10 18-23 * * *")
-public void syncActiveSeasons() { ... }
-
-// 새벽 전체 정합성 보정 (메타 + 종료 직전 시즌 포함)
-@Scheduled(cron = "0 30 4 * * *")
-public void syncAll() { ... }
+```json
+{
+  "result": "SUCCESS",
+  "data": {
+    "seasonId": "lck_2026", "bracket": "REGULAR",
+    "series": [
+      { "team": { "teamCode": "T1", "name": "T1" },
+        "points": [
+          { "date": "2026-01-19", "weekNo": 1, "rank": 3, "wins": 1, "loses": 1, "score": 0 },
+          { "date": "2026-01-26", "weekNo": 2, "rank": 1, "wins": 3, "loses": 1, "score": 4 }
+        ] }
+    ]
+  }
+}
 ```
 
-- 컴포지션 루트(`module/app/application/src/main/java/.../config/EsportsRecordSyncScheduler.java`)에 배치.
-  `CacheScheduler` 와 동일 패턴 (`@Scheduled` + UseCase 호출).
-- 수집 단위: **시즌 × 대진**. `EsportsRecordSyncService` 가
-  ① 메타(리그·시즌) 동기화 → ② 활성 시즌 목록 산출 → ③ 팀/선수 순위 upsert → ④ 캐시 evict 순으로 진행.
-- **upsert 는 전량 교체가 아니라 `INSERT ... ON CONFLICT DO UPDATE`** 로 처리한다.
-  선수 로스터 변동으로 사라진 행은 `synced_at` 이 갱신되지 않으므로, 수집 종료 시
-  `DELETE ... WHERE season_id=? AND bracket=? AND synced_at < ?` 로 정리한다.
-- 외부 호출 실패 시 기존 데이터를 유지하고 로그만 남긴다 (순위표는 stale 해도 화면이 비는 것보다 낫다).
-- 활성 시즌 판별: `esports_season.end_date IS NULL OR end_date >= today()`. 종료된 시즌은 수집 대상에서 제외.
+`teamCode` 를 생략하면 전 팀 시리즈를 내려준다(10팀 × 주차 → 그래프 한 장).
+
+### 8.4 에러
+
+| 상황 | 코드 |
+|---|---|
+| 없는 `seasonId` | 404 `EsportsSeasonNotFoundException` |
+| 잘못된 `sort`/`position`/`bracket` | 400 (enum 바인딩 실패) |
+| 집계 전 (원장은 있으나 순위표 없음) | 200 + 빈 `groups` + `aggregatedAt: null` |
+| 집계 트리거 시 원장 정합성 위반 | 409 + 위반 매치 목록 (§6.2 뷰 결과) |
 
 ---
 
-## 8. 구현 순서
+## 9. 정렬 · 캐시
 
-1. `module/domain/esports` 모듈 생성 + `settings.gradle` / 컴포지션 루트 등록 (빈 컨트롤러로 부팅 확인)
-2. `V31` 마이그레이션 작성 + 엔티티/JPA 리포지토리
-3. 도메인 모델 + 포트 정의, `ArchUnit` 아키텍처 테스트 추가 (다른 컨텍스트와 동일 규칙)
-4. 수집 어댑터(`EsportsRecordClientAdapter`) + `EsportsRecordSyncService` — 여기서 **데이터 출처 확정 필요**
-5. 조회 서비스 + 컨트롤러 + ReadModel
-6. Redis 캐시 어댑터 연결
-7. RestDocs 테스트 → `./gradlew :module:infra:api:asciidoctor`
-8. 스케줄러 등록 및 운영 프로파일 cron 조정
+시즌 × 대진이 최대 70행이므로 DB 에서는 `rank` 순 flat 리스트를 한 번만 읽어 캐시하고,
+`position` 필터와 `sort` 는 애플리케이션 `Comparator`(화이트리스트 enum)로 처리한다.
+정렬 9종 × 포지션 6종 = 54개로 캐시 키를 쪼개는 것보다 낫다.
 
----
-
-## 9. 열린 이슈
-
-| # | 이슈 | 필요한 결정 |
+| 키 | TTL | 무효화 |
 |---|---|---|
-| 1 | **데이터 출처** | 네이버 API 상시 의존 여부. 약관 확인 필요. 대안은 LoL Esports 공식 피드 또는 자체 집계 |
-| 2 | 지원 리그 범위 | LCK 만인지, LPL/LEC/LTA 까지인지. 후자면 수집량·캐시 키 설계는 그대로지만 페이징 검토 필요 |
-| 3 | 플레이오프 대진 | 현재 확인된 bracket 은 `split`(팀) / `regular`(선수) 뿐. 플레이오프 진행 시 값 추가 확인 필요 |
-| 4 | 선수 프로필 이미지 | 네이버 응답의 이미지 URL 을 그대로 저장·노출할지, 자체 CDN 으로 미러링할지 |
-| 5 | 순위 추이 | 주차별 순위 변동 그래프가 요구사항이면 `*_history` 테이블을 초기 설계에 포함하는 편이 낫다 |
+| `esports:leagues` / `esports:seasons:{leagueId}` | 24h | 마스터 변경 시 |
+| `esports:standings:team:{seasonId}:{bracket}` | 1h | **집계 성공 시 evict** |
+| `esports:standings:player:{seasonId}:{bracket}` | 1h | 〃 |
+| `esports:history:{seasonId}:{bracket}` | 6h | 〃 |
+
+집계가 명시적 무효화 지점이라 TTL 을 v1(10분)보다 길게 잡아도 안전하다.
+
+> 값 클래스는 `GenericJackson2JsonRedisSerializer` 로 직렬화된다. **캐시 대상 ReadModel 에
+> 파생 boolean getter 를 추가하면 기존 엔트리 역직렬화가 전량 실패**하므로 파생 getter 에는 `@JsonIgnore` 를 붙이고,
+> 클래스 이동·리네임 시에는 배포 때 해당 키를 flush 한다.
+
+---
+
+## 10. 구현 순서
+
+**1단계 — 팀 순위표 (외부 의존 0)**
+
+1. `module/domain/esports` 생성 + `settings.gradle` / 컴포지션 루트 등록
+2. `V31` 마이그레이션 (마스터 + 원장 + 집계 + 이력 + 검증 뷰)
+3. 마스터 시드: LCK 10팀 · 시즌 · 그룹 편성 (`V32` seed 또는 운영 SQL)
+4. `StandingCalculator` + `TieBreakRule` **단위 테스트 먼저** — 동점 3팀 시나리오(§1.4)를 재현
+5. 집계 서비스 + 관리자 트리거 엔드포인트 + 스케줄러
+6. 조회 API 3종(리그·시즌·팀 순위표) + Redis 캐시
+7. 매치 원장 110건 입력 → 검증 뷰 0행 확인 → 집계 → 네이버 화면과 순위 대조
+
+**2단계 — 선수 순위표 · 팀 KDA**
+
+8. `esports_game_player` 일괄 적재 경로 (CSV 임포트 또는 livestats 수집 어댑터)
+9. POG 입력 + 선수 집계 로직
+10. 선수 순위표 API + 순위 추이 API
+11. RestDocs → `./gradlew :module:infra:api:asciidoctor`
+
+7번의 **네이버 화면 대조가 1단계의 완료 기준**이다. 순위·승패·득실차가 일치하면 집계 규칙이 맞은 것이다.
+
+---
+
+## 11. 열린 이슈
+
+| # | 이슈 | 결정 필요 사항 |
+|---|---|---|
+| 1 | **원장 초기 적재** | 공식 API `getCompletedEvents` 로 1회 임포트 — **권장**. LCK 매치가 실제로 내려오는 것과 팀코드·`gameWins`·주차(`blockName`)까지 확보되는 것을 확인했다. 단 ① 응답이 전 리그 혼합 최근 300건이라 **시즌 전체를 긁으려면 페이징 확인 필요** ② §2.1 의 미플레이 세트 함정 처리 필수 |
+| 2 | 동점 규칙 | LCK 규정의 정확한 타이브레이커 순서(득실차 → 상대전적 → ?) 확인 필요. `TieBreakRule` 구현 전 확정해야 함 |
+| 3 | POG 산정 단위 | 원본 POG 총합 9,000점(=90회)이 총 매치 110건과 맞지 않음. 세트당인지 매치당인지, 미집계 구간이 있는지 확인 필요 |
+| 4 | 선수 기록 확보 경로 | livestats 수집(세트 245회 호출·파싱) vs CSV 일괄 적재 vs 2단계 자체 보류 |
+| 5 | 지원 리그 범위 | LCK 만인지, LPL/LEC 까지인지. 확장 시 원장 입력 부담이 리그 수에 비례한다 |
+| 6 | 관리자 인증 | `/api/v1/admin/**` 권한 체계. 기존 member 컨텍스트의 역할을 재사용할지 |

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -227,11 +227,25 @@ module/domain/esports/src/main/java/com/example/lolserver/esports/
 
 ## 6. DB 테이블 설계
 
-마이그레이션: `lol-db-schema/db/migration/V31__add_esports_record_tables.sql`
-(현재 최신은 `V30__idempotent_guards.sql`)
+마이그레이션: `lol-db-schema/db/migration/V33__add_esports_record_tables.sql`
 
 > `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
 > 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
+>
+> **버전 번호는 착수 시점에 다시 확인한다.** 서브모듈은 이 리포와 독립적으로 진행되므로
+> 문서에 적힌 번호가 그사이 선점될 수 있다 (`V31`·`V32` 가 커뮤니티 작업으로 이미 사용됐다).
+> `ls db/migration | sort -V | tail -1` 로 최신을 확인하고 그다음 번호를 쓴다.
+
+| 서브모듈 최신 (`origin/main` `23723cc`) | 내용 |
+|---|---|
+| `V30__idempotent_guards.sql` | 멱등 가드 |
+| `V31__add_community_bookmark.sql` | 커뮤니티 북마크 |
+| `V32__add_community_category_tables.sql` | 커뮤니티 게시판 그룹·카테고리 |
+| **`V33__add_esports_record_tables.sql`** | **본 설계 (신규)** |
+
+V32 가 `community_board_group` 에 `ESPORTS` 그룹과 `LCK`·`LCK_NEWS` 카테고리를 시드하지만,
+그쪽은 **커뮤니티 게시판 분류**이고 본 설계의 `esports_*` 는 **기록 데이터**다.
+접두사가 달라 테이블·인덱스 충돌은 없다.
 
 ### 6.1 마스터
 
@@ -1120,7 +1134,8 @@ DDL → 시즌 구조 시드 → 매치 입력 → 검증 뷰 3종 → 집계 �
 **1단계 — 팀 순위표 (외부 의존 0)**
 
 1. `module/domain/esports` 생성 + `settings.gradle` / 컴포지션 루트 등록
-2. `V31` 마이그레이션 (마스터 + 로스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)
+2. `V33` 마이그레이션 (마스터 + 로스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)
+   — 착수 시점에 서브모듈 최신 번호를 다시 확인할 것 (§6 머리말)
 3. 마스터 시드: LCK 10팀 · `lck_2026` 시즌 · **스테이지 5개**(§8.1)
 4. **`StandingCalculator` · `GroupSplitter` · `TieBreakRule` 단위 테스트 먼저**
    — 동률 3팀(§2.4), 공동 순위, 누적 합산(§2.2) 시나리오를 재현

--- a/docs/esports-record-design.md
+++ b/docs/esports-record-design.md
@@ -227,30 +227,41 @@ module/domain/esports/src/main/java/com/example/lolserver/esports/
 
 ## 6. DB 테이블 설계
 
-마이그레이션: **`lol-db-schema/db/migration/V33__add_esports_record_tables.sql` — 작성 완료**
-(`lol-db-schema` 브랜치 `feature/MP-XXX-esports-record`)
+마이그레이션: **`lol-db-schema/db/migration/V34__add_esports_record_tables.sql` — 작성 완료**
+(`lol-db-schema` 브랜치 `fix/MP-XXX-esports-migration-v34`)
 
 > `lol-db-schema` 는 **git 서브모듈**(`padosol/lol-db-schema`)이다. 마이그레이션은 그쪽 리포에 별도 PR 로 올리고,
 > 본 리포에서는 서브모듈 포인터 갱신 커밋을 함께 넣는다.
 >
 > **머지 순서 주의**: 현재 포인터는 서브모듈의 *브랜치* 커밋을 가리킨다.
 > 이 브랜치를 `develop` 에 머지하기 전에 서브모듈 PR 을 먼저 머지하고 포인터를 `main` 커밋으로 옮겨야 한다.
->
-> **버전 번호는 머지 직전에 다시 확인한다.** 서브모듈은 이 리포와 독립적으로 진행되므로
-> 그사이 `V33` 이 선점될 수 있다 (`V31`·`V32` 가 커뮤니티 작업으로 이미 그렇게 됐다).
-> `ls db/migration | sort -V | tail -1` 로 최신을 확인하고, 선점됐다면 파일명을 리넘버링한다
-> (서브모듈 README 의 Flyway checksum 가드 참고).
 
-| 서브모듈 최신 (`origin/main` `23723cc`) | 내용 |
+| 서브모듈 (`origin/main` + 본 PR) | 내용 |
 |---|---|
 | `V30__idempotent_guards.sql` | 멱등 가드 |
 | `V31__add_community_bookmark.sql` | 커뮤니티 북마크 |
 | `V32__add_community_category_tables.sql` | 커뮤니티 게시판 그룹·카테고리 |
-| **`V33__add_esports_record_tables.sql`** | **본 설계 (신규)** |
+| `V33__community_post_category_id.sql` | `community_post.category` → `category_id` FK 전환 |
+| **`V34__add_esports_record_tables.sql`** | **본 설계 (신규)** |
 
 V32 가 `community_board_group` 에 `ESPORTS` 그룹과 `LCK`·`LCK_NEWS` 카테고리를 시드하지만,
 그쪽은 **커뮤니티 게시판 분류**이고 본 설계의 `esports_*` 는 **기록 데이터**다.
-접두사가 달라 테이블·인덱스 충돌은 없다.
+접두사가 달라 테이블·인덱스 충돌은 없다. V33 과도 참조 관계가 없어 적용 순서가 결과를 바꾸지 않는다.
+
+#### 번호 충돌 사고 기록
+
+초판은 이 파일을 `V31` 로 잡았고, 이후 `V33` 으로 두 번 옮겼다. 두 번째는 실제 사고였다 —
+커뮤니티 `V33__community_post_category_id` 와 e스포츠 `V33__add_esports_record_tables` 가
+**둘 다 `main` 에 머지됐다.** 파일명이 달라 git 은 충돌을 내지 않았지만 Flyway 는 같은 버전이
+둘 이상이면 적용 전에 전체를 거부하므로, 그 시점의 `main` 으로는 어떤 환경도 부팅되지 않았다.
+
+git 이 막지 못하는 종류의 충돌이다. **두 PR 이 각자 `main` 기준으로 다음 번호를 집으면 반드시 재발한다.**
+번호를 예약해두는 것으로는 막을 수 없고(예약 자체가 다른 브랜치에 안 보인다), 머지 직전 육안 확인도
+이번처럼 놓친다. CI 가드가 유일하게 확실한 방법이다:
+
+```bash
+ls db/migration | sed -n 's/^\(V[0-9]*\)__.*/\1/p' | sort | uniq -d | grep . && exit 1
+```
 
 ### 6.1 마스터
 
@@ -704,13 +715,14 @@ SELECT 'lck_2026', team_id, 1, 'worlds_2026', 1 FROM esports_team WHERE team_cod
 
 ### 6.9 스키마 검증
 
-`V33` 을 단독으로 실행한 것이 아니라 **빈 DB 에 `V1`~`V33` 전체 마이그레이션 체인을 순서대로 적용**해
+`V34` 를 단독으로 실행한 것이 아니라 **빈 DB 에 `V1`~`V34` 전체 마이그레이션 체인을 순서대로 적용**해
 실제 스키마 위에 올라가는지 확인했다 (로컬 `postgres:16-alpine`). 이후 제약 동작은 `ROLLBACK` 으로 검증했다.
 
 | 확인 | 기대 | 실제 |
 |---|---|---|
-| V1~V33 전체 체인 적용 | 29개 파일 전부 성공 | **전부 성공** |
-| V33 이 만든 객체 | 테이블 15 · 인덱스 11 · 뷰 4 | **일치** (테이블 코멘트 누락 0) |
+| 버전 번호 중복 | 0 | **0** (리네임 전에는 `V33` 이 2개) |
+| V1~V34 전체 체인 적용 | 30개 파일 전부 성공 | **전부 성공** |
+| V34 가 만든 객체 | 테이블 15 · 인덱스 11 · 뷰 4 | **일치** (테이블 코멘트 누락 0) |
 | `btree_gist` 확장 | 생성됨 | **생성됨** |
 | `ck_roster_period` (`left_at <= joined_at`) | CHECK 가 거부 | **거부** |
 | `ck_esports_stage_format` (정의 밖 포맷) | CHECK 가 거부 | **거부** |
@@ -1144,8 +1156,8 @@ DDL → 시즌 구조 시드 → 매치 입력 → 검증 뷰 3종 → 집계 �
 **1단계 — 팀 순위표 (외부 의존 0)**
 
 1. `module/domain/esports` 생성 + `settings.gradle` / 컴포지션 루트 등록
-2. ~~`V33` 마이그레이션 (마스터 + 로스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)~~
-   **완료** — V1~V33 전체 체인을 빈 DB 에 적용해 검증했다 (§6.9)
+2. ~~`V34` 마이그레이션 (마스터 + 로스터 + 스테이지 + 원장 + 집계 + 이력 + 검증 뷰)~~
+   **완료** — V1~V34 전체 체인을 빈 DB 에 적용해 검증했다 (§6.9)
 3. 마스터 시드: LCK 10팀 · `lck_2026` 시즌 · **스테이지 5개**(§8.1)
 4. **`StandingCalculator` · `GroupSplitter` · `TieBreakRule` 단위 테스트 먼저**
    — 동률 3팀(§2.4), 공동 순위, 누적 합산(§2.2) 시나리오를 재현


### PR DESCRIPTION
## 관련 이슈
- MP-XXX (Linear 이슈 미발행 — 브랜치·커밋의 `MP-XXX` 는 자리표시자다. 번호 확정 시 교체)

## 변경 유형
- [x] docs

## 변경 사항
| 파일 | 변경 |
|---|---|
| `docs/esports-record-design.md` | 신규 (설계서 1,231줄) |
| `lol-db-schema` | 서브모듈 포인터 `133d1526` → `445cb3ba` |

자바 코드 변경은 없다.

서브모듈 포인터는 두 가지를 함께 가져온다.
1. **최신화** — develop 의 포인터가 `133d1526` 이라 커뮤니티 `V31`(북마크)·`V32`(카테고리)·`V33`(`category_id` 전환)을 가리키지 못하는 상태였다. develop 에는 카테고리 API 코드가 이미 머지돼 있다.
2. 신규 `V34__add_esports_record_tables.sql` (padosol/lol-db-schema#9)

설계서 본문은 12장 구성이다 — 시즌 구조 / 수기 입력 정책 / 모듈 구조 / DB 15테이블 / 집계 로직 / 관리자 입력 절차 / REST API / 정렬·캐시 / 구현 순서 / 열린 이슈.

## 변경 이유
네이버 게임 e스포츠 "기록" 페이지와 동일한 화면(팀 순위표 · 선수 순위표 · 순위 추이)을 제공하기 위한 스키마·API 설계다.

**설계 요지 세 가지.**

**원장이 유일한 진실원천이고 순위표는 집계 산출물이다.** `esports_team_standing` 은 언제든 지우고 다시 만들 수 있다. 순위표를 그대로 적재하면 집계 규칙 버그를 고쳐도 과거 데이터를 바로잡을 방법이 없다.

**`standing_key` — 순위표는 여러 스테이지의 누적 합산이다.** 실제 데이터로 확인했다. 2026 LCK 에서 T1 의 1-2R 성적이 14승 4패, 3-5R 이 2승 2패인데 화면의 정규시즌 순위표는 16승 6패다. 스테이지별로 순위표를 따로 만들면 이 화면을 그릴 수 없다. 같은 `standing_key` 를 가진 스테이지들을 하나의 순위표로 누적한다.

**로스터를 계약 기간(`joined_at ~ left_at`)으로 모델링한다.** 선수 테이블에 `team_id` 를 두면 이적 시 과거 소속이 사라진다. 기간 모델이면 커리어가 보존되고 시즌 로스터가 입력 없이 유도된다. 기간 겹침은 `EXCLUDE USING gist` 로 DB 가 막는다 (`btree_gist` 확장 필요).

**데이터는 외부 API 없이 수기로 입력한다.** 네이버가 쓰는 엔드포인트는 공개 API 가 아니고, Riot 도 e스포츠 기록 API 를 공개하지 않는다. 1단계(팀 순위표)는 시즌당 매치 165회 입력으로 완결되고, 3단계(선수 기록)는 약 4,000행이라 수기로는 현실성이 없어 범위에서 뺐다.

## 테스트
- [ ] 단위 테스트 통과 (`./gradlew test`)
- [ ] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
- [ ] 로컬 빌드 확인 (`./gradlew build`)

위 3개는 **해당 없음** — 이 PR 의 diff 에 자바·Gradle 파일이 하나도 없다. 대신 아래를 실행했다.

- `./gradlew compileJava compileTestJava` — 전 모듈 컴파일 통과 (서브모듈 포인터 이동이 빌드에 영향 없음을 확인)
- **스키마 검증**: 빈 DB 에 `V1`~`V34` 30개 파일을 순서대로 전부 적용해 통과. 버전 번호 중복 0. `esports_*` 15테이블 · 33인덱스 · 4뷰 생성, `btree_gist` 적재, 테이블 COMMENT 누락 0
- **제약 동작**: 로스터 기간 겹침(`ex_roster_no_overlap`) · 기간 역전(`ck_roster_period`) · BRACKET 에 `standing_key`(`ck_stage_bracket_no_standing`) · 정의 밖 format(`ck_esports_stage_format`) — 4종 모두 정상 거부
- **기능**: 이적 3건(GEN→T1→GEN 재계약)에서 시즌 로스터가 입력 없이 유도되고, Bo3 인데 3:0 인 오입력을 `v_esports_match_invalid` 가 검출하며, 승패·득실 집계가 기대값(T1 1승 +1 / GEN 1승1패 +1 / HLE 1패 -2)과 일치

상세는 padosol/lol-db-schema#9 및 설계서 §6.9 · §8.5 참고.

## 리뷰 포인트
> **⚠️ 머지 순서 — padosol/lol-db-schema#9 가 먼저 머지되어야 한다.**
> 현재 서브모듈 포인터가 그쪽 *브랜치* 커밋(`445cb3ba`)을 가리킨다. 이 상태로 머지되면 develop 이 사라질 수 있는 커밋을 가리키게 된다. #9 머지 후 포인터를 `main` 커밋으로 옮기고 draft 를 해제할 것.

- **마이그레이션 번호가 `V33` → `V34` 로 바뀌었다.** 먼저 머지된 lol-db-schema#7(e스포츠)과 #8(커뮤니티 `category_id`)이 **둘 다 `V33`** 이라 서브모듈 `main` 이 Flyway 를 못 돌리는 상태가 됐다. 파일명이 달라 git 은 충돌을 내지 않았다. #9 가 e스포츠 쪽을 `V34` 로 옮겨 해소한다. 사고 경위와 CI 가드 제안을 설계서 6장에 기록했다
- **`btree_gist` 확장 권한** — 운영 DB 롤에 없으면 마이그레이션이 실패한다. 의도적으로 조용히 넘어가지 않게 했고, 대안 경로는 #9 에 정리했다
- **서브모듈 포인터 최신화**를 이 PR 에 포함한 것이 맞는지. develop 의 포인터가 자기 코드보다 뒤처져 있던 걸 함께 고친 것인데, 별도 PR 이 낫다면 `b0f74ed6` 만 떼어낼 수 있다
- **§12 열린 이슈 11건 중 #1 동점 규칙이 1단계 착수를 막는다.** T1·HLE·GEN 이 모두 16승 6패였고 득실차로만 갈렸다. 공동 순위도 실제로 발생한다(3-5R GEN·T1 공동 2위). LCK 규정의 타이브레이커 순서 확정이 필요하다
- **Linear 이슈가 아직 없다.** 브랜치·커밋의 `MP-XXX` 는 자리표시자다
