### PR TITLE
feat: MP-XXX 패치 버전에 Data Dragon 데이터 버전 분리 저장

### DIFF
--- a/module/app/application/src/main/resources/db/seed/season-local.sql
+++ b/module/app/application/src/main/resources/db/seed/season-local.sql
@@ -8,8 +8,10 @@ VALUES (16, '2025 Season 2', '2025-05-01', NULL, now())
 ON CONFLICT (season_value) DO NOTHING;
 
 -- 패치 버전 16.10 ~ 16.14 (시즌 16 소속)
-INSERT INTO patch_version (version_value, season_id, created_at)
-SELECT v.version_value, s.season_id, now()
+-- patch_version_data 는 Data Dragon 정적 데이터 버전이다. 패치 버전에 마지막 자리를
+-- 붙인 형태(16.14 -> 16.14.1)라 로컬에서는 그대로 파생시켜 넣는다.
+INSERT INTO patch_version (version_value, patch_version_data, season_id, created_at)
+SELECT v.version_value, v.version_value || '.1', s.season_id, now()
 FROM season s
 CROSS JOIN (VALUES
     ('16.10'),
@@ -20,3 +22,13 @@ CROSS JOIN (VALUES
 ) AS v(version_value)
 WHERE s.season_value = 16
 ON CONFLICT (version_value) DO NOTHING;
+
+-- 이미 patch_version 행이 있는 로컬 DB 백필.
+-- 위 INSERT 는 ON CONFLICT DO NOTHING 이라 기존 행의 새 컬럼을 채우지 못한다.
+-- 운영 DB 는 값을 지어내지 않기 위해 마이그레이션(V35)에서 백필을 하지 않으므로,
+-- 이 스크립트를 읽는 local 프로파일에서만 채워진다.
+-- 2자리(x.y) 행만 대상으로 삼아, 이미 3자리가 들어 있는 행은 건드리지 않는다.
+UPDATE patch_version
+   SET patch_version_data = version_value || '.1'
+ WHERE patch_version_data IS NULL
+   AND version_value ~ '^[0-9]+\.[0-9]+$';

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/in/web/VersionController.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/in/web/VersionController.java
@@ -26,8 +26,8 @@ public class VersionController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<VersionReadModel>>> getAllVersions() {
-        List<VersionReadModel> versions = versionService.getAllVersions();
+    public ResponseEntity<ApiResponse<List<VersionReadModel>>> getRecentVersions() {
+        List<VersionReadModel> versions = versionService.getRecentVersions();
         return ResponseEntity.ok(ApiResponse.success(versions));
     }
 

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/cache/VersionRedisAdapter.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/cache/VersionRedisAdapter.java
@@ -16,7 +16,11 @@ public class VersionRedisAdapter implements VersionCachePort {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    private static final String CACHE_KEY = "version:latest";
+    /**
+     * patchVersionData 가 붙기 전 값이 TTL(24시간) 동안 남아 데이터 버전이 null 로
+     * 내려가는 것을 막으려고 키를 올렸다. 옛 키(version:latest)는 TTL 로 알아서 사라진다.
+     */
+    private static final String CACHE_KEY = "version:latest:v2";
     private static final Duration CACHE_TTL = Duration.ofHours(24);
 
     @Override

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/VersionJpaRepository.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/VersionJpaRepository.java
@@ -1,6 +1,7 @@
 package com.example.lolserver.gamedata.adapter.out.persistence;
 
 import com.example.lolserver.gamedata.adapter.out.persistence.entity.VersionEntity;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -14,6 +15,10 @@ public interface VersionJpaRepository extends JpaRepository<VersionEntity, Long>
     @Query("SELECT v FROM VersionEntity v ORDER BY v.versionId DESC LIMIT 1")
     Optional<VersionEntity> findLatestVersion();
 
+    /**
+     * 최신 버전부터 {@code pageable} 크기만큼 조회한다.
+     * 몇 개를 노출할지는 정책이라 애플리케이션 계층이 정한다.
+     */
     @Query("SELECT v FROM VersionEntity v ORDER BY v.versionId DESC")
-    List<VersionEntity> findAllOrderByVersionIdDesc();
+    List<VersionEntity> findRecentVersions(Pageable pageable);
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/VersionPersistenceAdapter.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/VersionPersistenceAdapter.java
@@ -4,6 +4,7 @@ import com.example.lolserver.gamedata.application.model.readmodel.VersionReadMod
 import com.example.lolserver.gamedata.application.port.out.VersionPersistencePort;
 import com.example.lolserver.gamedata.adapter.out.persistence.mapper.VersionMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -23,8 +24,8 @@ public class VersionPersistenceAdapter implements VersionPersistencePort {
     }
 
     @Override
-    public List<VersionReadModel> findAllVersions() {
-        return versionJpaRepository.findAllOrderByVersionIdDesc()
+    public List<VersionReadModel> findRecentVersions(int limit) {
+        return versionJpaRepository.findRecentVersions(PageRequest.of(0, limit))
                 .stream()
                 .map(versionMapper::entityToReadModel)
                 .toList();

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/entity/VersionEntity.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/entity/VersionEntity.java
@@ -33,11 +33,24 @@ public class VersionEntity {
     @Column(name = "version_value", nullable = false, length = 20)
     private String versionValue;
 
+    /**
+     * Data Dragon 정적 데이터 버전 (예: 16.16.1).
+     * 패치 번호인 {@link #versionValue}(예: 26.16)와 체계가 달라 별도로 들고 있는다.
+     * 이미 쌓인 행은 아직 값이 없을 수 있어 null 을 허용한다.
+     */
+    @Column(name = "patch_version_data", length = 20)
+    private String patchVersionData;
+
     @CreatedDate
     @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     public VersionEntity(String versionValue) {
+        this(versionValue, null);
+    }
+
+    public VersionEntity(String versionValue, String patchVersionData) {
         this.versionValue = versionValue;
+        this.patchVersionData = patchVersionData;
     }
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/entity/VersionEntity.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/entity/VersionEntity.java
@@ -35,7 +35,8 @@ public class VersionEntity {
 
     /**
      * Data Dragon 정적 데이터 버전 (예: 16.16.1).
-     * 패치 번호인 {@link #versionValue}(예: 26.16)와 체계가 달라 별도로 들고 있는다.
+     * {@link #versionValue}(예: 16.16)에 마지막 자리를 붙인 형태이나, 핫픽스 때
+     * 그 자리가 달라질 수 있어 파생하지 않고 저장한다.
      * 이미 쌓인 행은 아직 값이 없을 수 있어 null 을 허용한다.
      */
     @Column(name = "patch_version_data", length = 20)

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/mapper/VersionMapper.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/adapter/out/persistence/mapper/VersionMapper.java
@@ -17,6 +17,7 @@ public interface VersionMapper {
         return new VersionReadModel(
                 entity.getVersionId(),
                 entity.getVersionValue(),
+                entity.getPatchVersionData(),
                 entity.getCreatedAt()
         );
     }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/VersionService.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/VersionService.java
@@ -14,6 +14,12 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class VersionService implements VersionQueryUseCase {
 
+    /**
+     * 버전 목록 노출 상한. 화면에서 고르는 대상은 현재 패치와 직전 패치뿐이라
+     * 시즌이 쌓여도 목록이 길어지지 않도록 여기서 자른다.
+     */
+    private static final int RECENT_VERSION_LIMIT = 2;
+
     private final VersionFinder versionFinder;
     private final VersionPersistencePort versionPersistencePort;
 
@@ -21,8 +27,8 @@ public class VersionService implements VersionQueryUseCase {
         return versionFinder.findLatestVersion();
     }
 
-    public List<VersionReadModel> getAllVersions() {
-        return versionPersistencePort.findAllVersions();
+    public List<VersionReadModel> getRecentVersions() {
+        return versionPersistencePort.findRecentVersions(RECENT_VERSION_LIMIT);
     }
 
     public VersionReadModel getVersionById(Long versionId) {

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/model/readmodel/VersionReadModel.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/model/readmodel/VersionReadModel.java
@@ -4,9 +4,15 @@ import java.time.LocalDateTime;
 
 /**
  * 버전 정보 ReadModel
+ *
+ * @param versionValue     패치 번호 (예: 26.16)
+ * @param patchVersionData Data Dragon 정적 데이터 버전 (예: 16.16.1).
+ *                         챔피언 아이콘 같은 정적 리소스 URL 은 이 값으로 만든다.
+ *                         아직 채워지지 않은 과거 패치는 null.
  */
 public record VersionReadModel(
     Long versionId,
     String versionValue,
+    String patchVersionData,
     LocalDateTime createdAt
 ) {}

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/model/readmodel/VersionReadModel.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/model/readmodel/VersionReadModel.java
@@ -5,7 +5,7 @@ import java.time.LocalDateTime;
 /**
  * 버전 정보 ReadModel
  *
- * @param versionValue     패치 번호 (예: 26.16)
+ * @param versionValue     패치 버전 (예: 16.16)
  * @param patchVersionData Data Dragon 정적 데이터 버전 (예: 16.16.1).
  *                         챔피언 아이콘 같은 정적 리소스 URL 은 이 값으로 만든다.
  *                         아직 채워지지 않은 과거 패치는 null.

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/model/readmodel/VersionReadModel.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/model/readmodel/VersionReadModel.java
@@ -5,7 +5,9 @@ import java.time.LocalDateTime;
 /**
  * 버전 정보 ReadModel
  *
- * @param versionValue     패치 버전 (예: 16.16)
+ * @param versionValue     패치 버전 (예: 16.16). 공식 패치노트는 26.16 으로 표기하지만
+ *                         Riot match API 의 gameVersion 이 16.16.x 라, 전적·통계와 같은
+ *                         축을 쓰려고 16.x 를 저장한다.
  * @param patchVersionData Data Dragon 정적 데이터 버전 (예: 16.16.1).
  *                         챔피언 아이콘 같은 정적 리소스 URL 은 이 값으로 만든다.
  *                         아직 채워지지 않은 과거 패치는 null.

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/port/in/VersionQueryUseCase.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/port/in/VersionQueryUseCase.java
@@ -8,7 +8,10 @@ public interface VersionQueryUseCase {
 
     VersionReadModel getLatestVersion();
 
-    List<VersionReadModel> getAllVersions();
+    /**
+     * 최신 패치부터 노출 상한만큼의 버전 목록을 반환합니다.
+     */
+    List<VersionReadModel> getRecentVersions();
 
     VersionReadModel getVersionById(Long versionId);
 }

--- a/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/port/out/VersionPersistencePort.java
+++ b/module/domain/gamedata/src/main/java/com/example/lolserver/gamedata/application/port/out/VersionPersistencePort.java
@@ -18,12 +18,13 @@ public interface VersionPersistencePort {
     Optional<VersionReadModel> findLatestVersion();
 
     /**
-     * 전체 버전 목록을 조회합니다.
+     * 최근 버전 목록을 조회합니다.
      * 최신 버전이 먼저 오도록 정렬됩니다.
      *
-     * @return 버전 목록
+     * @param limit 조회할 최대 개수
+     * @return 버전 목록 (최대 {@code limit} 개)
      */
-    List<VersionReadModel> findAllVersions();
+    List<VersionReadModel> findRecentVersions(int limit);
 
     /**
      * ID로 버전을 조회합니다.

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/in/web/VersionControllerTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/in/web/VersionControllerTest.java
@@ -40,7 +40,7 @@ class VersionControllerTest extends RestDocsSupport {
     void getLatestVersion_성공() throws Exception {
         // given
         VersionReadModel latestVersion = new VersionReadModel(
-                3L, "26.16", "16.16.1", LocalDateTime.of(2026, 8, 13, 10, 0)
+                3L, "16.16", "16.16.1", LocalDateTime.of(2026, 8, 13, 10, 0)
         );
 
         given(versionService.getLatestVersion()).willReturn(latestVersion);
@@ -63,7 +63,7 @@ class VersionControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.versionId").type(JsonFieldType.NUMBER)
                                         .description("버전 ID"),
                                 fieldWithPath("data.versionValue").type(JsonFieldType.STRING)
-                                        .description("패치 번호 (e.g., 26.16)"),
+                                        .description("패치 버전 (e.g., 16.16)"),
                                 fieldWithPath("data.patchVersionData").type(JsonFieldType.STRING)
                                         .description("Data Dragon 정적 데이터 버전 (e.g., 16.16.1). 챔피언 아이콘 등 리소스 URL 에 사용"),
                                 fieldWithPath("data.createdAt").type(JsonFieldType.STRING)
@@ -77,8 +77,8 @@ class VersionControllerTest extends RestDocsSupport {
     void getRecentVersions_성공() throws Exception {
         // given
         List<VersionReadModel> versions = List.of(
-                new VersionReadModel(3L, "26.16", "16.16.1", LocalDateTime.of(2026, 8, 13, 10, 0)),
-                new VersionReadModel(2L, "26.15", "16.15.1", LocalDateTime.of(2026, 7, 30, 10, 0))
+                new VersionReadModel(3L, "16.16", "16.16.1", LocalDateTime.of(2026, 8, 13, 10, 0)),
+                new VersionReadModel(2L, "16.15", "16.15.1", LocalDateTime.of(2026, 7, 30, 10, 0))
         );
 
         given(versionService.getRecentVersions()).willReturn(versions);
@@ -103,7 +103,7 @@ class VersionControllerTest extends RestDocsSupport {
                                 fieldWithPath("data[].versionId").type(JsonFieldType.NUMBER)
                                         .description("버전 ID"),
                                 fieldWithPath("data[].versionValue").type(JsonFieldType.STRING)
-                                        .description("패치 번호 (e.g., 26.16)"),
+                                        .description("패치 버전 (e.g., 16.16)"),
                                 fieldWithPath("data[].patchVersionData").type(JsonFieldType.STRING)
                                         .description("Data Dragon 정적 데이터 버전 (e.g., 16.16.1). 챔피언 아이콘 등 리소스 URL 에 사용"),
                                 fieldWithPath("data[].createdAt").type(JsonFieldType.STRING)
@@ -118,7 +118,7 @@ class VersionControllerTest extends RestDocsSupport {
         // given
         Long versionId = 1L;
         VersionReadModel version = new VersionReadModel(
-                versionId, "26.15", "16.15.1", LocalDateTime.of(2026, 7, 30, 10, 0)
+                versionId, "16.15", "16.15.1", LocalDateTime.of(2026, 7, 30, 10, 0)
         );
 
         given(versionService.getVersionById(versionId)).willReturn(version);
@@ -144,7 +144,7 @@ class VersionControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.versionId").type(JsonFieldType.NUMBER)
                                         .description("버전 ID"),
                                 fieldWithPath("data.versionValue").type(JsonFieldType.STRING)
-                                        .description("패치 번호 (e.g., 26.15)"),
+                                        .description("패치 버전 (e.g., 16.15)"),
                                 fieldWithPath("data.patchVersionData").type(JsonFieldType.STRING)
                                         .description("Data Dragon 정적 데이터 버전 (e.g., 16.15.1). 챔피언 아이콘 등 리소스 URL 에 사용"),
                                 fieldWithPath("data.createdAt").type(JsonFieldType.STRING)

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/in/web/VersionControllerTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/in/web/VersionControllerTest.java
@@ -40,7 +40,7 @@ class VersionControllerTest extends RestDocsSupport {
     void getLatestVersion_성공() throws Exception {
         // given
         VersionReadModel latestVersion = new VersionReadModel(
-                3L, "14.24.1", LocalDateTime.of(2024, 12, 11, 10, 0)
+                3L, "26.16", "16.16.1", LocalDateTime.of(2026, 8, 13, 10, 0)
         );
 
         given(versionService.getLatestVersion()).willReturn(latestVersion);
@@ -63,24 +63,25 @@ class VersionControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.versionId").type(JsonFieldType.NUMBER)
                                         .description("버전 ID"),
                                 fieldWithPath("data.versionValue").type(JsonFieldType.STRING)
-                                        .description("버전 값 (e.g., 14.24.1)"),
+                                        .description("패치 번호 (e.g., 26.16)"),
+                                fieldWithPath("data.patchVersionData").type(JsonFieldType.STRING)
+                                        .description("Data Dragon 정적 데이터 버전 (e.g., 16.16.1). 챔피언 아이콘 등 리소스 URL 에 사용"),
                                 fieldWithPath("data.createdAt").type(JsonFieldType.STRING)
                                         .description("버전 생성 시간")
                         )
                 ));
     }
 
-    @DisplayName("전체 버전 목록 조회 API")
+    @DisplayName("최근 버전 목록 조회 API")
     @Test
-    void getAllVersions_성공() throws Exception {
+    void getRecentVersions_성공() throws Exception {
         // given
         List<VersionReadModel> versions = List.of(
-                new VersionReadModel(3L, "14.24.1", LocalDateTime.of(2024, 12, 11, 10, 0)),
-                new VersionReadModel(2L, "14.23.1", LocalDateTime.of(2024, 11, 27, 10, 0)),
-                new VersionReadModel(1L, "14.22.1", LocalDateTime.of(2024, 11, 13, 10, 0))
+                new VersionReadModel(3L, "26.16", "16.16.1", LocalDateTime.of(2026, 8, 13, 10, 0)),
+                new VersionReadModel(2L, "26.15", "16.15.1", LocalDateTime.of(2026, 7, 30, 10, 0))
         );
 
-        given(versionService.getAllVersions()).willReturn(versions);
+        given(versionService.getRecentVersions()).willReturn(versions);
 
         // when & then
         mockMvc.perform(
@@ -98,11 +99,13 @@ class VersionControllerTest extends RestDocsSupport {
                                 fieldWithPath("errorMessage").type(JsonFieldType.NULL)
                                         .description("에러 메시지 (정상 응답 시 null)"),
                                 fieldWithPath("data[]").type(JsonFieldType.ARRAY)
-                                        .description("버전 목록 (최신순 정렬)"),
+                                        .description("버전 목록 (최신순 정렬, 최대 2개)"),
                                 fieldWithPath("data[].versionId").type(JsonFieldType.NUMBER)
                                         .description("버전 ID"),
                                 fieldWithPath("data[].versionValue").type(JsonFieldType.STRING)
-                                        .description("버전 값 (e.g., 14.24.1)"),
+                                        .description("패치 번호 (e.g., 26.16)"),
+                                fieldWithPath("data[].patchVersionData").type(JsonFieldType.STRING)
+                                        .description("Data Dragon 정적 데이터 버전 (e.g., 16.16.1). 챔피언 아이콘 등 리소스 URL 에 사용"),
                                 fieldWithPath("data[].createdAt").type(JsonFieldType.STRING)
                                         .description("버전 생성 시간")
                         )
@@ -115,7 +118,7 @@ class VersionControllerTest extends RestDocsSupport {
         // given
         Long versionId = 1L;
         VersionReadModel version = new VersionReadModel(
-                versionId, "14.22.1", LocalDateTime.of(2024, 11, 13, 10, 0)
+                versionId, "26.15", "16.15.1", LocalDateTime.of(2026, 7, 30, 10, 0)
         );
 
         given(versionService.getVersionById(versionId)).willReturn(version);
@@ -141,7 +144,9 @@ class VersionControllerTest extends RestDocsSupport {
                                 fieldWithPath("data.versionId").type(JsonFieldType.NUMBER)
                                         .description("버전 ID"),
                                 fieldWithPath("data.versionValue").type(JsonFieldType.STRING)
-                                        .description("버전 값 (e.g., 14.22.1)"),
+                                        .description("패치 번호 (e.g., 26.15)"),
+                                fieldWithPath("data.patchVersionData").type(JsonFieldType.STRING)
+                                        .description("Data Dragon 정적 데이터 버전 (e.g., 16.15.1). 챔피언 아이콘 등 리소스 URL 에 사용"),
                                 fieldWithPath("data.createdAt").type(JsonFieldType.STRING)
                                         .description("버전 생성 시간")
                         )

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/VersionRedisAdapterTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/VersionRedisAdapterTest.java
@@ -41,7 +41,7 @@ class VersionRedisAdapterTest {
     @Test
     void findLatestVersion_cacheHit_returnsVersion() {
         // given
-        VersionReadModel cachedVersion = new VersionReadModel(1L, "26.16", "16.16.1", LocalDateTime.now());
+        VersionReadModel cachedVersion = new VersionReadModel(1L, "16.16", "16.16.1", LocalDateTime.now());
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(CACHE_KEY)).willReturn(cachedVersion);
@@ -51,7 +51,7 @@ class VersionRedisAdapterTest {
 
         // then
         assertThat(result).isEqualTo(cachedVersion);
-        assertThat(result.versionValue()).isEqualTo("26.16");
+        assertThat(result.versionValue()).isEqualTo("16.16");
         assertThat(result.patchVersionData()).isEqualTo("16.16.1");
         then(redisTemplate).should().opsForValue();
         then(valueOperations).should().get(CACHE_KEY);
@@ -77,7 +77,7 @@ class VersionRedisAdapterTest {
     @Test
     void saveLatestVersion_validData_savesWithTTL() {
         // given
-        VersionReadModel version = new VersionReadModel(1L, "26.16", "16.16.1", LocalDateTime.now());
+        VersionReadModel version = new VersionReadModel(1L, "16.16", "16.16.1", LocalDateTime.now());
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/VersionRedisAdapterTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/cache/VersionRedisAdapterTest.java
@@ -29,7 +29,7 @@ class VersionRedisAdapterTest {
 
     private VersionRedisAdapter adapter;
 
-    private static final String CACHE_KEY = "version:latest";
+    private static final String CACHE_KEY = "version:latest:v2";
     private static final Duration CACHE_TTL = Duration.ofHours(24);
 
     @BeforeEach
@@ -41,7 +41,7 @@ class VersionRedisAdapterTest {
     @Test
     void findLatestVersion_cacheHit_returnsVersion() {
         // given
-        VersionReadModel cachedVersion = new VersionReadModel(1L, "14.24.1", LocalDateTime.now());
+        VersionReadModel cachedVersion = new VersionReadModel(1L, "26.16", "16.16.1", LocalDateTime.now());
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
         given(valueOperations.get(CACHE_KEY)).willReturn(cachedVersion);
@@ -51,7 +51,8 @@ class VersionRedisAdapterTest {
 
         // then
         assertThat(result).isEqualTo(cachedVersion);
-        assertThat(result.versionValue()).isEqualTo("14.24.1");
+        assertThat(result.versionValue()).isEqualTo("26.16");
+        assertThat(result.patchVersionData()).isEqualTo("16.16.1");
         then(redisTemplate).should().opsForValue();
         then(valueOperations).should().get(CACHE_KEY);
     }
@@ -76,7 +77,7 @@ class VersionRedisAdapterTest {
     @Test
     void saveLatestVersion_validData_savesWithTTL() {
         // given
-        VersionReadModel version = new VersionReadModel(1L, "14.24.1", LocalDateTime.now());
+        VersionReadModel version = new VersionReadModel(1L, "26.16", "16.16.1", LocalDateTime.now());
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
 

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/persistence/VersionPersistenceAdapterTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/persistence/VersionPersistenceAdapterTest.java
@@ -56,23 +56,38 @@ class VersionPersistenceAdapterTest extends RepositoryTestBase {
         assertThat(result).isEmpty();
     }
 
-    @DisplayName("전체 버전을 조회하면 최신순으로 정렬된 목록을 반환한다")
+    @DisplayName("최근 버전을 조회하면 limit 개수만큼 최신순으로 반환한다")
     @Test
-    void findAllVersions_multipleVersions_returnsOrderedList() {
+    void findRecentVersions_multipleVersions_returnsLimitedOrderedList() {
         // given
-        VersionEntity v1 = createVersionEntity("14.22.1");
-        VersionEntity v2 = createVersionEntity("14.23.1");
-        VersionEntity v3 = createVersionEntity("14.24.1");
+        VersionEntity v1 = createVersionEntity("26.14", "16.14.1");
+        VersionEntity v2 = createVersionEntity("26.15", "16.15.1");
+        VersionEntity v3 = createVersionEntity("26.16", "16.16.1");
         versionJpaRepository.saveAll(List.of(v1, v2, v3));
 
         // when
-        List<VersionReadModel> result = adapter.findAllVersions();
+        List<VersionReadModel> result = adapter.findRecentVersions(2);
 
         // then
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).versionValue()).isEqualTo("14.24.1");
-        assertThat(result.get(1).versionValue()).isEqualTo("14.23.1");
-        assertThat(result.get(2).versionValue()).isEqualTo("14.22.1");
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).versionValue()).isEqualTo("26.16");
+        assertThat(result.get(0).patchVersionData()).isEqualTo("16.16.1");
+        assertThat(result.get(1).versionValue()).isEqualTo("26.15");
+        assertThat(result.get(1).patchVersionData()).isEqualTo("16.15.1");
+    }
+
+    @DisplayName("데이터 버전이 없는 과거 버전은 null 로 조회된다")
+    @Test
+    void findRecentVersions_missingPatchVersionData_returnsNull() {
+        // given
+        versionJpaRepository.save(createVersionEntity("26.16"));
+
+        // when
+        List<VersionReadModel> result = adapter.findRecentVersions(2);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).patchVersionData()).isNull();
     }
 
     @DisplayName("ID로 버전을 조회하면 해당 버전을 반환한다")
@@ -102,5 +117,9 @@ class VersionPersistenceAdapterTest extends RepositoryTestBase {
 
     private VersionEntity createVersionEntity(String versionValue) {
         return new VersionEntity(versionValue);
+    }
+
+    private VersionEntity createVersionEntity(String versionValue, String patchVersionData) {
+        return new VersionEntity(versionValue, patchVersionData);
     }
 }

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/persistence/VersionPersistenceAdapterTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/persistence/VersionPersistenceAdapterTest.java
@@ -60,9 +60,9 @@ class VersionPersistenceAdapterTest extends RepositoryTestBase {
     @Test
     void findRecentVersions_multipleVersions_returnsLimitedOrderedList() {
         // given
-        VersionEntity v1 = createVersionEntity("26.14", "16.14.1");
-        VersionEntity v2 = createVersionEntity("26.15", "16.15.1");
-        VersionEntity v3 = createVersionEntity("26.16", "16.16.1");
+        VersionEntity v1 = createVersionEntity("16.14", "16.14.1");
+        VersionEntity v2 = createVersionEntity("16.15", "16.15.1");
+        VersionEntity v3 = createVersionEntity("16.16", "16.16.1");
         versionJpaRepository.saveAll(List.of(v1, v2, v3));
 
         // when
@@ -70,9 +70,9 @@ class VersionPersistenceAdapterTest extends RepositoryTestBase {
 
         // then
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).versionValue()).isEqualTo("26.16");
+        assertThat(result.get(0).versionValue()).isEqualTo("16.16");
         assertThat(result.get(0).patchVersionData()).isEqualTo("16.16.1");
-        assertThat(result.get(1).versionValue()).isEqualTo("26.15");
+        assertThat(result.get(1).versionValue()).isEqualTo("16.15");
         assertThat(result.get(1).patchVersionData()).isEqualTo("16.15.1");
     }
 
@@ -80,7 +80,7 @@ class VersionPersistenceAdapterTest extends RepositoryTestBase {
     @Test
     void findRecentVersions_missingPatchVersionData_returnsNull() {
         // given
-        versionJpaRepository.save(createVersionEntity("26.16"));
+        versionJpaRepository.save(createVersionEntity("16.16"));
 
         // when
         List<VersionReadModel> result = adapter.findRecentVersions(2);

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/persistence/mapper/VersionMapperTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/persistence/mapper/VersionMapperTest.java
@@ -19,7 +19,7 @@ class VersionMapperTest {
     void entityToReadModel_validEntity_returnsReadModel() throws Exception {
         // given
         LocalDateTime now = LocalDateTime.now();
-        VersionEntity entity = createVersionEntity(1L, "14.24.1", now);
+        VersionEntity entity = createVersionEntity(1L, "26.16", "16.16.1", now);
 
         // when
         VersionReadModel result = mapper.entityToReadModel(entity);
@@ -27,7 +27,8 @@ class VersionMapperTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.versionId()).isEqualTo(1L);
-        assertThat(result.versionValue()).isEqualTo("14.24.1");
+        assertThat(result.versionValue()).isEqualTo("26.16");
+        assertThat(result.patchVersionData()).isEqualTo("16.16.1");
         assertThat(result.createdAt()).isEqualTo(now);
     }
 
@@ -41,12 +42,12 @@ class VersionMapperTest {
         assertThat(result).isNull();
     }
 
-    @DisplayName("다양한 버전 형식을 올바르게 변환한다")
+    @DisplayName("데이터 버전이 비어 있는 엔티티는 patchVersionData 가 null 로 변환된다")
     @Test
-    void entityToReadModel_variousVersionFormats_returnsCorrectReadModel() throws Exception {
+    void entityToReadModel_nullPatchVersionData_returnsNullField() throws Exception {
         // given
         LocalDateTime now = LocalDateTime.now();
-        VersionEntity entity = createVersionEntity(2L, "15.1.1", now);
+        VersionEntity entity = createVersionEntity(2L, "26.1", null, now);
 
         // when
         VersionReadModel result = mapper.entityToReadModel(entity);
@@ -54,10 +55,13 @@ class VersionMapperTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.versionId()).isEqualTo(2L);
-        assertThat(result.versionValue()).isEqualTo("15.1.1");
+        assertThat(result.versionValue()).isEqualTo("26.1");
+        assertThat(result.patchVersionData()).isNull();
     }
 
-    private VersionEntity createVersionEntity(Long versionId, String versionValue, LocalDateTime createdAt) throws Exception {
+    private VersionEntity createVersionEntity(
+            Long versionId, String versionValue, String patchVersionData, LocalDateTime createdAt
+    ) throws Exception {
         java.lang.reflect.Constructor<VersionEntity> constructor = VersionEntity.class.getDeclaredConstructor();
         constructor.setAccessible(true);
         VersionEntity entity = constructor.newInstance();
@@ -69,6 +73,10 @@ class VersionMapperTest {
         Field versionValueField = VersionEntity.class.getDeclaredField("versionValue");
         versionValueField.setAccessible(true);
         versionValueField.set(entity, versionValue);
+
+        Field patchVersionDataField = VersionEntity.class.getDeclaredField("patchVersionData");
+        patchVersionDataField.setAccessible(true);
+        patchVersionDataField.set(entity, patchVersionData);
 
         Field createdAtField = VersionEntity.class.getDeclaredField("createdAt");
         createdAtField.setAccessible(true);

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/persistence/mapper/VersionMapperTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/adapter/out/persistence/mapper/VersionMapperTest.java
@@ -19,7 +19,7 @@ class VersionMapperTest {
     void entityToReadModel_validEntity_returnsReadModel() throws Exception {
         // given
         LocalDateTime now = LocalDateTime.now();
-        VersionEntity entity = createVersionEntity(1L, "26.16", "16.16.1", now);
+        VersionEntity entity = createVersionEntity(1L, "16.16", "16.16.1", now);
 
         // when
         VersionReadModel result = mapper.entityToReadModel(entity);
@@ -27,7 +27,7 @@ class VersionMapperTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.versionId()).isEqualTo(1L);
-        assertThat(result.versionValue()).isEqualTo("26.16");
+        assertThat(result.versionValue()).isEqualTo("16.16");
         assertThat(result.patchVersionData()).isEqualTo("16.16.1");
         assertThat(result.createdAt()).isEqualTo(now);
     }
@@ -47,7 +47,7 @@ class VersionMapperTest {
     void entityToReadModel_nullPatchVersionData_returnsNullField() throws Exception {
         // given
         LocalDateTime now = LocalDateTime.now();
-        VersionEntity entity = createVersionEntity(2L, "26.1", null, now);
+        VersionEntity entity = createVersionEntity(2L, "16.1", null, now);
 
         // when
         VersionReadModel result = mapper.entityToReadModel(entity);
@@ -55,7 +55,7 @@ class VersionMapperTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.versionId()).isEqualTo(2L);
-        assertThat(result.versionValue()).isEqualTo("26.1");
+        assertThat(result.versionValue()).isEqualTo("16.1");
         assertThat(result.patchVersionData()).isNull();
     }
 

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/VersionFinderTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/VersionFinderTest.java
@@ -97,6 +97,6 @@ class VersionFinderTest {
     }
 
     private VersionReadModel createVersionReadModel(Long id, String versionValue) {
-        return new VersionReadModel(id, versionValue, LocalDateTime.now());
+        return new VersionReadModel(id, versionValue, "16.16.1", LocalDateTime.now());
     }
 }

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/VersionServiceTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/VersionServiceTest.java
@@ -66,8 +66,8 @@ class VersionServiceTest {
     void getRecentVersions_최대2개조회() {
         // given
         List<VersionReadModel> versions = List.of(
-                createVersionReadModel(3L, "26.16", "16.16.1"),
-                createVersionReadModel(2L, "26.15", "16.15.1")
+                createVersionReadModel(3L, "16.16", "16.16.1"),
+                createVersionReadModel(2L, "16.15", "16.15.1")
         );
         given(versionPersistencePort.findRecentVersions(2)).willReturn(versions);
 
@@ -76,9 +76,9 @@ class VersionServiceTest {
 
         // then
         assertThat(result).hasSize(2);
-        assertThat(result.get(0).versionValue()).isEqualTo("26.16");
+        assertThat(result.get(0).versionValue()).isEqualTo("16.16");
         assertThat(result.get(0).patchVersionData()).isEqualTo("16.16.1");
-        assertThat(result.get(1).versionValue()).isEqualTo("26.15");
+        assertThat(result.get(1).versionValue()).isEqualTo("16.15");
         then(versionPersistencePort).should().findRecentVersions(2);
     }
 

--- a/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/VersionServiceTest.java
+++ b/module/domain/gamedata/src/test/java/com/example/lolserver/gamedata/application/VersionServiceTest.java
@@ -61,25 +61,25 @@ class VersionServiceTest {
         then(versionFinder).should().findLatestVersion();
     }
 
-    @DisplayName("전체 버전 조회 - 목록 반환")
+    @DisplayName("최근 버전 조회 - 최대 2개까지만 요청한다")
     @Test
-    void getAllVersions_목록반환() {
+    void getRecentVersions_최대2개조회() {
         // given
         List<VersionReadModel> versions = List.of(
-                createVersionReadModel(3L, "14.24.1"),
-                createVersionReadModel(2L, "14.23.1"),
-                createVersionReadModel(1L, "14.22.1")
+                createVersionReadModel(3L, "26.16", "16.16.1"),
+                createVersionReadModel(2L, "26.15", "16.15.1")
         );
-        given(versionPersistencePort.findAllVersions()).willReturn(versions);
+        given(versionPersistencePort.findRecentVersions(2)).willReturn(versions);
 
         // when
-        List<VersionReadModel> result = versionService.getAllVersions();
+        List<VersionReadModel> result = versionService.getRecentVersions();
 
         // then
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).versionValue()).isEqualTo("14.24.1");
-        assertThat(result.get(2).versionValue()).isEqualTo("14.22.1");
-        then(versionPersistencePort).should().findAllVersions();
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).versionValue()).isEqualTo("26.16");
+        assertThat(result.get(0).patchVersionData()).isEqualTo("16.16.1");
+        assertThat(result.get(1).versionValue()).isEqualTo("26.15");
+        then(versionPersistencePort).should().findRecentVersions(2);
     }
 
     @DisplayName("ID로 버전 조회 - 해당 버전 반환")
@@ -116,6 +116,10 @@ class VersionServiceTest {
     }
 
     private VersionReadModel createVersionReadModel(Long id, String versionValue) {
-        return new VersionReadModel(id, versionValue, LocalDateTime.now());
+        return createVersionReadModel(id, versionValue, "16.16.1");
+    }
+
+    private VersionReadModel createVersionReadModel(Long id, String versionValue, String patchVersionData) {
+        return new VersionReadModel(id, versionValue, patchVersionData, LocalDateTime.now());
     }
 }


### PR DESCRIPTION
## 관련 이슈
- MP-XXX

## 변경 유형
- [x] feat

## 변경 사항

**DB (`lol-db-schema` V35)**
- `patch_version.patch_version_data VARCHAR(20)` 추가 (NULL 허용, 백필 없음)
- 서브모듈 포인터 갱신

**로컬 시드 (`db/seed/season-local.sql`)**
- 신규 패치 행은 `version_value || '.1'` 로 `patch_version_data` 를 함께 INSERT
- 기존 행은 UPDATE 로 백필. INSERT 가 `ON CONFLICT DO NOTHING` 이라 새 컬럼을 채우지 못하기 때문

**API 계약 (하위 호환 — 필드 추가 + 목록 개수 축소)**
- `GET /api/v1/versions/latest`, `GET /api/v1/versions`, `GET /api/v1/versions/{id}` 응답에 **`patchVersionData`** 추가 (예: `16.16.1`)
- `GET /api/v1/versions` 가 **최신 2개까지만** 반환 (기존: 전체)

**내부**
- `VersionEntity` → `VersionReadModel` → 응답까지 `patchVersionData` 전달
- `VersionQueryUseCase.getAllVersions` → `getRecentVersions`, `VersionPersistencePort.findAllVersions` → `findRecentVersions(int limit)`
- 상한은 애플리케이션 계층이 정하고(`VersionService.RECENT_VERSION_LIMIT = 2`), 어댑터는 `Pageable` 로 받아 DB 에서 자름
- Redis 캐시 키 `version:latest` → `version:latest:v2`

## 변경 이유

`patch_version.version_value` 에는 전적의 게임 버전과 같은 **2자리 패치**가 들어갑니다 (`16.14` — 로컬 시드도, `championstats` 의 `patch` 파라미터도 이 형식). Data Dragon 정적 데이터 버전은 여기에 마지막 자리를 붙인 **3자리**입니다.

```
16.16  ->  16.16.1
16.14  ->  16.14.1
```

`version_value` 하나로는 챔피언 아이콘 같은 리소스 URL 을 만들 수 없어, 패치 행마다 대응하는 데이터 버전을 함께 들고 있게 했습니다.

**파생 규칙이 단순한데 왜 컬럼인가** — 라이엇이 핫픽스를 내면 그 자리가 올라갑니다(과거 `7.24.2`). 규칙을 코드에 박아 두면 그날 조용히 404 가 나지만, 컬럼이면 그 행만 고치면 됩니다. 로컬 시드에서만 규칙으로 파생시키고, 운영은 실제 값을 넣는 구조입니다.

**백필을 마이그레이션이 아니라 로컬 시드에 둔 이유** — 운영 DB 에 값을 지어내 넣지 않기 위해서입니다. `spring.sql.init` 은 `postgresql-local.yml` 에만 설정돼 있어(prod 에는 `sql.init` 블록 자체가 없고 Spring 기본값은 embedded DB 전용) 이 스크립트는 local 프로파일에서만 실행됩니다.

**서버가 아니라 클라이언트가 쓰는 값입니다** — 전 모듈을 뒤졌지만 서버에는 Data Dragon 호출부가 없습니다(`ddragon`·CDN 문자열 0건, 챔피언 정적 데이터 테이블도 없음). 서버는 이 값을 저장·노출하고, 실제 리소스 fetch 는 프론트가 합니다.

**캐시 키를 올린 이유** — `VersionReadModel` 에 필드가 하나 늘었습니다. 키를 그대로 두면 새 필드가 없는 옛 값이 TTL 24시간 동안 살아남아 `patchVersionData` 가 null 로 내려갑니다. 옛 키는 TTL 로 알아서 사라집니다.

## 테스트
- [x] 단위 테스트 통과 (`./gradlew :module:domain:gamedata:test`)
- [x] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`)
- [x] 로컬 빌드 확인 (`./gradlew compileJava compileTestJava` 전 모듈)

추가로 확인한 것:
- `./gradlew archTest` 전 모듈 통과
- RestDocs 스니펫에 `patchVersionData` 필드 문서 추가 (`version-latest` / `version-list` / `version-by-id`). `asciidoctor` 태스크는 현재 빌드에 없어(CLAUDE.md 의 stale 표기대로) HTML 재생성 단계는 없습니다
- **시드 스크립트를 Postgres 16 컨테이너에서 직접 실행**해 확인했습니다. 컬럼이 생기기 전 행(`16.10`, `16.11`)이 있는 로컬 DB 를 재현한 뒤:

  | 시나리오 | 결과 |
  |---|---|
  | 기존 2자리 행 백필 | `16.10 → 16.10.1`, `16.11 → 16.11.1` (UPDATE 2) |
  | 신규 행 INSERT | `16.12`~`16.14` 가 `.1` 포함해 들어감 |
  | 재실행 (매 부팅) | INSERT 0 · UPDATE 0, 데이터 불변 |
  | 핫픽스로 `16.15 → 16.15.2` 가 이미 든 행 | 덮어쓰지 않음 |

- 마이그레이션(V35)은 적용 시 `UPDATE` 를 0건 실행하는 것까지 확인 (상세는 lol-db-schema PR)

## 리뷰 포인트

- **스키마 PR 은 머지 완료** (`padosol/lol-db-schema#10`). 서브모듈 포인터를 머지 커밋(`5ff5491`)으로 올려 두었고, 그 과정에서 e스포츠 `V34` 도 함께 들어와 브랜치가 `V33` 다음에 `V35` 로 건너뛰던 간극이 사라졌습니다. 이 PR 은 단독으로 머지 가능합니다.
- **운영 DB 의 `patch_version_data` 를 채우는 경로가 아직 없습니다.** 로컬은 시드가 채우지만, 운영은 신규 패치 행을 넣을 때 값을 함께 넣어야 합니다. 서버가 `versions.json` 을 주기적으로 조회해 `patch_version` 을 적재하는 배치가 자연스러운 후보인데, 이 PR 범위 밖이라 넣지 않았습니다. 원하시면 별도로 올리겠습니다.
- **`GET /api/v1/versions` 응답 개수 축소**: 전체 → 최신 2개. 프론트가 3개 이상을 기대하는 화면이 있으면 알려주세요. 상한은 `VersionService` 상수 하나라 조정은 한 줄입니다.
- **메서드 이름 변경(`getAllVersions` → `getRecentVersions`)**: 전체를 안 주는데 `All` 이라는 이름을 남기면 다음 사람이 속습니다. 엔드포인트 경로는 그대로입니다.
- **문서 표기 정정**: 초안에서 이 컬럼의 짝을 공식 패치노트 번호(`26.16`)로 적었는데, `patch_version` 이 담는 값은 게임 버전(`16.16`)입니다. 공식 패치노트는 `26.16` 으로 표기하지만 Riot match API 의 `gameVersion` 이 `16.16.x` 라, 전적(`match.patch_version`)·통계(`championstats.patch_version_int`)와 같은 축을 쓰려고 `16.x` 를 저장합니다. 그 근거를 `VersionReadModel` javadoc 에 남겼고, 주석·RestDocs·테스트 픽스처도 모두 `16.x` 로 맞췄습니다. 패치노트 식별자(`patch_note.version_id` = `26.S1.1` 등)는 별개 체계라 건드리지 않았습니다.
  - 같은 설명을 `V35` SQL 주석에도 넣었다가 되돌렸습니다 — 이미 머지된 마이그레이션 파일을 고치면 Flyway 체크섬이 바뀌어 `V35` 를 적용한 DB 가 다음 부팅에서 깨집니다. DB 메타데이터에도 남기길 원하시면 `COMMENT ON COLUMN` 만 하는 후속 마이그레이션으로 올리겠습니다(`V2` 에 선례가 있습니다).

