### PR TITLE
release: develop → main (2 commits)

### DIFF
--- a/module/domain/match/src/main/java/com/example/lolserver/match/adapter/out/cache/MatchIdsCacheAdapter.java
+++ b/module/domain/match/src/main/java/com/example/lolserver/match/adapter/out/cache/MatchIdsCacheAdapter.java
@@ -3,7 +3,7 @@ package com.example.lolserver.match.adapter.out.cache;
 import com.example.lolserver.match.application.port.out.MatchIdsCachePort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -11,6 +11,14 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * lol-repository 가 Redis `match:ids:v1:{puuid}` ZSET (score = gameCreation) 에 Redisson StringCodec 으로
+ * 써 둔 matchId 를 최신순으로 읽는다.
+ * <p>
+ * 멤버는 따옴표 없는 raw 문자열이라 JSON 직렬화를 쓰는 {@code RedisTemplate<String, Object>} 로는
+ * 역직렬화가 실패하고 그 실패가 캐시 미스와 구분되지 않는다. {@link MatchSingleCacheAdapter} 와 같은 이유로
+ * {@link StringRedisTemplate} 을 쓴다.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -18,25 +26,17 @@ public class MatchIdsCacheAdapter implements MatchIdsCachePort {
 
     static final String KEY_PREFIX = "match:ids:v1:";
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final StringRedisTemplate stringRedisTemplate;
 
     @Override
     public Optional<List<String>> findIds(String puuid) {
         String key = buildKey(puuid);
         try {
-            Set<Object> raw = redisTemplate.opsForZSet().reverseRange(key, 0, -1);
+            Set<String> raw = stringRedisTemplate.opsForZSet().reverseRange(key, 0, -1);
             if (raw == null || raw.isEmpty()) {
                 return Optional.empty();
             }
-            List<String> ids = new ArrayList<>(raw.size());
-            for (Object o : raw) {
-                if (o instanceof String s) {
-                    ids.add(s);
-                } else if (o != null) {
-                    ids.add(o.toString());
-                }
-            }
-            return Optional.of(ids);
+            return Optional.of(new ArrayList<>(raw));
         } catch (Exception e) {
             log.warn("매치 ID ZSET 조회 실패 - puuid: {}, message: {}", puuid, e.getMessage());
             return Optional.empty();

--- a/module/domain/match/src/main/java/com/example/lolserver/match/application/MatchService.java
+++ b/module/domain/match/src/main/java/com/example/lolserver/match/application/MatchService.java
@@ -27,11 +27,12 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
+import java.util.Set;
 
 @Slf4j
 @Service
@@ -41,6 +42,10 @@ public class MatchService implements MatchQueryUseCase {
 
     private static final int DEFAULT_PAGE_SIZE = 20;
     private static final String DEFAULT_SORT_FIELD = "match";
+    private static final int FIRST_PAGE_NO = 0;
+
+    /** 전적 목록 DB 쿼리가 노출하는 게임 모드. 오버레이도 같은 제한을 걸어야 목록 구성이 어긋나지 않는다. */
+    private static final Set<String> LISTABLE_GAME_MODES = Set.of("CLASSIC", "CHERRY");
 
     private final MatchPersistencePort matchPersistencePort;
     private final MatchIdsCachePort matchIdsCachePort;
@@ -93,30 +98,26 @@ public class MatchService implements MatchQueryUseCase {
         return matchPersistencePort.getTimelineData(matchId);
     }
 
+    /**
+     * 전적 목록 조회. DB 조회는 항상 수행하고, 첫 페이지에 한해 캐시 오버레이를 덧씌운다.
+     * <p>
+     * 캐시 ZSET 은 write 측(lol-repository)에서 20 건으로 trim 되므로 목록 전체의 소스로 쓸 수 없다.
+     * season·queueId 필터와 페이징은 DB 가 그대로 책임지고, 캐시는 "갱신 직후 비동기 적재가 아직 안 끝나
+     * DB 에는 없고 캐시에만 있는 최신 매치" 만 첫 페이지 위에 얹는 역할을 한다.
+     */
     @LogExecutionTime
     public SliceResult<GameReadModel> getMatchesBatch(MatchCommand matchCommand) {
         String puuid = matchCommand.getPuuid();
         Integer season = matchCommand.getSeason();
         Integer queueId = matchCommand.getQueueId();
-        int pageNo = matchCommand.getPageNo() == null ? 0 : matchCommand.getPageNo();
+        int pageNo = matchCommand.getPageNo() == null ? FIRST_PAGE_NO : matchCommand.getPageNo();
 
-        if (season != null) {
-            return loadFromDbDirect(puuid, season, queueId, pageNo);
+        SliceResult<GameReadModel> dbResult = loadFromDbDirect(puuid, season, queueId, pageNo);
+        if (pageNo != FIRST_PAGE_NO) {
+            return dbResult;
         }
 
-        Optional<List<String>> cachedIds = matchIdsCachePort.findIds(puuid);
-        if (cachedIds.isEmpty()) {
-            return loadFromDbDirect(puuid, null, queueId, pageNo);
-        }
-
-        List<String> matchIds = cachedIds.get();
-        if (matchIds.isEmpty()) {
-            return new SliceResult<>(Collections.emptyList(), false);
-        }
-
-        Map<String, GameReadModel> matchesById = resolveMatchesByIds(matchIds);
-        List<GameReadModel> ordered = filterAndOrder(matchIds, matchesById, queueId);
-        return pageSlice(ordered, pageNo);
+        return overlayCachedMatches(puuid, season, queueId, dbResult);
     }
 
     private SliceResult<GameReadModel> loadFromDbDirect(
@@ -126,58 +127,115 @@ public class MatchService implements MatchQueryUseCase {
         return matchPersistencePort.getMatchesBatch(puuid, season, queueId, paginationRequest);
     }
 
-    private Map<String, GameReadModel> resolveMatchesByIds(List<String> matchIds) {
-        Map<String, GameReadModel> cached = matchSingleCachePort.findByIds(matchIds);
-        List<String> missingIds = new ArrayList<>();
-        for (String id : matchIds) {
-            if (!cached.containsKey(id)) {
-                missingIds.add(id);
+    private SliceResult<GameReadModel> overlayCachedMatches(
+            String puuid, Integer season, Integer queueId, SliceResult<GameReadModel> dbResult) {
+        List<String> cachedIds = matchIdsCachePort.findIds(puuid).orElseGet(Collections::emptyList);
+        if (cachedIds.isEmpty()) {
+            return dbResult;
+        }
+
+        List<GameReadModel> dbContent = dbResult.getContent();
+        Set<String> dbMatchIds = new HashSet<>();
+        for (GameReadModel game : dbContent) {
+            String matchId = matchIdOf(game);
+            if (matchId != null) {
+                dbMatchIds.add(matchId);
             }
         }
 
-        if (missingIds.isEmpty()) {
-            return new HashMap<>(cached);
+        List<String> candidateIds = cachedIds.stream()
+                .filter(matchId -> !dbMatchIds.contains(matchId))
+                .toList();
+        if (candidateIds.isEmpty()) {
+            return dbResult;
         }
 
-        Map<String, GameReadModel> matchesById = new HashMap<>(cached);
-        matchesById.putAll(fetchFromDb(missingIds));
-        return matchesById;
+        List<GameReadModel> overlay = collectOverlay(candidateIds, season, queueId, pageFloorOf(dbContent));
+        if (overlay.isEmpty()) {
+            return dbResult;
+        }
+
+        overlay.sort(Comparator.comparingLong(this::orderKeyOf).reversed());
+
+        // DB 첫 페이지 꼬리를 잘라내면 그 매치가 어느 페이지에서도 안 보이므로 자르지 않는다.
+        List<GameReadModel> merged = new ArrayList<>(overlay.size() + dbContent.size());
+        merged.addAll(overlay);
+        merged.addAll(dbContent);
+        return new SliceResult<>(merged, dbResult.isHasNext());
     }
 
-    private Map<String, GameReadModel> fetchFromDb(List<String> ids) {
-        List<GameReadModel> games = matchPersistencePort.findMatchesByIds(ids);
-        Map<String, GameReadModel> dbMap = new LinkedHashMap<>();
-        for (GameReadModel game : games) {
-            String id = matchIdOf(game);
-            if (id != null) {
-                dbMap.put(id, game);
+    private List<GameReadModel> collectOverlay(
+            List<String> candidateIds, Integer season, Integer queueId, long pageFloor) {
+        Map<String, GameReadModel> cachedMatches = matchSingleCachePort.findByIds(candidateIds);
+
+        List<GameReadModel> overlay = new ArrayList<>();
+        for (String matchId : candidateIds) {
+            // 단건 캐시에 없으면 DB 폴백 없이 버린다. DB 에 있는 매치는 이미 DB 페이지가 책임진다.
+            GameReadModel game = cachedMatches.get(matchId);
+            if (game == null || game.getGameInfoData() == null) {
+                continue;
             }
-        }
-        return dbMap;
-    }
-
-    private List<GameReadModel> filterAndOrder(
-            List<String> matchIds, Map<String, GameReadModel> matchesById, Integer queueId) {
-        List<GameReadModel> ordered = new ArrayList<>(matchIds.size());
-        for (String id : matchIds) {
-            GameReadModel game = matchesById.get(id);
-            if (game == null) {
+            // DB 첫 페이지 최하단보다 오래된 매치는 2페이지 영역과 겹쳐 중복·순서역전을 만든다.
+            if (orderKeyOf(game) <= pageFloor) {
+                continue;
+            }
+            if (!isListableGameMode(game)) {
                 continue;
             }
             if (queueId != null && !queueIdMatches(game, queueId)) {
                 continue;
             }
-            ordered.add(game);
+            if (season != null && !seasonMatches(game, season)) {
+                continue;
+            }
+            overlay.add(game);
         }
-        return ordered;
+        return overlay;
     }
 
-    private SliceResult<GameReadModel> pageSlice(List<GameReadModel> ordered, int pageNo) {
-        int fromIndex = Math.min(pageNo * DEFAULT_PAGE_SIZE, ordered.size());
-        int toIndex = Math.min(fromIndex + DEFAULT_PAGE_SIZE, ordered.size());
-        List<GameReadModel> pageContent = ordered.subList(fromIndex, toIndex);
-        boolean hasNext = toIndex < ordered.size();
-        return new SliceResult<>(new ArrayList<>(pageContent), hasNext);
+    /** DB 첫 페이지의 가장 오래된 매치 정렬키. 페이지가 비었으면 오버레이를 제한하지 않는다. */
+    private long pageFloorOf(List<GameReadModel> dbContent) {
+        long floor = Long.MIN_VALUE;
+        boolean found = false;
+        for (GameReadModel game : dbContent) {
+            if (game.getGameInfoData() == null) {
+                continue;
+            }
+            long orderKey = orderKeyOf(game);
+            floor = found ? Math.min(floor, orderKey) : orderKey;
+            found = true;
+        }
+        return floor;
+    }
+
+    /** DB 목록은 gameEndTimestamp DESC 로 정렬되므로 오버레이도 같은 키로 비교·정렬한다. */
+    private long orderKeyOf(GameReadModel game) {
+        return game.getGameInfoData() == null
+                ? Long.MIN_VALUE : game.getGameInfoData().getGameEndTimestamp();
+    }
+
+    private boolean isListableGameMode(GameReadModel game) {
+        String gameMode = game.getGameInfoData().getGameMode();
+        return gameMode != null && LISTABLE_GAME_MODES.contains(gameMode.toUpperCase(Locale.ROOT));
+    }
+
+    /**
+     * 캐시 JSON 에는 season 필드가 없으므로 gameVersion major 로 판별한다.
+     * lol-repository 가 MatchEntity.season 을 {@code gameVersion.split("\\.")[0]} 으로 채우므로 DB 와 규칙이 같다.
+     * 판별 불가능하면 시즌 필터 결과를 오염시키지 않도록 제외한다.
+     */
+    private boolean seasonMatches(GameReadModel game, int season) {
+        String gameVersion = game.getGameInfoData().getGameVersion();
+        if (gameVersion == null || gameVersion.isBlank()) {
+            return false;
+        }
+        int dotIndex = gameVersion.indexOf('.');
+        String major = dotIndex < 0 ? gameVersion : gameVersion.substring(0, dotIndex);
+        try {
+            return Integer.parseInt(major.trim()) == season;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     private boolean queueIdMatches(GameReadModel game, int queueId) {

--- a/module/domain/match/src/test/java/com/example/lolserver/match/adapter/out/cache/MatchIdsCacheAdapterTest.java
+++ b/module/domain/match/src/test/java/com/example/lolserver/match/adapter/out/cache/MatchIdsCacheAdapterTest.java
@@ -6,7 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.RedisSystemException;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
 import java.util.LinkedHashSet;
@@ -21,22 +22,22 @@ import static org.mockito.BDDMockito.given;
 class MatchIdsCacheAdapterTest {
 
     @Mock
-    private RedisTemplate<String, Object> redisTemplate;
+    private StringRedisTemplate stringRedisTemplate;
 
     @Mock
-    private ZSetOperations<String, Object> zSetOperations;
+    private ZSetOperations<String, String> zSetOperations;
 
     private MatchIdsCacheAdapter adapter;
 
     @BeforeEach
     void setUp() {
-        adapter = new MatchIdsCacheAdapter(redisTemplate);
+        adapter = new MatchIdsCacheAdapter(stringRedisTemplate);
     }
 
     @DisplayName("findIds 키 없음/빈 결과이면 Optional.empty 를 반환한다")
     @Test
     void findIds_missing_returnsEmptyOptional() {
-        given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
+        given(stringRedisTemplate.opsForZSet()).willReturn(zSetOperations);
         given(zSetOperations.reverseRange("match:ids:v1:test-puuid", 0, -1)).willReturn(new LinkedHashSet<>());
 
         Optional<List<String>> result = adapter.findIds("test-puuid");
@@ -47,9 +48,9 @@ class MatchIdsCacheAdapterTest {
     @DisplayName("findIds 멤버가 있으면 최신순 리스트를 반환한다")
     @Test
     void findIds_populated_returnsIdsInOrder() {
-        given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
+        given(stringRedisTemplate.opsForZSet()).willReturn(zSetOperations);
 
-        Set<Object> raw = new LinkedHashSet<>();
+        Set<String> raw = new LinkedHashSet<>();
         raw.add("KR_3");
         raw.add("KR_2");
         raw.add("KR_1");
@@ -59,6 +60,18 @@ class MatchIdsCacheAdapterTest {
 
         assertThat(result).isPresent();
         assertThat(result.get()).containsExactly("KR_3", "KR_2", "KR_1");
+    }
+
+    @DisplayName("findIds Redis 예외가 나면 Optional.empty 로 흡수한다")
+    @Test
+    void findIds_redisFailure_returnsEmptyOptional() {
+        given(stringRedisTemplate.opsForZSet()).willReturn(zSetOperations);
+        given(zSetOperations.reverseRange("match:ids:v1:test-puuid", 0, -1))
+                .willThrow(new RedisSystemException("boom", new IllegalStateException()));
+
+        Optional<List<String>> result = adapter.findIds("test-puuid");
+
+        assertThat(result).isEmpty();
     }
 
 }

--- a/module/domain/match/src/test/java/com/example/lolserver/match/application/MatchServiceTest.java
+++ b/module/domain/match/src/test/java/com/example/lolserver/match/application/MatchServiceTest.java
@@ -17,6 +17,7 @@ import com.example.lolserver.common.error.ErrorType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -39,6 +40,9 @@ import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 class MatchServiceTest {
+
+    private static final String CURRENT_SEASON_VERSION = "16.16.804.9184";
+    private static final String PREVIOUS_SEASON_VERSION = "15.24.700.1000";
 
     @Mock
     private MatchPersistencePort matchPersistencePort;
@@ -176,133 +180,46 @@ class MatchServiceTest {
         assertThat(result.isHasNext()).isTrue();
     }
 
-    @DisplayName("getMatchesBatch ZSET 캐시 hit + 단건 캐시 all hit 이면 DB 조회를 하지 않는다")
+    @DisplayName("getMatchesBatch 캐시에만 있는 최신 매치를 DB 첫 페이지 위에 얹고 DB 꼬리는 자르지 않는다")
     @Test
-    void getMatchesBatch_zsetHitAndSingleAllHit_noDbCall() {
+    void getMatchesBatch_cacheOnlyMatch_prependedWithoutTruncatingDbPage() {
         // given
         MatchCommand command = MatchCommand.builder()
                 .puuid("test-puuid")
                 .pageNo(0)
                 .build();
-
-        List<String> ids = List.of("KR_1", "KR_2");
-        given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.of(ids));
-
-        Map<String, GameReadModel> cached = new HashMap<>();
-        cached.put("KR_1", gameOf("KR_1", 420, 1000L));
-        cached.put("KR_2", gameOf("KR_2", 420, 2000L));
-        given(matchSingleCachePort.findByIds(ids)).willReturn(cached);
-
-        // when
-        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
-
-        // then
-        assertThat(result.getContent()).hasSize(2);
-        assertThat(result.isHasNext()).isFalse();
-        then(matchPersistencePort).should(never()).findMatchesByIds(anyCollection());
-        then(matchPersistencePort).should(never())
-                .getMatchesBatch(any(), any(), any(), any(PaginationRequest.class));
-    }
-
-    @DisplayName("getMatchesBatch ZSET 캐시 miss 시 DB 직조회로 떨어지고 캐시를 채우지 않는다")
-    @Test
-    void getMatchesBatch_zsetMiss_loadsFromDbDirectAndDoesNotWriteCache() {
-        // given
-        MatchCommand command = MatchCommand.builder()
-                .puuid("test-puuid")
-                .queueId(420)
-                .pageNo(0)
-                .build();
-
-        given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.empty());
 
         SliceResult<GameReadModel> dbResult = new SliceResult<>(
-                List.of(gameOf("KR_A", 420, 1000L), gameOf("KR_B", 420, 2000L)), false);
-        given(matchPersistencePort.getMatchesBatch(
-                eq("test-puuid"), isNull(), eq(420), any(PaginationRequest.class)))
-                .willReturn(dbResult);
+                List.of(gameOf("KR_OLD_1", 420, 2_000L), gameOf("KR_OLD_2", 420, 1_000L)), true);
+        givenDbFirstPage(null, null, dbResult);
+
+        given(matchIdsCachePort.findIds("test-puuid"))
+                .willReturn(Optional.of(List.of("KR_NEW", "KR_OLD_1", "KR_OLD_2")));
+        given(matchSingleCachePort.findByIds(List.of("KR_NEW")))
+                .willReturn(Map.of("KR_NEW", gameOf("KR_NEW", 420, 3_000L)));
 
         // when
         SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
 
         // then
-        assertThat(result).isSameAs(dbResult);
-        then(matchSingleCachePort).should(never()).findByIds(anyCollection());
-        then(matchPersistencePort).should(never()).findMatchesByIds(anyCollection());
-    }
-
-    @DisplayName("getMatchesBatch ZSET hit + 단건 캐시 partial miss 시 누락분만 DB IN 조회로 보강하고 캐시는 채우지 않는다")
-    @Test
-    void getMatchesBatch_zsetHitAndSinglePartialMiss_loadsMissingNoCacheWrite() {
-        // given
-        MatchCommand command = MatchCommand.builder()
-                .puuid("test-puuid")
-                .pageNo(0)
-                .build();
-
-        List<String> ids = List.of("KR_1", "KR_2", "KR_3");
-        given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.of(ids));
-
-        Map<String, GameReadModel> cached = new HashMap<>();
-        cached.put("KR_1", gameOf("KR_1", 420, 1000L));
-        given(matchSingleCachePort.findByIds(ids)).willReturn(cached);
-
-        GameReadModel game2 = gameOf("KR_2", 420, 2000L);
-        GameReadModel game3 = gameOf("KR_3", 420, 3000L);
-        given(matchPersistencePort.findMatchesByIds(List.of("KR_2", "KR_3")))
-                .willReturn(List.of(game2, game3));
-
-        // when
-        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
-
-        // then
-        assertThat(result.getContent()).hasSize(3);
-        then(matchPersistencePort).should().findMatchesByIds(List.of("KR_2", "KR_3"));
-    }
-
-    @DisplayName("getMatchesBatch queueId 필터는 in-memory 로 동작한다")
-    @Test
-    void getMatchesBatch_queueIdFilter_appliedInMemory() {
-        // given
-        MatchCommand command = MatchCommand.builder()
-                .puuid("test-puuid")
-                .queueId(420)
-                .pageNo(0)
-                .build();
-
-        List<String> ids = List.of("KR_1", "KR_2", "KR_3");
-        given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.of(ids));
-
-        Map<String, GameReadModel> cached = new HashMap<>();
-        cached.put("KR_1", gameOf("KR_1", 420, 1000L));
-        cached.put("KR_2", gameOf("KR_2", 440, 2000L)); // 다른 큐
-        cached.put("KR_3", gameOf("KR_3", 420, 3000L));
-        given(matchSingleCachePort.findByIds(ids)).willReturn(cached);
-
-        // when
-        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
-
-        // then
-        assertThat(result.getContent()).hasSize(2);
         assertThat(result.getContent())
-                .extracting(g -> g.getGameInfoData().getMatchId())
-                .containsExactly("KR_1", "KR_3");
+                .extracting(game -> game.getGameInfoData().getMatchId())
+                .containsExactly("KR_NEW", "KR_OLD_1", "KR_OLD_2");
+        assertThat(result.isHasNext()).isTrue();
     }
 
-    @DisplayName("getMatchesBatch season 필터는 캐시를 우회하고 DB getMatchesBatch 를 직접 호출한다")
+    @DisplayName("getMatchesBatch 두 번째 페이지부터는 캐시를 보지 않고 DB 결과를 그대로 반환한다")
     @Test
-    void getMatchesBatch_seasonFilter_bypassesCacheAndCallsDb() {
+    void getMatchesBatch_secondPage_returnsDbResultWithoutCache() {
         // given
         MatchCommand command = MatchCommand.builder()
                 .puuid("test-puuid")
-                .season(14)
-                .queueId(420)
-                .pageNo(0)
+                .pageNo(1)
                 .build();
 
-        SliceResult<GameReadModel> dbResult = new SliceResult<>(List.of(new GameReadModel()), true);
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(List.of(gameOf("KR_21", 420, 500L)), false);
         given(matchPersistencePort.getMatchesBatch(
-                eq("test-puuid"), eq(14), eq(420), any(PaginationRequest.class)))
+                eq("test-puuid"), isNull(), isNull(), any(PaginationRequest.class)))
                 .willReturn(dbResult);
 
         // when
@@ -311,35 +228,240 @@ class MatchServiceTest {
         // then
         assertThat(result).isSameAs(dbResult);
         then(matchIdsCachePort).should(never()).findIds(any());
-        then(matchSingleCachePort).should(never()).findByIds(any());
+        then(matchSingleCachePort).should(never()).findByIds(anyCollection());
+
+        ArgumentCaptor<PaginationRequest> captor = ArgumentCaptor.forClass(PaginationRequest.class);
+        then(matchPersistencePort).should()
+                .getMatchesBatch(eq("test-puuid"), isNull(), isNull(), captor.capture());
+        assertThat(captor.getValue().page()).isEqualTo(1);
     }
 
-    @DisplayName("getMatchesBatch 빈 ZSET 캐시 hit 이면 빈 SliceResult 를 반환한다")
+    @DisplayName("getMatchesBatch ZSET 캐시 miss 여도 DB 결과를 그대로 반환한다")
     @Test
-    void getMatchesBatch_emptyIds_returnsEmptySlice() {
+    void getMatchesBatch_zsetMiss_returnsDbResult() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .queueId(420)
+                .pageNo(0)
+                .build();
+
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(
+                List.of(gameOf("KR_A", 420, 2_000L), gameOf("KR_B", 420, 1_000L)), false);
+        givenDbFirstPage(null, 420, dbResult);
+        given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.empty());
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result).isSameAs(dbResult);
+        then(matchSingleCachePort).should(never()).findByIds(anyCollection());
+    }
+
+    @DisplayName("getMatchesBatch 빈 ZSET 캐시 hit 이면 DB 결과를 그대로 반환한다")
+    @Test
+    void getMatchesBatch_emptyIds_returnsDbResult() {
         // given
         MatchCommand command = MatchCommand.builder()
                 .puuid("test-puuid")
                 .pageNo(0)
                 .build();
 
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(List.of(gameOf("KR_A", 420, 1_000L)), false);
+        givenDbFirstPage(null, null, dbResult);
         given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.of(Collections.emptyList()));
 
         // when
         SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
 
         // then
-        assertThat(result.getContent()).isEmpty();
-        assertThat(result.isHasNext()).isFalse();
-        then(matchSingleCachePort).should(never()).findByIds(any());
+        assertThat(result).isSameAs(dbResult);
+        then(matchSingleCachePort).should(never()).findByIds(anyCollection());
     }
 
-    private GameReadModel gameOf(String matchId, int queueId, long gameCreation) {
+    @DisplayName("getMatchesBatch DB 첫 페이지 최하단보다 오래된 캐시 매치는 오버레이하지 않는다")
+    @Test
+    void getMatchesBatch_olderThanPageFloor_excludedFromOverlay() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .pageNo(0)
+                .build();
+
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(
+                List.of(gameOf("KR_A", 420, 3_000L), gameOf("KR_B", 420, 2_000L)), true);
+        givenDbFirstPage(null, null, dbResult);
+
+        given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.of(List.of("KR_OLDER")));
+        given(matchSingleCachePort.findByIds(List.of("KR_OLDER")))
+                .willReturn(Map.of("KR_OLDER", gameOf("KR_OLDER", 420, 1_500L)));
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result).isSameAs(dbResult);
+    }
+
+    @DisplayName("getMatchesBatch 단건 캐시에 없는 후보는 DB 폴백 없이 버린다")
+    @Test
+    void getMatchesBatch_singleCacheMiss_droppedWithoutDbFallback() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .pageNo(0)
+                .build();
+
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(List.of(gameOf("KR_A", 420, 1_000L)), false);
+        givenDbFirstPage(null, null, dbResult);
+
+        given(matchIdsCachePort.findIds("test-puuid")).willReturn(Optional.of(List.of("KR_NEW")));
+        given(matchSingleCachePort.findByIds(List.of("KR_NEW"))).willReturn(Collections.emptyMap());
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result).isSameAs(dbResult);
+        then(matchPersistencePort).should(never()).findMatchesByIds(anyCollection());
+    }
+
+    @DisplayName("getMatchesBatch season 필터는 DB 에 그대로 전달되고 오버레이는 gameVersion major 로 걸러진다")
+    @Test
+    void getMatchesBatch_seasonFilter_passedToDbAndAppliedToOverlay() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .season(16)
+                .pageNo(0)
+                .build();
+
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(List.of(gameOf("KR_A", 420, 1_000L)), true);
+        givenDbFirstPage(16, null, dbResult);
+
+        given(matchIdsCachePort.findIds("test-puuid"))
+                .willReturn(Optional.of(List.of("KR_S16", "KR_S15")));
+        given(matchSingleCachePort.findByIds(List.of("KR_S16", "KR_S15"))).willReturn(Map.of(
+                "KR_S16", gameOf("KR_S16", 420, 3_000L, "CLASSIC", CURRENT_SEASON_VERSION),
+                "KR_S15", gameOf("KR_S15", 420, 2_000L, "CLASSIC", PREVIOUS_SEASON_VERSION)));
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result.getContent())
+                .extracting(game -> game.getGameInfoData().getMatchId())
+                .containsExactly("KR_S16", "KR_A");
+        then(matchPersistencePort).should()
+                .getMatchesBatch(eq("test-puuid"), eq(16), isNull(), any(PaginationRequest.class));
+    }
+
+    @DisplayName("getMatchesBatch queueId 필터는 오버레이 후보에도 적용된다")
+    @Test
+    void getMatchesBatch_queueIdFilter_appliedToOverlay() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .queueId(420)
+                .pageNo(0)
+                .build();
+
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(List.of(gameOf("KR_A", 420, 1_000L)), true);
+        givenDbFirstPage(null, 420, dbResult);
+
+        given(matchIdsCachePort.findIds("test-puuid"))
+                .willReturn(Optional.of(List.of("KR_SOLO", "KR_FLEX")));
+        given(matchSingleCachePort.findByIds(List.of("KR_SOLO", "KR_FLEX"))).willReturn(Map.of(
+                "KR_SOLO", gameOf("KR_SOLO", 420, 3_000L),
+                "KR_FLEX", gameOf("KR_FLEX", 440, 2_000L)));
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result.getContent())
+                .extracting(game -> game.getGameInfoData().getMatchId())
+                .containsExactly("KR_SOLO", "KR_A");
+    }
+
+    @DisplayName("getMatchesBatch DB 목록에 없는 게임 모드는 오버레이하지 않는다")
+    @Test
+    void getMatchesBatch_nonListableGameMode_excludedFromOverlay() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .pageNo(0)
+                .build();
+
+        SliceResult<GameReadModel> dbResult = new SliceResult<>(List.of(gameOf("KR_A", 420, 1_000L)), true);
+        givenDbFirstPage(null, null, dbResult);
+
+        given(matchIdsCachePort.findIds("test-puuid"))
+                .willReturn(Optional.of(List.of("KR_ARAM", "KR_ARENA")));
+        given(matchSingleCachePort.findByIds(List.of("KR_ARAM", "KR_ARENA"))).willReturn(Map.of(
+                "KR_ARAM", gameOf("KR_ARAM", 450, 3_000L, "ARAM", CURRENT_SEASON_VERSION),
+                "KR_ARENA", gameOf("KR_ARENA", 1700, 2_500L, "CHERRY", CURRENT_SEASON_VERSION)));
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result.getContent())
+                .extracting(game -> game.getGameInfoData().getMatchId())
+                .containsExactly("KR_ARENA", "KR_A");
+    }
+
+    @DisplayName("getMatchesBatch DB 첫 페이지가 비어 있어도 캐시 매치를 반환한다")
+    @Test
+    void getMatchesBatch_emptyDbPage_returnsOverlayOnly() {
+        // given
+        MatchCommand command = MatchCommand.builder()
+                .puuid("test-puuid")
+                .pageNo(0)
+                .build();
+
+        givenDbFirstPage(null, null, new SliceResult<>(Collections.emptyList(), false));
+
+        given(matchIdsCachePort.findIds("test-puuid"))
+                .willReturn(Optional.of(List.of("KR_NEW_1", "KR_NEW_2")));
+        given(matchSingleCachePort.findByIds(List.of("KR_NEW_1", "KR_NEW_2"))).willReturn(Map.of(
+                "KR_NEW_1", gameOf("KR_NEW_1", 420, 2_000L),
+                "KR_NEW_2", gameOf("KR_NEW_2", 420, 3_000L)));
+
+        // when
+        SliceResult<GameReadModel> result = matchService.getMatchesBatch(command);
+
+        // then
+        assertThat(result.getContent())
+                .extracting(game -> game.getGameInfoData().getMatchId())
+                .containsExactly("KR_NEW_2", "KR_NEW_1");
+        assertThat(result.isHasNext()).isFalse();
+    }
+
+    private void givenDbFirstPage(Integer season, Integer queueId, SliceResult<GameReadModel> dbResult) {
+        given(matchPersistencePort.getMatchesBatch(
+                eq("test-puuid"),
+                season == null ? isNull() : eq(season),
+                queueId == null ? isNull() : eq(queueId),
+                any(PaginationRequest.class)))
+                .willReturn(dbResult);
+    }
+
+    private GameReadModel gameOf(String matchId, int queueId, long gameEndTimestamp) {
+        return gameOf(matchId, queueId, gameEndTimestamp, "CLASSIC", CURRENT_SEASON_VERSION);
+    }
+
+    private GameReadModel gameOf(
+            String matchId, int queueId, long gameEndTimestamp, String gameMode, String gameVersion) {
         GameReadModel game = new GameReadModel();
         GameInfoReadModel info = new GameInfoReadModel();
         info.setMatchId(matchId);
         info.setQueueId(queueId);
-        info.setGameCreation(gameCreation);
+        info.setGameCreation(gameEndTimestamp);
+        info.setGameEndTimestamp(gameEndTimestamp);
+        info.setGameMode(gameMode);
+        info.setGameVersion(gameVersion);
         game.setGameInfoData(info);
         return game;
     }


### PR DESCRIPTION
## 관련 이슈
- 없음 (릴리스 롤업 — 개별 이슈는 PR #155 에 연결됨)

## 변경 유형
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] docs
- [ ] chore

## 변경 사항
`develop` 누적분 2 커밋 (non-merge 1, 4 files, +331 / −138). 이전 릴리스(#154) 이후 develop 으로 들어온 PR 은 #155 하나이고, merge-base 가 이전 릴리스 헤드(`9c17c99`)라 main 고유 변경은 없다.

- **매치 캐시 read 경로 복구 + 첫 페이지 오버레이 재설계** (#155, `87c216b4`) — 소환사 갱신 직후 새 게임이 전적 목록에 나타나지 않던 문제. 직렬로 걸려 있던 read 경로 결함 두 개를 함께 고친다
  - `MatchIdsCacheAdapter`: `RedisTemplate<String, Object>` → `StringRedisTemplate`. ZSET 멤버는 write 측(lol-repository)이 Redisson `StringCodec` 으로 쓴 raw 문자열이라 JSON 역직렬화가 실패했고, 그 예외가 `catch` 에 흡수돼 캐시 미스와 구분되지 않은 채 조용히 DB 폴백되고 있었다
  - `MatchService.getMatchesBatch()`: `season != null` 이면 캐시 경로에 진입조차 못 하던 가드를 제거하고, 캐시를 "목록 전체의 소스" 가 아니라 **DB 첫 페이지 위의 오버레이**로 재설계. DB 조회는 항상 수행해 season·queueId·페이징은 그대로 DB 가 책임지고, `pageNo == 0` 에 한해 DB 첫 페이지에 없고 그 페이지 최하단보다 최신인 캐시 매치만 얹는다 (정렬키 `gameEndTimestamp`, 모드는 CLASSIC/CHERRY, 시즌은 `gameVersion` major 로 판별)
  - 사용되지 않게 된 `resolveMatchesByIds` / `fetchFromDb` / `filterAndOrder` / `pageSlice` 제거
- 스키마 서브모듈(`lol-db-schema`) 포인터 변경 없음

## 변경 이유
갱신을 눌러도 새 게임이 전적 목록에 즉시 반영되지 않던 회귀를 prod 에 반영한다.

## 테스트
- [x] 단위 테스트 통과 (`./gradlew test`) — #155 에서 `MatchServiceTest` 16건 / `MatchIdsCacheAdapterTest` 3건 실행
- [x] Checkstyle 통과 (`./gradlew checkstyleMain checkstyleTest`) — #155 에서 확인
- [x] 로컬 빌드 확인 (`./gradlew build`) — #155 에서 확인

이 PR 자체의 추가 검증은 develop 헤드 `29cc3c8f` 의 CI(run 32262863815) 통과 확인뿐이다. 변경 자체는 develop 으로 들어올 때 #155 에서 검증됐다.

## 리뷰 포인트

**1. 이번 릴리스는 스키마 마이그레이션을 요구하지 않는다.**
`lol-db-schema` 서브모듈 포인터가 그대로다(diff 0). 이전 릴리스(#154)가 전제한 `V32`·`V33`·`V35` 가 이미 prod 에 반영돼 있다는 조건만 유지되면 된다.

**2. Redis flush 도 필요 없다.**
캐시되는 값 클래스는 바뀌지 않았고, 바뀐 것은 읽기 측 직렬화기뿐이다(`RedisTemplate<String, Object>` → `StringRedisTemplate`). ZSET `match:ids:v1:{puuid}` 는 lol-repository 가 계속 raw 문자열로 쓰므로 기존 엔트리가 그대로 읽힌다 — 지금까지 못 읽던 엔트리를 이제 읽게 되는 방향의 변화다.

**3. 전적 목록 첫 페이지 응답 길이가 달라질 수 있다.**
오버레이가 붙으면 첫 페이지는 20 이 아니라 `20 + 오버레이 건수` 로 나간다(DB 꼬리를 자르지 않는다). `hasNext` 는 DB 판단을 그대로 따르고 2페이지부터는 순수 DB 경로라 기존과 동일하다. 프론트가 페이지 길이를 20 고정으로 가정하고 있다면 확인이 필요하다.

**4. 미검증 항목이 하나 남아 있다.**
"갱신 후 새 게임이 곧바로 목록 최상단에 노출" 은 Postgres/Redis/RabbitMQ 기동 + 실제 갱신 플로우가 필요해 실측되지 않았다. 정렬·중복·모드/시즌 필터·더 보기는 단위 테스트로 커버됐다.

**5. 이 PR 이 머지되면 곧바로 prod 로 나간다.**
main CI 성공 → ECR 이미지 push → `repository_dispatch(deploy)` → CD 리포. 사람이 개입하는 승인 단계가 없다.
